### PR TITLE
move zone background color and padding to data-type=ad only; test in …

### DIFF
--- a/content/decks/gallery.html
+++ b/content/decks/gallery.html
@@ -15,7 +15,7 @@ aliases:
   {{< card >}}
   {{< card >}}
 
-  <div class="zone two-rows">
+  <div class="zone two-rows" data-type="ad">
     <fake-ad size="[300,600]"></fake-ad>
   </div>
 
@@ -29,7 +29,7 @@ aliases:
   {{< card >}}
   {{< card >}}
 
-  <div class="zone">
+  <div class="zone" data-type="ad">
     <fake-ad></fake-ad>
   </div>
 

--- a/content/decks/homepage.html
+++ b/content/decks/homepage.html
@@ -10,7 +10,7 @@ aliases:
 
 {{< big-news >}}
 
-<div id="zone-el-3" class="zone-el zone">
+<div id="zone-el-3" class="zone-el zone" data-type="ad">
   <fake-ad size="[970,250]"></fake-ad>
 </div>
 
@@ -25,7 +25,7 @@ aliases:
     {{< card class="lead-item" headline-size="h1" taboola=true >}}
   </div>
 
-  <div id="zone-el-5" class="zone-el zone">
+  <div id="zone-el-5" class="zone-el zone" data-type="ad">
     <fake-ad></fake-ad>
   </div>
   
@@ -59,7 +59,7 @@ aliases:
   {{< card >}}
   {{< card >}}
 
-  <div id="zone-el-6" class="zone-el zone">
+  <div id="zone-el-6" class="zone-el zone" data-type="ad">
     <fake-ad></fake-ad>
   </div>
   
@@ -75,7 +75,7 @@ aliases:
   {{< card >}}
   {{< card >}}
 
-  <div id="zone-el-8" class="zone-el zone">
+  <div id="zone-el-8" class="zone-el zone" data-type="ad">
     <fake-ad></fake-ad>
   </div>
 
@@ -90,7 +90,7 @@ aliases:
   {{< card >}}
   {{< card >}}
 
-  <div id="zone-el-9" class="zone-el zone">
+  <div id="zone-el-9" class="zone-el zone" data-type="ad">
     <fake-ad></fake-ad>
   </div>
 
@@ -105,4 +105,4 @@ aliases:
 
 </section>
 
-<div id="zone-el-15" class="zone-el"></div>
+<div id="zone-el-15" class="zone-el" data-type="ad"></div>

--- a/content/decks/search.html
+++ b/content/decks/search.html
@@ -29,13 +29,13 @@ aliases:
   <div class="grid search-results">
     {{< card >}}
     {{< card >}}
-    <fake-ad class="zone"></fake-ad>
+    <fake-ad class="zone" data-type="ad"></fake-ad>
     {{< card >}}
     {{< card >}}
     {{< card >}}
     {{< card >}}
     {{< card >}}
-    <fake-ad class="zone"></fake-ad>
+    <fake-ad class="zone" data-type="ad"></fake-ad>
     {{< card >}}
     {{< card >}}
     {{< card >}}
@@ -47,5 +47,5 @@ aliases:
 </section>
 
 <section>
-  <fake-ad size="[728,90]" class="zone"></fake-ad>
+  <fake-ad size="[728,90]" class="zone" data-type="ad"></fake-ad>
 </section>

--- a/content/decks/section.html
+++ b/content/decks/section.html
@@ -17,7 +17,7 @@ aliases:
 
   {{< card class="lead-item" headline-size="h1" >}}
 
-  <div class="zone two-rows">
+  <div class="zone two-rows" data-type="ad">
     <fake-ad size="[300,600]" data-zone="3"></fake-ad>
   </div>
 
@@ -27,7 +27,7 @@ aliases:
   {{< card >}}
   {{< card >}}
 
-  <div class="zone two-rows">
+  <div class="zone two-rows" data-type="ad">
     <fake-ad size="[300,600]" data-zone="4"></fake-ad>
   </div>
 
@@ -54,7 +54,7 @@ aliases:
   {{< card >}}
   {{< card >}}
 
-  <div class="zone three-columns">
+  <div class="zone three-columns" data-type="ad">
     <fake-ad size="[[970,250],[728,90]]" data-zone="9"></fake-ad>
   </div>
 
@@ -63,7 +63,7 @@ aliases:
   {{< card >}}
   {{< card >}}
 
-  <div class="zone three-columns">
+  <div class="zone three-columns" data-type="ad">
     <fake-ad size="[[728,90],[320,50]]" data-zone="10"></fake-ad>
   </div>
 

--- a/content/decks/section.html
+++ b/content/decks/section.html
@@ -18,7 +18,7 @@ aliases:
   {{< card class="lead-item" headline-size="h1" >}}
 
   <div class="zone two-rows" data-type="ad">
-    <fake-ad size="[300,600]" data-zone="3"></fake-ad>
+    <fake-ad size="[300,600]"></fake-ad>
   </div>
 
   {{< digest >}}
@@ -28,7 +28,7 @@ aliases:
   {{< card >}}
 
   <div class="zone two-rows" data-type="ad">
-    <fake-ad size="[300,600]" data-zone="4"></fake-ad>
+    <fake-ad size="[300,600]"></fake-ad>
   </div>
 
   {{< digest class="optional-digest" kicker="OPTIONAL DIGEST" >}}
@@ -38,14 +38,14 @@ aliases:
   {{< card >}}
   {{< card >}}
 
-  <div class="zone three-columns">
-    <fake-ad size="[[970,250],[728,90]]" data-zone="23" style="--color: cornflowerblue;"></fake-ad>
+  <div class="zone three-columns" data-type="ad">
+    <fake-ad size="[[970,250],[728,90]]"></fake-ad>
   </div>
 
   {{< card >}}
   {{< card >}}
 
-  <div class="zone">
+  <div class="zone" data-type="ad">
     <fake-ad data-zone="5"></fake-ad>
   </div>
 

--- a/content/decks/story.md
+++ b/content/decks/story.md
@@ -40,7 +40,7 @@ Some posit the svelter tie to be less than stockinged. The princely dragon revea
 
 In recent years, the beating geography reveals itself as an unslung fountain to those who look. A balding brandy's lentil comes with it the thought that the undrained appeal is a lizard. They were lost without the bookish offer that composed their thing. A rutabaga is a meteorology from the right perspective.
 
-{{< zone >}}
+{{< zone type="editorial" size="[728,400]" >}}
 
 In ancient times the first rhinal cappelletti is, in its own way, a polish. The hatted leek reveals itself as a southward apple to those who look. The junes could be said to resemble trackless stems. An apartment sees an interest as a herbaged vein.
 

--- a/content/decks/topic.html
+++ b/content/decks/topic.html
@@ -114,7 +114,7 @@ aliases:
   {{< card class="horizontal in-depth impact">}}
   {{< card >}}
   {{< card >}}
-  <fake-ad class="zone three-columns" size="[[970,250],[728,90]]"></fake-ad>
+  <fake-ad class="zone three-columns" size="[[970,250],[728,90]]" data-type="ad"></fake-ad>
   {{< card >}}
   {{< card >}}
   {{< card >}}
@@ -122,7 +122,7 @@ aliases:
   {{< card >}}
   {{< card >}}
   {{< card >}}
-  <fake-ad class="zone"></fake-ad>
+  <fake-ad class="zone" data-type="ad"></fake-ad>
   {{< card >}}
   {{< card >}}
   {{< card >}}

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -21,7 +21,7 @@
   </div>
 
   <div id="zone-el-1" class="zone-el hidden"></div>
-  <div id="zone-el-2" class="zone-el zone">
+  <div id="zone-el-2" class="zone-el zone" data-type="ad">
     <fake-ad size="[[970,250],[728,90],[320,50]]"></fake-ad>
   </div>
 

--- a/layouts/_default/story.html
+++ b/layouts/_default/story.html
@@ -3,7 +3,7 @@
 {{ end }}
 
 {{ define "content" -}}
-  <div class="zone">
+  <div class="zone" data-type="ad">
     <fake-ad size="[970,250]"></fake-ad>
   </div>
 

--- a/layouts/shortcodes/zone.html
+++ b/layouts/shortcodes/zone.html
@@ -1,3 +1,5 @@
-<div class="zone" data-type="ad">
+{{- $type := default "ad" (.Get "type") -}}
+
+<div class="zone" data-type="{{ $type }}">
   <fake-ad size="{{ .Get "size" }}"></fake-ad>
 </div>

--- a/layouts/shortcodes/zone.html
+++ b/layouts/shortcodes/zone.html
@@ -1,3 +1,3 @@
-<div class="zone">
+<div class="zone" data-type="ad">
   <fake-ad size="{{ .Get "size" }}"></fake-ad>
 </div>

--- a/static/css/cards/zones.css
+++ b/static/css/cards/zones.css
@@ -6,8 +6,6 @@
   clear: both;
   display: block;
   position: relative;
-  padding: var(--page-padding) 0; 
-  background-color: var(--zone-background);
 }
 
 .zone:empty {
@@ -16,6 +14,11 @@
 
 .zone.contents {
   display: contents;
+}
+
+.zone[data-type="ad"] {
+  padding: var(--page-padding) 0; 
+  background-color: var(--zone-background);
 }
 
 /*

--- a/static/css/website/site.css
+++ b/static/css/website/site.css
@@ -165,13 +165,17 @@ td:first-child {
  */
 
 .zone::before {
-  content: '#' attr(id);
+  content: attr(id);
   display: block;
   position: absolute;
-  left: 0;
-  top: -1.1em;
+  left: 5px;
+  top: 5px;
   font: 14px/1em var(--sans);
-  color: #555;
+  color: #777;
+}
+
+.zone[data-type=editorial] {
+  --color: cornflowerblue;
 }
 
 #zone-el-15 {

--- a/static/js/fake-ad.js
+++ b/static/js/fake-ad.js
@@ -28,8 +28,6 @@ class FakeAd extends HTMLElement {
     t.innerHTML = `
     <style>
       :host {
-        --color: #f2b6be;
-
         display: flex !important;
         align-items: center;
         justify-content: center;
@@ -38,7 +36,7 @@ class FakeAd extends HTMLElement {
 
       .ad {
         display: none;
-        background-color: var(--color);
+        background-color: var(--color, #f2b6be);
         font-family: var(--font-family, var(--sans));
         font-size: 24px;
       }


### PR DESCRIPTION
This moves the background and padding styling to `data-type="ad"` zones only.

To test/review:
1. Pull down the `ft-zone-data-attribute` branch to your local machine.
2. Start your local server with `Hugo server -p 3000` to run the SDS website.
3. Check the **story** and **section** decks from the Style Guide page. 

You can add or remove the ad type data attribute on zones across the website to ensure that the updated styling is functioning properly.
