### PR TITLE
cleaning up card and digest shortcodes

### DIFF
--- a/content/decks/homepage.html
+++ b/content/decks/homepage.html
@@ -45,7 +45,13 @@ aliases:
   <div class="region" data-tb-region="BigSix-Bottom">
     {{< card taboola=true >}}
     {{< card taboola=true >}}
+  </div>
+
+  <div class="region" data-tb-region="NewRegion4">
     {{< card taboola=true >}}
+  </div>
+
+  <div class="region" data-tb-region="NewRegion5">
     {{< card taboola=true >}}
   </div>
 
@@ -56,8 +62,9 @@ aliases:
     <div class="three-columns" style="padding-top: 50%; background-color: var(--impact);"></div>
   </div>
 
-  {{< card >}}
-  {{< card >}}
+  <div class="region" data-tb-region="NewRegion6">
+    {{< card taboola=true >}}
+  </div>
 
   <div id="zone-el-6" class="zone-el zone" data-type="ad">
     <fake-ad></fake-ad>
@@ -67,40 +74,42 @@ aliases:
     <div class="partner-label">
       <span>From our partners</span>
     </div>
-    {{< digest label="sticky" kicker="NATIONAL STORIES" >}}
-    {{< digest label="sticky" kicker="BETTING" >}}
-    {{< digest label="sticky" kicker="THE STREET" >}}
+    {{< digest label="sticky" kicker="NATIONAL SPORTS" feed="nationalsports" >}}
+    {{< digest label="sticky" kicker="BETTING" feed="betting" >}}
+    {{< digest label="sticky" kicker="THE STREET" feed="thestreet" >}}
   </div>
-
-  {{< card >}}
-  {{< card >}}
 
   <div id="zone-el-8" class="zone-el zone" data-type="ad">
     <fake-ad></fake-ad>
   </div>
 
-  {{< in-depth >}}
-
   <div class="digest-group">
-    {{< digest label="sticky" kicker="SPORTS" region="sports" >}}
+    {{< digest label="sticky" kicker="SPORTS" feed="sports" region="sports" >}}
     {{< digest label="sticky" kicker="LOCAL" region="local">}}
-    {{< digest label="sticky" kicker="OPINION" region="opinion">}}
+    {{< digest label="sticky" kicker="OPINION" feed="opinion" region="opinion">}}
   </div>
 
-  {{< card >}}
-  {{< card >}}
+  <div class="region" data-tb-region="NewRegion7">
+    {{< card taboola=true >}}
+    {{< card taboola=true >}}
+    {{< card taboola=true >}}
+    {{< card taboola=true >}}
+    {{< card taboola=true >}}
+  </div>
 
   <div id="zone-el-9" class="zone-el zone" data-type="ad">
     <fake-ad></fake-ad>
   </div>
 
-  {{< card >}}
-  {{< card >}}
-  {{< card >}}
-  {{< card >}}
-  {{< card >}}
-  {{< card >}}
-  {{< card >}}
+  <div class="region" data-tb-region="NewRegion8">
+    {{< card taboola=true >}}
+    {{< card taboola=true >}}
+    {{< card taboola=true >}}
+    {{< card taboola=true >}}
+    {{< card taboola=true >}}
+    {{< card taboola=true >}}
+    {{< card taboola=true >}}
+  </div>
   <!-- End main card loop -->
 
 </section>

--- a/data/betting.json
+++ b/data/betting.json
@@ -1,0 +1,1599 @@
+{
+  "items": [
+    {
+      "id": "272515329",
+      "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/article272515329.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "2023 Genesis Invitational Betting: Picks, Odds, Predictions \u0026 Best Bets",
+      "publication": "mcclatchy-partners",
+      "layout_option": "none",
+      "home": "/web/v1/sections/87287",
+      "home_section": {
+        "name": "Betting",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/"
+      },
+      "modified_date": 1676487600,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "2023 Genesis Invitational Betting: Picks, Odds, Predictions \u0026 Best Bets",
+      "originating_url": "https://www.rotowire.com/golf/article/2023-the-genesis-invitational-betting-picks-odds-predictions-and-best-bets-69929",
+      "meta_description": "The PGA Tour takes center stage this weekend with a loaded field ready to go at iconic Riviera Country Club for the Genesis Invitational.",
+      "published_date": 1676487600,
+      "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/pf2k9a/picture272515376/alternates/FREE_1140/USATSI_17732150.jpg",
+      "authors": [
+        {
+          "name": "Ryan Pohle",
+          "email": "gamblingmc@gdcgroup.com"
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "87287",
+        "88698"
+      ],
+      "credit": "Rotowire",
+      "dateline": "",
+      "summary": "The PGA Tour takes center stage this weekend with a loaded field ready to go at iconic Riviera Country Club for the Genesis Invitational.",
+      "content": "\u003cp\u003e\u003c!-- %asset:266375316% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003cp\u003eThe PGA Tour heads back to California for the final stop on the West Coast Swing -- The Genesis Invitational at Riviera Country Club in Los Angeles. \u003c/p\u003e\u003cp\u003eIt’s the second straight designated event on the schedule and another $20 million purse comes with it. The much-anticipated return of Tiger Woods is the big news of the week, as he will be teeing it up for the first time since The Open Championship last July. Also in the field are tournament favorite Jon Rahm -- at 15-2 odds -- and world No. 1 Scottie Scheffler, who checks in at 10-1. They are among 23 of the top 25 players making the trip.\u003c/p\u003e\u003cp\u003eLast year, Joaquin Niemann -- at 60-1 -- picked up his second PGA Tour victory by two shots over Collin Morikawa and Cameron Young. Niemann will not be on hand this week to defend his title.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877363% --\u003e\u003c/p\u003e\u003ch2\u003eGenesis Invitational Odds \u0026 Best Bets to Back\u003c/h2\u003e\u003ch3\u003eOutright Picks\u003c/h3\u003e\u003cp\u003e\u003cb\u003eJustin Thomas\u003c/b\u003e\u003cb\u003e (+1600): \u003c/b\u003eThomas surged back into form last week with his first top-5 finish since June, ranking third for the tournament in SG: Off-the-Tee and second in SG: Tee-to-Green. It was only a matter of time for the superb ball striker, who gained 8.8 strokes with his long game in Phoenix. He notched three top-10s at Riviera over his last five appearances.\u003c/p\u003e\u003cp\u003e\u003cb\u003eXander Schauffele\u003c/b\u003e\u003cb\u003e (+1600): \u003c/b\u003eSchauffele’s results in this event have been consistent, as he has posted a top-25 in all five of his starts, although just one top-10. He started out strong last week with consecutive rounds of 67, so the form is there as well. He appears to be close to putting it all together and winning again soon.\u003c/p\u003e\u003cp\u003e\u003cb\u003eWill Zalatoris\u003c/b\u003e\u003cb\u003e (+4000): \u003c/b\u003eWe’re not sure if Zalatoris is 100% after taking last week off following a missed cut at the Farmers, but at these odds I’m willing to take the risk. He’s finished T26 and T15 in his two appearances at Riviera and ranked 10th in SG: Approach here last year.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877378% --\u003e\u003c/p\u003e\u003ch3\u003eTop-10 Wagers to back\u003c/h3\u003e\u003cp\u003e\u003cb\u003eAlex Noren\u003c/b\u003e\u003cb\u003e (+650): \u003c/b\u003eComing off a top-10 with Hatton last week, I’ll look at another European in Noren, who has a decent track record here, with four made cuts in four starts and a pair of top-20s. He closed last season with a top-5 in Houston and started the year with another one in a solid field in Abu Dhabi, so I’m going to overlook last week’s missed cut.\u003c/p\u003e\u003cp\u003e\u003cb\u003eWyndham Clark\u003c/b\u003e\u003cb\u003e (+700): \u003c/b\u003eSince last summer Clark has become more than your average Tour professional, recording seven top-20 finishes over his last 20 starts, including a top-10 last week. He’s a great course fit for Riviera, with his only weakness being that he’s sporadic off the tee. That won’t be as much of a detriment as usual considering how difficult it is for even the most accurate drivers to hit the Riviera fairways at a high clip.\u003c/p\u003e\u003cp\u003e\u003cb\u003eCam Davis\u003c/b\u003e\u003cb\u003e (+1200): \u003c/b\u003eDavis has been trending in the wrong direction, but with that comes value, and he does rank 20th in SG: Off-the-Tee despite his struggles. Most of his troubles have been in the short game, so we like his chances to finish near the top of the leaderboard if he can right the ship in that area.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch3\u003eHead-to-Head Matchups\u003c/h3\u003e\u003cp\u003e\u003cb\u003eSam Burns (-120) over Cameron Young: \u003c/b\u003eYoung broke through at this event last year with a T2, but he is in the midst of a bit of a sophomore slump. Burns, on the other hand, is full of confidence on the heels of consecutive top-15 results. He has also had success here, notching a third-place finish in 2021. That’s enough for us to pay up slightly on the narrow favorite.\u003c/p\u003e\u003cp\u003e\u003cb\u003eCorey Conners\u003c/b\u003e\u003cb\u003e (-110) over Keith Mitchell:\u003c/b\u003e Conners lacks a top-10 showing through seven starts this season, but we don’t necessarily need one in a one-on-one bet. He made the cut in six of his last seven starts and has done so despite ranking 165th in SG: Putting. This is an event Mitchell has traditionally skipped because it doesn’t fit his game well, but it’s hard to pass up these designated events. He missed the cut in his only appearance in 2019.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877363% --\u003e\u003c/p\u003e\u003ch2\u003eGenesis Invitational Betting Tips\u003c/h2\u003e\u003ch3\u003eCourse Characteristics\u003c/h3\u003e\u003cp\u003e\u003ci\u003ePar-71, 7,322 yards\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eAverage Strokes Gained Rankings: The Genesis Invitational Winners Since 2018\u003c/i\u003e\u003c/p\u003e\u003cul\u003e\u003cli\u003eSG: Off-the-Tee: \u003cb\u003e19.6\u003c/b\u003e\u003c/li\u003e\u003cli\u003eSG: Approach: \u003cb\u003e9.2\u003c/b\u003e\u003c/li\u003e\u003cli\u003eSG: Around-the-Green: \u003cb\u003e14.6\u003c/b\u003e\u003c/li\u003e\u003cli\u003eSG: Putting: \u003cb\u003e17.8\u003c/b\u003e\u003c/li\u003e\u003cli\u003eSG: Tee-to-Green: \u003cb\u003e4.0\u003c/b\u003e\u003c/li\u003e\u003cli\u003eDriving Distance: \u003cb\u003e15.8\u003c/b\u003e\u003c/li\u003e\u003cli\u003eDriving Accuracy: \u003cb\u003e45.6\u003c/b\u003e\u003c/li\u003e\u003c/ul\u003e\u003cp\u003eRiviera plays as one of the tougher tests on Tour and doesn’t provide many scoring opportunities outside of the short and downhill par-5 first hole that plays more like a par-4. The par-3s average nearly 200 yards and all but two of the par-4s are under 430 yards. One of those is one of the most recognizable holes on Tour in the driveable par-4 10th that is surrounded by bunkers -- a risk/reward hole that will yield birdies and also plenty of double bogeys. \u003c/p\u003e\u003cp\u003eTee-to-green play has been a key to success, with the champion ranking top-3 in that category three straight years. Distance off the tee gets a premium over accuracy due to a lack of deep rough or hazards. I’ll be targeting players that do a good job of avoiding bogeys and those that approach it well from 150-200 yards, with many iron shots coming in that range. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch3\u003eRegal at Riviera\u003c/h3\u003e\u003cp\u003eThe following golfers, with a minimum of eight rounds played, have the lowest scoring average at Riviera County Club over the last five years.\u003c/p\u003e\u003cul\u003e\u003cli\u003eViktor Hovland: 68.4\u003c/li\u003e\u003cli\u003eMax Homa: 69.0\u003c/li\u003e\u003cli\u003eJon Rahm: 69.4\u003c/li\u003e\u003cli\u003eCollin Morikawa: 69.4\u003c/li\u003e\u003cli\u003eAdam Scott: 69.5\u003c/li\u003e\u003cli\u003eTony Finau: 69.5\u003c/li\u003e\u003c/ul\u003e\u003cp\u003eHovland will be making his third trip to Riviera. He found immediate success, notching back-to-back top-5 finishes. He has excelled with his ball striking at this venue, ranking top-20 in Strokes Gained: Tee-to-Green and SG: Approach both years. He’s due for a bounceback following a mediocre T42 in Phoenix, where he lost 4.6 shots around the green and putting combined. \u003c/p\u003e\u003cp\u003eMeanwhile, the only two-time winner in the field is Scott, who went 15 years between victories before coming out on top in 2020. Despite a strong finish to last season and a runner-up at the Australian Open in December, he seems somewhat overlooked by the oddsmakers, ranking outside the top 20 choices on the board at 55-1. I like Scott as a mid-range DFS option as well.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877378% --\u003e\u003c/p\u003e\u003ch3\u003eTrending in Tee-to-Green\u003c/h3\u003e\u003cp\u003eThese five players gained the most strokes from tee to green over their last 20 rounds.\u003c/p\u003e\u003cul\u003e\u003cli\u003eRory McIlroy: 2.30\u003c/li\u003e\u003cli\u003eScottie Scheffler: 2.05\u003c/li\u003e\u003cli\u003eXander Schauffele: 1.92\u003c/li\u003e\u003cli\u003eTony Finau: 1.89\u003c/li\u003e\u003cli\u003eCollin Morikawa: 1.73\u003c/li\u003e\u003c/ul\u003e\u003cp\u003eAfter winning in his first two appearances of the season -- one on the PGA Tour and one on the DP World Tour -- McIlroy disappointed in his stateside debut last week with a T32 finish. Even so, he did gain strokes in every category except for putting. The Phoenix Open is not his preferred scene, and he should enjoy going back to Riviera, where he finished top-10 in three of his last four visits. \u003c/p\u003e\u003cp\u003ePopping up on both lists are Finau (16-1) and Morikawa (20-1), who both have a runner-up here and have been in good form this season. Morikawa is looking to bounce back from a missed cut, and considering his struggles came in the short game, it seems there is a good possibility he will.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877363% --\u003e\u003c/p\u003e\u003ch2\u003eResponsible Gambling\u003cbr/\u003e\u003cbr/\u003e\u003c/h2\u003e\u003cp\u003e\u003ci\u003e Always gamble responsibly. All licensed and legal operators in the United States have resources available to bettors, including educational guides on how to spot problem gaming, links to support services and tools to self-exclude for a set period of time. Support is available at the \u003c/i\u003e\u003ci\u003eNational Council on Problem Gaming\u003c/i\u003e\u003ci\u003e, \u003c/i\u003e\u003ci\u003e1-800-GAMBLER\u003c/i\u003e\u003ci\u003e and \u003c/i\u003e\u003ci\u003eAmerican Addiction Centers.\u003c/i\u003e\u003ci\u003e Be sure to only wager on gambling sites that are licensed and regulated by the gaming regulatory body in your state. That ensures games are fair, bets are honored, customers’ funds are secure and that there are legal protections for the consumer.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003e Sports betting and gambling are not legal in all locations. Be sure to comply with laws applicable where you reside.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/272515329",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Ryan Pohle\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:gamblingmc@gdcgroup.com\"\u003egamblingmc@gdcgroup.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eRotowire\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Sponsored content",
+      "lead_media": {
+        "id": "272515376",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/pf2k9a/picture272515376",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "USATSI_17732150.jpg",
+        "publication": "mcclatchy-partners",
+        "layout_option": "",
+        "home": "/web/v1/sections/87287",
+        "modified_date": 1676479903,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1676479903,
+        "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/pf2k9a/picture272515376/alternates/FREE_1140/USATSI_17732150.jpg",
+        "href": "/web/v1/content/272515376",
+        "additional_sections": [
+          "87287"
+        ],
+        "credit": "USA TODAY Sports",
+        "dateline": "",
+        "caption": "Event host Tiger Woods attends the trophy ceremony following the final round of the 2022 Genesis Invitational golf tournament.",
+        "photographer": "Gary A. Vasquez",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "mcclatchypartners",
+      "allow_comments": false,
+      "disable_amp": true,
+      "topic_tags": []
+    },
+    {
+      "id": "272322673",
+      "url": "https://www.mcclatchy-partners.com/gdc-group/raleigh/betting/article272322673.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "ACC Betting: How North Carolina Teams Stack Up in 2023 NCAA Tournament",
+      "publication": "mcclatchy-partners",
+      "layout_option": "none",
+      "home": "/web/v1/sections/87608",
+      "home_section": {
+        "name": "Betting",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/raleigh/betting/"
+      },
+      "modified_date": 1675965600,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "How North Carolina Teams Stack Up for 2023 NCAA Tournament ",
+      "originating_url": "https://www.newsobserver.com/betting/article272322673.html",
+      "meta_description": "March Madness is weeks away. Find out how North Carolina’s teams are holding up and review the current odds.",
+      "published_date": 1675965600,
+      "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/raleigh/betting/5l05cv/picture272322633/alternates/FREE_1140/USATSI_19942521.jpg",
+      "authors": [
+        {
+          "name": "Christopher Boan",
+          "email": "gamblingmc@gdcgroup.com"
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "87608",
+        "88698"
+      ],
+      "credit": "Gambling.com",
+      "dateline": "",
+      "summary": "March Madness is weeks away. Find out how North Carolina’s teams are holding up and review the current odds.",
+      "content": "\u003cp\u003e\u003c!-- %asset:266375316% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003cp\u003eWe’ve officially hit the home stretch of the NCAA basketball season, with less than a month until the ACC Men’s Basketball Tournament tips off from Greensboro. \u003c/p\u003e\u003cp\u003eTobacco Road’s four members appear set for a disappointing spring, at least according to oddsmakers from two \u003ca href=\"https://www.miamiherald.com/betting/article258259270.html\" target=\"_blank\" rel=\"Follow\"\u003esports betting sites\u003c/a\u003e, leaving the fans of the N.C. quartet longing for the days of old. \u003c/p\u003e\u003cp\u003eBetween Duke’s unexpected issues in Year 1 of the Jon Scheyer era and UNC’s slide from preseason No. 1 to the middle of the ACC, 2023 is shaping up to be a year to forget in North Carolina. \u003c/p\u003e\u003ch3\u003eNorth Carolina ACC Teams Struggle for Momentum \u003c/h3\u003e\u003cp\u003eThe ACC’s four members from North Carolina find themselves between scrambling and dire straits when it comes to seeding entering the 2023 NCAA Men’s Basketball Tournament. \u003c/p\u003e\u003cp\u003eOddsmakers at \u003ca href=\"https://www.miamiherald.com/betting/article257660528.html\" target=\"_blank\" rel=\"Follow\"\u003eBetMGM Sportsbook\u003c/a\u003e give the four long title odds through Feb. 8, with Duke and UNC sitting in a tie for 22nd with Arkansas at +5000. North Carolina State is listed at +15000 to win it all in 2023 and Wake Forest trails the pack at +20000. \u003c/p\u003e\u003cp\u003eBetMGM has Purdue as the second overall choice to win March Madness at +800. Duke and UNC are tied for 21st overall at +500. \u003ca href=\"https://www.betohio.com/promo-codes\" target=\"_blank\" rel=\"Follow\"\u003eBonus codes are available\u003c/a\u003e for these odds. \u003c/p\u003e\u003cp\u003eWhen it comes to ACC title futures, FanDuel lists Duke (+5000), N.C. State (+6000), North Carolina (+11000) and Wake Forest (+25000) in succession, ranking fifth to ninth out of 15 teams. Virginia is the solid favorite at -160. \u003c/p\u003e\u003cp\u003eAs of Wednesday, N.C. State has the best conference record of the four, sitting at 9-5 (and 19-6 overall). Duke is 8-5, Wake Forest is 8-6 and North Carolina is 7-6 in ACC play. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877383% --\u003e\u003c/p\u003e\u003ch3\u003eHow ACC, Big Ten Teams Stack Up in Latest ESPN Bracketology \u003c/h3\u003e\u003cp\u003eIn Tuesday’s bracket update from \u003ca href=\"https://www.espn.com/espn/feature/story/_/page/bracketology/ncaa-bracketology-projecting-2023-march-madness-men-field\" target=\"_blank\" rel=\"Follow\"\u003eESPN.com bracketologist Joe Lunardi\u003c/a\u003e, the ACC has the third-most teams (seven) of any conference, behind the Big Ten and Big 12 with eight. \u003c/p\u003e\u003cp\u003eOf those seven, UVA is the highest-seeded team (a third seed), and Clemson is the lowest (11th). \u003c/p\u003e\u003cp\u003eTo put that in perspective, the Big Ten has eight teams in Lunardi’s hypothetical field, ranging from top-seeded Purdue to 9th-seeded Northwestern. In between, Indiana and Rutgers are listed as five seeds, Iowa and Illinois are six seeds, Maryland is a seven seed and Michigan State and Northwestern are nine seeds.\u003c/p\u003e\u003cp\u003eIn the ACC, UVA is a three seed, Miami is a six, Duke is a seven, N.C. State and Pitt are eights, UNC is a nine and Clemson is an 11. Wake Forest is on the outside looking in, per Lunardi’s rankings. But Lunardi did acknowledge that Wake’s convincing win over UNC Tuesday night would get the Demon Deacons back in the conversation. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877363% --\u003e\u003c/p\u003e\u003ch3\u003eHow ACC Race Could Look Down the Stretch \u003c/h3\u003e\u003cp\u003eHeading into the final few weeks of the regular season, UVA, Clemson and Pittsburgh are tied for first in the ACC standings with Miami a half-game behind. \u003c/p\u003e\u003cp\u003eThen come the four North Carolina teams, five through eight. \u003c/p\u003e\u003cp\u003eWith four games separating first-place Clemson from 10th-place Florida State, it seems that everything is on the table for most of the ACC’s 15 men’s basketball teams as we speed towards Greensboro. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877378% --\u003e\u003c/p\u003e\u003ch3\u003eResponsible Gambling\u003c/h3\u003e\u003cp\u003e\u003ci\u003e Always gamble responsibly. All licensed and legal operators in the United States have resources available to bettors, including educational guides on how to spot problem gaming, links to support services and tools to self-exclude for a set period of time. Support is available at the \u003c/i\u003e\u003ci\u003eNational Council on Problem Gaming\u003c/i\u003e\u003ci\u003e, \u003c/i\u003e\u003ci\u003e1-800-GAMBLER\u003c/i\u003e\u003ci\u003e and \u003c/i\u003e\u003ci\u003eAmerican Addiction Centers.\u003c/i\u003e\u003ci\u003e Be sure to only wager on gambling sites that are licensed and regulated by the gaming regulatory body in your state. That ensures games are fair, bets are honored, customers’ funds are secure and that there are legal protections for the consumer.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003e Sports betting and gambling are not legal in all locations. Be sure to comply with laws applicable where you reside.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/272322673",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Christopher Boan\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:gamblingmc@gdcgroup.com\"\u003egamblingmc@gdcgroup.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eGambling.com\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Sponsored content",
+      "lead_media": {
+        "id": "272322633",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/raleigh/betting/5l05cv/picture272322633",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "USATSI_19942521.jpg",
+        "publication": "mcclatchy-partners",
+        "layout_option": "",
+        "home": "/web/v1/sections/87608",
+        "modified_date": 1675960657,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1675960657,
+        "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/raleigh/betting/5l05cv/picture272322633/alternates/FREE_1140/USATSI_19942521.jpg",
+        "href": "/web/v1/content/272322633",
+        "additional_sections": [
+          "87608"
+        ],
+        "credit": "William Howard-USA TODAY Sports",
+        "dateline": "",
+        "caption": "North Carolina Tar Heels forward Armando Bacot (5) makes a move on the past against Wake Forest Demon Deacons forward Davion Bradford (20) during the second half at Lawrence Joel Veterans Memorial Coliseum.",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "mcclatchypartners",
+      "allow_comments": false,
+      "disable_amp": true,
+      "topic_tags": []
+    },
+    {
+      "id": "272507041",
+      "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/article272507041.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Caesars Sportsbook Ohio Promo Code MC1BET First-Bet Insurance Up To $1500 For Cavs",
+      "publication": "mcclatchy-partners",
+      "layout_option": "none",
+      "home": "/web/v1/sections/87287",
+      "home_section": {
+        "name": "Betting",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/"
+      },
+      "modified_date": 1676498400,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Caesars Sportsbook Ohio Promo Code MC1BET First-Bet Insurance Up To $1500 For Cavs",
+      "originating_url": "https://www.miamiherald.com/betting/article272507041.html",
+      "meta_description": "NBA bettors can ride the Cavs and create an account with the Caesars Ohio promo code MC1BET and take advantage of first-bet insurance on Caesars up to $1,500.",
+      "published_date": 1676498400,
+      "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/i3om09/picture269662776/alternates/FREE_1140/Caesars%20Ohio%20Promo%20Code%20Generic%204.jpg",
+      "authors": [
+        {
+          "name": "Lindsey Willhite",
+          "email": "gamblingmc@gdcgroup.com"
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "87287",
+        "88698"
+      ],
+      "credit": "Gambling.com",
+      "dateline": "",
+      "summary": "NBA bettors can ride the Cavs and create an account with the Caesars Ohio promo code MC1BET and take advantage of first-bet insurance on Caesars up to $1,500.",
+      "content": "\u003cp\u003e\u003c!-- %asset:266375316% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:267946667% --\u003e\u003c/p\u003e\u003cp\u003eThe Cleveland Cavaliers continue to be in the thick of the Eastern Conference race, but tonight’s road trip to face Joel Embiid and the Philadelphia 76ers could tell a lot about their chances going forward. If you’re ready to ride the red-hot Cavs – who’ve won seven in a row – then create a Caesars Sportsbook account today with the \u003ca href=\"https://www.miamiherald.com/betting/article257659158.html\" target=\"_blank\" rel=\"Follow\"\u003eCaesars Ohio promo code\u003c/a\u003e \u003cb\u003eMC1BET\u003c/b\u003e and take advantage of first-bet insurance on Caesars up to $1,500.\u003c/p\u003e\u003cp\u003eDonovan Mitchell and the Cavaliers started their seven-game winning spree with a 15-point win over the strong Memphis Grizzlies. Then they proceeded to knock off the Pacers, Wizards, Pistons, Pelicans, Bulls and Spurs to prepare for tonight’s battle.\u003c/p\u003e\u003cp\u003eClearly Cavs management seems willing to do what it takes to get back to the NBA Finals as they recently signed three-time NBA champ Danny Green to add another proven 3-point shooter. If the Cavs are going for it, then you can too – and you have the additional benefit of the \u003cb\u003eCaesars Ohio promo code \u003c/b\u003e– the most generous of all \u003ca href=\"https://www.miamiherald.com/betting/article263218723.html\" target=\"_blank\"\u003eOhio sportsbook promo codes\u003c/a\u003e – that gives you a first bet up to $1,500 on Caesars.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:267946667% --\u003e\u003c/p\u003e\u003ch3\u003eCaesars Sportsbook Ohio Promo Code: Getting On Board\u003c/h3\u003e\u003ctable\u003e\u003ctbody\u003e\u003ctr\u003e\u003ctd\u003e\u003cb\u003eCaesars Ohio Promo Code\u003c/b\u003e\u003c/td\u003e\u003ctd\u003eMC1BET\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cb\u003eCaesars Ohio Bonus\u003c/b\u003e\u003c/td\u003e\u003ctd\u003eFirst-bet insurance up to $1500\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cb\u003eTerms \u0026 Conditions \u003c/b\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003eNew customers 21 and over in Ohio; site credit issued as a single bet, has 1x playthrough and must be used within 14 days\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cb\u003eVerified\u003c/b\u003e\u003c/td\u003e\u003ctd\u003eFeb. 15\u003c/td\u003e\u003c/tr\u003e\u003c/tbody\u003e\u003c/table\u003e\u003cp\u003e\u003c!-- %asset:267946667% --\u003e\u003c/p\u003e\u003cp\u003eThe \u003cb\u003eCaesars Ohio promo code\u003c/b\u003e gains you access to a special deal – a first bet up to $1,500 on Caesars – but it doesn’t require special powers or an exaggerated amount of time to claim this offer. Just follow these easy steps:\u003c/p\u003e\u003col\u003e\u003cli\u003eTap any green BET NOW button found in this story. It’ll whisk you to the Caesars Ohio signup page. \u003c/li\u003e\u003cli\u003eType in a valid email address. On the next line, it’ll say Promo Code, you want to make sure it reads \u003cb\u003eMC1BET\u003c/b\u003e underneath that line because that’s what triggers the first bet up to $1,500 on Caesars.\u003c/li\u003e\u003cli\u003ePlace at least $20 into your new account. \u003c/li\u003e\u003c/ol\u003e\u003cp\u003eNow go Full Caesar with the \u003cb\u003eCaesars Ohio promo code\u003c/b\u003e!\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:267946667% --\u003e\u003c/p\u003e\u003ch3\u003eHow Caesars Sportsbook Ohio Promo Code Works\u003c/h3\u003e\u003cp\u003eYou’re not going to find a better deal than a first bet on Caesars up to $1,500, so you should be excited that you’ve used the \u003cb\u003eCaesars Ohio promo code \u003c/b\u003eto create a Caesars Sportsbook account and claim this offer.\u003c/p\u003e\u003cp\u003eBettors should download the Caesars Sportsbook app on your phone and/or tablet. As the most comprehensive of all \u003ca href=\"https://www.miamiherald.com/betting/article258182498.html\"\u003eOhio sports betting apps\u003c/a\u003e, it will show you so many ways to play your first bet. If you win, cash is headed directly to your account. If your first bet falls short, the amount of the bet will be returned to your account in the form of one bet credit.\u003c/p\u003e\u003cp\u003eYou’ll have 14 days to play your bet credit. To transform that credit into cash, you only need to win once because Caesars Sportsbook boasts just a 1X playthrough requirement. Moreover, no matter how your first bet works out, Caesars gives you 1,000 Rewards credits and 1,000 Tier Credits. Save up these credits so you can exchange them for free rewards, including bets.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:267946667% --\u003e\u003c/p\u003e\u003ch3\u003eCaesars Sportsbook Ohio Covers All The Sports\u003c/h3\u003e\u003cp\u003eWhile the Super Bowl is over, there’s always something to wager on \u003ca href=\"https://www.miamiherald.com/betting/article258259270.html\" target=\"_blank\" rel=\"Follow\"\u003eonline sportsbooks\u003c/a\u003e with the NFL. If you have a hunch on the NFL Draft’s No. 1 overall pick or who’ll win the 2024 Super Bowl in Nevada – the Cincinnati Bengals boast some good odds -- then check out Caesars’ picks there.\u003c/p\u003e\u003cp\u003eSpring training gets underway this week. The Cleveland Guardians should be the class of the AL Central again this year – and maybe a lot more if their young pitching keeps improving. And, hey, March Madness is just four weeks away!\u003c/p\u003e\u003cp\u003eIn short, there are plenty of good reasons to place a bet or two – but there’s one best reason to do it with Caesars: The first bet up to $1,500 on Caesars that happens only with the king of all \u003ca href=\"https://www.miamiherald.com/betting/article257662778.html\" target=\"_blank\" rel=\"Follow\"\u003esportsbook promo codes\u003c/a\u003e\u003cb\u003e – the Caesars Sportsbook promo code MC1BET\u003c/b\u003e.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:267946667% --\u003e\u003c/p\u003e\u003ch3\u003eResponsible Gambling\u003c/h3\u003e\u003cp\u003e\u003ci\u003e Always gamble responsibly. All licensed and legal operators in the United States have resources available to bettors, including educational guides on how to spot problem gaming, links to support services and tools to self-exclude for a set period of time. Support is available at the \u003c/i\u003e\u003ca href=\"https://www.ncpgambling.org/\" target=\"_blank\"\u003e\u003ci\u003eNational Council on Problem Gaming\u003c/i\u003e\u003c/a\u003e\u003ci\u003e, \u003c/i\u003e\u003ca href=\"https://www.1800gambler.net/\" target=\"_blank\"\u003e\u003ci\u003e1-800-GAMBLER\u003c/i\u003e\u003c/a\u003e\u003ci\u003e and \u003c/i\u003e\u003ca href=\"https://americanaddictioncenters.org/\" target=\"_blank\"\u003e\u003ci\u003eAmerican Addiction Centers.\u003c/i\u003e\u003c/a\u003e\u003ci\u003e Be sure to only wager on gambling sites that are licensed and regulated by the gaming regulatory body in your state. That ensures games are fair, bets are honored, customers’ funds are secure and that there are legal protections for the consumer.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003e Sports betting and gambling are not legal in all locations. Be sure to comply with laws applicable where you reside.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:258181493% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/272507041",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Lindsey Willhite\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:gamblingmc@gdcgroup.com\"\u003egamblingmc@gdcgroup.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eGambling.com\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Sponsored Content",
+      "lead_media": {
+        "id": "269662776",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/i3om09/picture269662776",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "Caesars Ohio Promo Code Generic 4.jpg",
+        "publication": "mcclatchy-partners",
+        "layout_option": "",
+        "home": "/web/v1/sections/87287",
+        "modified_date": 1675789046,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1670342546,
+        "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/i3om09/picture269662776/alternates/FREE_1140/Caesars%20Ohio%20Promo%20Code%20Generic%204.jpg",
+        "href": "/web/v1/content/269662776",
+        "additional_sections": [
+          "87287"
+        ],
+        "credit": "",
+        "dateline": "",
+        "alt": "Caesars Sportsbook Ohio Promo Code",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "mcclatchypartners",
+      "allow_comments": false,
+      "disable_amp": true,
+      "topic_tags": []
+    },
+    {
+      "id": "272505766",
+      "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/article272505766.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "BetMGM PA Bonus Code MCBETFULL Lands $1000 First-Bet Offer For Sixers",
+      "publication": "mcclatchy-partners",
+      "layout_option": "none",
+      "home": "/web/v1/sections/87287",
+      "home_section": {
+        "name": "Betting",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/"
+      },
+      "modified_date": 1676498400,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "BetMGM PA Bonus Code MCBETFULL Lands $1000 First-Bet Offer For Sixers",
+      "originating_url": "https://www.miamiherald.com/betting/article272505766.html",
+      "meta_description": "You can get in on the betting action with the BetMGM bonus code MCBETFULL that has a first-bet offer that will give you up to $1,000 in bonus bets back",
+      "published_date": 1676498400,
+      "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/h7eiff/picture262530502/alternates/FREE_1140/BETMGM%20PA%20GENERIC%20(1).jpg",
+      "authors": [
+        {
+          "name": "KC Joyner",
+          "email": "gamblingmc@gdcgroup.com"
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "87287",
+        "88698"
+      ],
+      "credit": "Gambling.com",
+      "dateline": "",
+      "summary": "You can get in on the betting action with the BetMGM bonus code MCBETFULL that has a first-bet offer that will give you up to $1,000 in bonus bets back",
+      "content": "\u003cp\u003e\u003c!-- %asset:266375316% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:258663408% --\u003e\u003c/p\u003e\u003cp\u003eThe Philadelphia 76ers recent seven-game win streak helped propel the club back into contention for Eastern Conference title. The pursuit of the No. 1 seed is something to get some betting action on and you can do that with the \u003ca href=\"https://www.miamiherald.com/betting/article257660528.html\" target=\"_blank\" rel=\"Follow\"\u003eBetMGM bonus code\u003c/a\u003e \u003cb\u003eMCBETFULL \u003c/b\u003ethat has a first-bet offer that will give you up to $1,000 in bonus bets back if your first bet results in a loss.\u003c/p\u003e\u003cp\u003eOvertaking Boston or Milwaukee won’t be easy since the 76ers have 15 of their last 22 games on the road, but this club ranks sixth in road win percentage this year. That makes wagering on the 76ers at \u003ca href=\"https://www.miamiherald.com/betting/article258663718.html\" target=\"_blank\" rel=\"Follow\"\u003ePennsylvania sportsbook apps\u003c/a\u003e down the regular season stretch an even stronger proposition.\u003c/p\u003e\u003cp\u003eYou can also get on Philadelphia’s postseason bandwagon with the \u003cb\u003eBetMGM bonus code\u003c/b\u003e, as BetMGM has the 76ers listed with the third best futures odds to win the Eastern Conference (+450) and the sixth most favorable odds to win the NBA championship (+1200).\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:258663408% --\u003e\u003c/p\u003e\u003ch3\u003eBetMGM Bonus Code PA Has Extremely Fast Sign Up\u003c/h3\u003e\u003ctable\u003e\u003ctbody\u003e\u003ctr\u003e\u003ctd\u003e\u003cb\u003eBetMGM Bonus Code PA\u003c/b\u003e\u003c/td\u003e\u003ctd\u003eMCBET\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cb\u003eBetMGM PA Bonus\u003c/b\u003e\u003c/td\u003e\u003ctd\u003e$1,000 first-bet offer\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cb\u003eTerms \u0026 Conditions\u003c/b\u003e\u003c/td\u003e\u003ctd\u003eNew customers, 21 and over in Pennsylvania as well as AZ, CO, IN, IA, IL, KS, LA, MD, MI, MS, NV, NJ, OH, TN, VA, WV, WY. There’s a 1x playthrough requirement\u003c/td\u003e\u003c/tr\u003e\u003c/tbody\u003e\u003c/table\u003e\u003cp\u003e\u003c!-- %asset:258663408% --\u003e\u003c/p\u003e\u003cp\u003eThe sign-up process for the \u003cb\u003eBetMGM bonus code\u003c/b\u003e is equivalent to a fast-break dunk on the court, as you can create a new account in minutes.\u003c/p\u003e\u003col\u003e\u003cli\u003eStart by hitting the BET NOW button.\u003c/li\u003e\u003cli\u003eFill out some basic personal information that confirms your age and location.\u003c/li\u003e\u003cli\u003eGo to the bonus code and type in the \u003cb\u003eBetMGM bonus code MCBETFULL\u003c/b\u003e.\u003c/li\u003e\u003cli\u003ePlace an initial deposit of $10 or more.\u003c/li\u003e\u003c/ol\u003e\u003cp\u003eIt will then be first bet time. Your selection of wager types here is equal to or superior to other \u003ca href=\"https://www.miamiherald.com/betting/article257662833.html\" target=\"_blank\" rel=\"Follow\"\u003esports betting apps\u003c/a\u003e, as you can bet on the NBA, NHL, MLB, golf and tennis, the Daytona 500 or dozens of additional sports betting markets.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:258663408% --\u003e\u003c/p\u003e\u003ch3\u003eBetMGM Bonus Code PA Gets You Bonus Bets\u003cbr/\u003e\u003cbr/\u003e\u003c/h3\u003e\u003cp\u003eThe world of \u003ca href=\"https://www.miamiherald.com/betting/article257662778.html\" target=\"_blank\"\u003esportsbook promo codes\u003c/a\u003e is chock full of intriguing offers, but few if any will give you five bonus bets if your first bet loses.\u003c/p\u003e\u003cp\u003eThe \u003cb\u003eBetMGM bonus code\u003c/b\u003e is an exception here, as any first-bet loss of $50 or more (up to $1,000) will be refunded with five bonus bets of equal value. Lose less than $50 on your initial wager and the refund will be delivered with one bonus bet.\u003c/p\u003e\u003cp\u003eThese bonus bets are built to recover your losses fast, as they have a 1X playthrough that will register profits in your account after only one winning wager.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:258663408% --\u003e\u003c/p\u003e\u003ch3\u003eBetMGM Adds Parlays To Betting Mix\u003cbr/\u003e\u003cbr/\u003e\u003c/h3\u003e\u003cp\u003eBetMGM makes it tremendously easy to make parlay wagers, as you can do so right in your betting slip or go to the Easy Parlay generator to do so. Each of the \u003ca href=\"https://www.miamiherald.com/betting/article258259270.html\" target=\"_blank\" rel=\"Follow\"\u003eonline sportsbooks\u003c/a\u003e aims to smooth out this process, but few if any can match the smoothness of wagering here.\u003c/p\u003e\u003cp\u003eBetMGM also has a select your squad feature that will deliver 76ers-centric content and special betting offers to you if you let BetMGM know that Philadelphia is your favorite NBA team.\u003c/p\u003e\u003cp\u003eWith the NBA playoffs not that far away, it’s a perfect time to sharpen your NBA betting skills, so hit that link and sign up for the \u003cb\u003eBetMGM bonus code MCBETFULL\u003c/b\u003e today.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:258663408% --\u003e\u003c/p\u003e\u003ch3\u003eResponsible Gambling\u003cbr/\u003e\u003cbr/\u003e\u003c/h3\u003e\u003cp\u003e\u003ci\u003e Always gamble responsibly. All licensed and legal operators in the United States have resources available to bettors, including educational guides on how to spot problem gaming, links to support services and tools to self-exclude for a set period of time. Support is available at the \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://www.ncpgambling.org/\"\u003e\u003ci\u003eNational Council on Problem Gaming\u003c/i\u003e\u003c/a\u003e\u003ci\u003e, \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://www.1800gambler.net/\"\u003e\u003ci\u003e1-800-GAMBLER\u003c/i\u003e\u003c/a\u003e\u003ci\u003e and \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://americanaddictioncenters.org/\"\u003e\u003ci\u003eAmerican Addiction Centers.\u003c/i\u003e\u003c/a\u003e\u003ci\u003e Be sure to only wager on gambling sites that are licensed and regulated by the gaming regulatory body in your state. That ensures games are fair, bets are honored, customers’ funds are secure and that there are legal protections for the consumer.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003e Sports betting and gambling are not legal in all locations. Be sure to comply with laws applicable where you reside.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:258663388% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/272505766",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy KC Joyner\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:gamblingmc@gdcgroup.com\"\u003egamblingmc@gdcgroup.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eGambling.com\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Sponsored Content",
+      "lead_media": {
+        "id": "262530502",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/h7eiff/picture262530502",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "BETMGM PA GENERIC (1).jpg",
+        "publication": "mcclatchy-partners",
+        "layout_option": "",
+        "home": "/web/v1/sections/87287",
+        "modified_date": 1655302445,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1655302445,
+        "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/h7eiff/picture262530502/alternates/FREE_1140/BETMGM%20PA%20GENERIC%20(1).jpg",
+        "href": "/web/v1/content/262530502",
+        "additional_sections": [
+          "87287"
+        ],
+        "credit": "",
+        "dateline": "",
+        "alt": "BETMGM PA Generic Sportsbook",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "mcclatchypartners",
+      "allow_comments": false,
+      "disable_amp": true,
+      "topic_tags": []
+    },
+    {
+      "id": "272497877",
+      "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/nfl/article272497877.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "BetMGM Bonus Code MCBET Lets Fans Look Ahead With First-Bet Offer Up To $1000",
+      "publication": "mcclatchy-partners",
+      "layout_option": "none",
+      "home": "/web/v1/sections/87347",
+      "home_section": {
+        "name": "NFL",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/nfl/"
+      },
+      "modified_date": 1676476800,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "BetMGM Bonus Code MCBET Lets Fans Look Ahead With First-Bet Offer Up To $1000",
+      "originating_url": "https://www.miamiherald.com/betting/nfl/article272497877.html",
+      "meta_description": "It’s never too early to look ahead with BetMGM bonus code MCBET and a first-bet offer up to $1000 that you can use to wager on who will win the next Super Bowl",
+      "published_date": 1676476800,
+      "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/kansas-city/betting/d1fxdp/picture257731538/alternates/FREE_1140/BetMGM%20-%20Generic%20-%20Promo%20Code%20-%20Wide.jpg",
+      "authors": [
+        {
+          "name": "Jesse Jones",
+          "email": "gamblingmc@gdcgroup.com"
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "87347",
+        "88698"
+      ],
+      "credit": "Gambling.com",
+      "dateline": "",
+      "summary": "It’s never too early to look ahead with BetMGM bonus code MCBET and a first-bet offer up to $1000 that you can use to wager on who will win the next Super Bowl",
+      "content": "\u003cp\u003e\u003c!-- %asset:266375316% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003cp\u003eWhen the confetti rained down on the Kansas City Chiefs to conclude their thrilling Super Bowl 57 win, the NFL offseason officially began. However, it’s never too early to look ahead with \u003cb\u003e\u003ca href=\"https://www.miamiherald.com/betting/article257660528.html\" target=\"_blank\" rel=\"Follow\"\u003eBetMGM bonus code\u003c/a\u003e MCBET\u003c/b\u003e. Signing up now will grab you a first-bet offer up to $1000 that you can use to wager on who will win the next Super Bowl (or just about anything else).\u003c/p\u003e\u003cp\u003e\u003ca href=\"https://www.miamiherald.com/betting/article258259270.html\" target=\"_blank\" rel=\"Follow\"\u003eOnline sportsbooks\u003c/a\u003e have begun releasing odds on who will lift the Lombardi Trophy following Super Bowl 58, and if you’re lucky, you can use the early odds to turn some serious profit. With your \u003cb\u003eBetMGM bonus code\u003c/b\u003e, however, you’re protected even if you don’t win.\u003c/p\u003e\u003cp\u003eNo surprise that the Chiefs are currently the betting favorite to win it all again. Even betting on them, NFL futures bets have the potential to make some big bucks. With BetMGM, one of the top \u003ca href=\"https://www.miamiherald.com/betting/article257662833.html\" target=\"_blank\" rel=\"Follow\"\u003esports betting apps\u003c/a\u003e around, now might be the best time to make that bet.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch3\u003eBetMGM Bonus Code: Getting Started\u003c/h3\u003e\u003ctable\u003e\u003ctbody\u003e\u003ctr\u003e\u003ctd\u003e\u003cb\u003eBetMGM Bonus Code\u003c/b\u003e\u003c/td\u003e\u003ctd\u003eMCBET\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cb\u003eBetMGM Bonus\u003c/b\u003e\u003c/td\u003e\u003ctd\u003eFirst-Bet Offer Worth up to $1,000\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cb\u003eTerms \u0026 Conditions\u003c/b\u003e\u003c/td\u003e\u003ctd\u003eNew customers, 21 and over in AZ, CO, IN, IA, IL, KS, LA, MD, MI, MS, NV, NJ, OH, PA, TN, VA, WV, WY. There’s a 1x playthrough requirement\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cb\u003eLast verified\u003c/b\u003e\u003c/td\u003e\u003ctd\u003eFeb. 15\u003c/td\u003e\u003c/tr\u003e\u003c/tbody\u003e\u003c/table\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003cp\u003eThe \u003cb\u003eBetMGM bonus code,\u003c/b\u003e among the best \u003ca href=\"https://www.miamiherald.com/betting/article257662778.html\" target=\"_blank\" rel=\"Follow\"\u003esportsbook promo codes\u003c/a\u003e, might be the best for this situation. Fortunately, it’s easy to sign up.\u003c/p\u003e\u003col\u003e\u003cli\u003eClick on one of the “BET NOW” buttons you see on this page. You’ll be taken to BetMGM’s website to register. Once there, follow the necessary steps to sign up.\u003c/li\u003e\u003cli\u003eEnter your BetMGM bonus code \u003cb\u003eMCBET\u003c/b\u003e when prompted (it may show up already filled in).\u003c/li\u003e\u003cli\u003eEstablish your identity by entering in things like your name, phone number, email address and other pertinent information. You have to be at least 21 and physically in a BetMGM state.\u003c/li\u003e\u003cli\u003eEnter in your banking information and select how you’d like to deposit. Minimum deposits are $10..\u003c/li\u003e\u003c/ol\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch3\u003eBetMGM Bonus Code MCBET: How It Works\u003c/h3\u003e\u003cp\u003eMany sportsbooks offer some form protection on your first bet. What makes this \u003cb\u003eBetMGM bonus code\u003c/b\u003e special is that it offers a high cap of $1,000 and bonuses. So, if you bet on your favorite team to win next February’s Super Bowl 58 and they win, you’ve just made some big bucks. \u003c/p\u003e\u003cp\u003eHowever, if they fall short, with \u003cb\u003eBetMGM bonus code\u003c/b\u003e, you’re protected. If your wager falls through, you’ll get five bonus bets matching your original wager amount. So, if you bet $700, you’ll get five, $140 wagers. Original bets under $50 still get a single bonus wager.\u003c/p\u003e\u003cp\u003eThe offer only has a 1x playthrough requirement, meaning you can cash out any winnings. The bonus bets can’t be cashed out, though, and must be used within seven days.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch3\u003eBetMGM Makes Future Bets Easy\u003c/h3\u003e\u003cp\u003eWe’ve seen some pretty improbable odds come true recently in the world of sports. However long the odds, crazier things have happened. That’s one thing that makes NFL futures bets, especially this early with the best odds, so fun. \u003c/p\u003e\u003cp\u003eThere are some good teams given some pretty long odds right now. You can bet on the Steelers or Patriots, for instance, to win the next Super Bowl at +5000. Don’t forget, the then-St. Louis Rams finished the 1998 season 4-12 and had 300-1 odds to win the 1999 Super Bowl.\u003c/p\u003e\u003cp\u003eNow might be the best time to bet on your long-shot, and you can do it with the first-bet offer up to $1,000 with the \u003cb\u003eBetMGM bonus code MCBET\u003c/b\u003e.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch3\u003eResponsible Gambling\u003cbr/\u003e\u003cbr/\u003e\u003c/h3\u003e\u003cp\u003e\u003ci\u003e Always gamble responsibly. All licensed and legal operators in the United States have resources available to bettors, including educational guides on how to spot problem gaming, links to support services and tools to self-exclude for a set period of time. Support is available at the \u003c/i\u003e\u003ci\u003eNational Council on Problem Gaming\u003c/i\u003e\u003ci\u003e, \u003c/i\u003e\u003ci\u003e1-800-GAMBLER\u003c/i\u003e\u003ci\u003e and \u003c/i\u003e\u003ci\u003eAmerican Addiction Centers.\u003c/i\u003e\u003ci\u003e Be sure to only wager on gambling sites that are licensed and regulated by the gaming regulatory body in your state. That ensures games are fair, bets are honored, customers’ funds are secure and that there are legal protections for the consumer.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003e Sports betting and gambling are not legal in all locations. Be sure to comply with laws applicable where you reside.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/272497877",
+      "allow_ads": false,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Jesse Jones\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:gamblingmc@gdcgroup.com\"\u003egamblingmc@gdcgroup.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eGambling.com\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Sponsored Content",
+      "lead_media": {
+        "id": "257731538",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/kansas-city/betting/d1fxdp/picture257731538",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "BetMGM - Generic - Promo Code - Wide.jpg",
+        "publication": "mcclatchy-partners",
+        "layout_option": "",
+        "home": "/web/v1/sections/87297",
+        "modified_date": 1675790099,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1643319597,
+        "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/kansas-city/betting/d1fxdp/picture257731538/alternates/FREE_1140/BetMGM%20-%20Generic%20-%20Promo%20Code%20-%20Wide.jpg",
+        "href": "/web/v1/content/257731538",
+        "additional_sections": [
+          "87297"
+        ],
+        "credit": "",
+        "dateline": "",
+        "alt": "BetMGM bonus Code",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "mcclatchypartners",
+      "allow_comments": false,
+      "disable_amp": true,
+      "topic_tags": []
+    },
+    {
+      "id": "272480385",
+      "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/article272480385.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "BetMGM Bonus Code MCBET Earns $1000 First-Bet Offer for Valentine’s Day Schedule",
+      "publication": "mcclatchy-partners",
+      "layout_option": "none",
+      "home": "/web/v1/sections/87287",
+      "home_section": {
+        "name": "Betting",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/"
+      },
+      "modified_date": 1676398825,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "BetMGM Bonus Code MCBET Earns $1000 First-Bet Offer for Valentine’s Day Schedule",
+      "originating_url": "https://www.miamiherald.com/betting/article272480385.html",
+      "meta_description": "Wednesday’s games could set your heart aflutter if you bet them using the BetMGM bonus code MCBET which provides a $1,000 first-bet offer for new users.",
+      "published_date": 1676390400,
+      "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/kansas-city/betting/jfcu1o/picture257731543/alternates/FREE_1140/BetMGM%20-%20Generic%20Different%20-%20Promo%20Code%20-%20Wide.jpg",
+      "authors": [
+        {
+          "name": "Blake Krass",
+          "email": "gamblingmc@gdcgroup.com"
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "87287",
+        "88698"
+      ],
+      "credit": "Gambling.com",
+      "dateline": "",
+      "summary": "Wednesday’s games could set your heart aflutter if you bet them using the BetMGM bonus code MCBET which provides a $1,000 first-bet offer for new users.",
+      "content": "\u003cp\u003e\u003c!-- %asset:266375316% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003cp\u003eThe NBA season is delivering an amazing Valentine’s Day TV doubleheader on Tuesday night before we head into the All-Star break. Meanwhile the NHL features a busy nine-game slate most of the top teams on the ice. These games could set your heart aflutter if you bet them using the \u003cb\u003e\u003ca href=\"https://www.miamiherald.com/betting/article257660528.html\" target=\"_blank\" rel=\"Follow\"\u003eBetMGM bonus code\u003c/a\u003e MCBET\u003c/b\u003e which provides a $1,000 first-bet offer for new users.\u003c/p\u003e\u003cp\u003eThe \u003cb\u003eBetMGM bonus code\u003c/b\u003e is one of the best welcome offers on any of the \u003ca href=\"https://www.miamiherald.com/betting/article257662833.html\" target=\"_blank\" rel=\"Follow\"\u003esports betting apps\u003c/a\u003e. This $1,000 first-bet offer allows you to take a real chance when placing your first bet. That is because if that first bet loses, you get refunded with a bonus bet. Then that bonus bet gives you a second chance at winning big.\u003c/p\u003e\u003cp\u003eThere are plenty of features that make BetMGM one of the top \u003ca href=\"https://www.miamiherald.com/betting/article258259270.html\" target=\"_blank\" rel=\"Follow\"\u003eonline sportsbooks\u003c/a\u003e on the market. Live betting and one-game parlays are two of the best ways to bet and BetMGM has great interfaces and odds for both of those popular features.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch3\u003eBetMGM Bonus Code MCBET: How To Secure The Offer\u003c/h3\u003e\u003ctable\u003e\u003ctbody\u003e\u003ctr\u003e\u003ctd\u003e\u003cb\u003eBetMGM Bonus Code\u003c/b\u003e\u003c/td\u003e\u003ctd\u003eMCBET\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cb\u003eBetMGM Bonus\u003c/b\u003e\u003c/td\u003e\u003ctd\u003eFirst-Bet Offer Worth up to $1,000\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cb\u003eTerms \u0026 Conditions\u003c/b\u003e\u003c/td\u003e\u003ctd\u003eNew customers, 21 and over in AZ, CO, IN, IA, IL, KS, LA, MD, MI, MS, NV, NJ, OH, PA, TN, VA, WV, WY. There’s a 1x playthrough requirement\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cb\u003eLast verified\u003c/b\u003e\u003c/td\u003e\u003ctd\u003eFeb. 14\u003c/td\u003e\u003c/tr\u003e\u003c/tbody\u003e\u003c/table\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003cp\u003eThe \u003cb\u003eBetMGM bonus code\u003c/b\u003e is one of the easiest-to-use \u003ca href=\"https://www.miamiherald.com/betting/article257662778.html\" target=\"_blank\" rel=\"Follow\"\u003esportsbook promo codes\u003c/a\u003e on the market. Any new user that is 21 or older and located in a BetMGM state is eligible for this offer and just needs to follow these steps to take advantage of the deal:\u003c/p\u003e\u003col\u003e\u003cli\u003eClick on any of the BET NOW links in this article to get to the operator.\u003c/li\u003e\u003cli\u003eEnter the BetMGM bonus code \u003cb\u003eMCBET\u003c/b\u003e in the appropriate field.\u003c/li\u003e\u003cli\u003eFill out a few bits of personal information to verify your identity.\u003c/li\u003e\u003cli\u003eMake an initial deposit of $10 or more.\u003c/li\u003e\u003cli\u003ePlace your first bet for $10 or more.\u003c/li\u003e\u003c/ol\u003e\u003cp\u003eIf that first bet wins, you will receive a cash payout like on any standard bet. If your first bet loses, you will be refunded with bonus bets. If your original bet was for $50 or more, you would receive five bonus bets that each equal 20% of that wager amount. If your original bet amount was less than $50, you would receive a single bonus bet that matches your wager amount.\u003c/p\u003e\u003cp\u003eAny bonus bets you do earn are valid for seven days and then they would expire. You only need to risk these bonus bets once to get any winnings in cash with the \u003cb\u003eBetMGM bonus code\u003c/b\u003e.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch3\u003eBetMGM’s Best Features\u003c/h3\u003e\u003cp\u003eThere are plenty of unique features to the BetMGM app beyond the \u003cb\u003eBetMGM bonus code\u003c/b\u003e. Live betting is one of the most popular of those features. Live betting allows you to wager on a game while it is already in progress. For example, if the Celtics jumped out to an early lead tonight, you could get a line with good value on the Bucks and bet them live to come back.\u003c/p\u003e\u003cp\u003eOne-game parlays are another fun way to bet. This feature allows you to combine multiple bets from the same game into one large wager. You can choose from the side and total, as well as a large selection of game and player props.\u003c/p\u003e\u003cp\u003eGive all of these great features a chance once you have placed your first bet with the \u003cb\u003eBetMGM bonus code MCBET\u003c/b\u003e.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch3\u003e\u003cspan\u003eResponsible Gambling\u003c/span\u003e\u003cbr/\u003e\u003cbr/\u003e\u003c/h3\u003e\u003cp\u003e\u003ci\u003e Always gamble responsibly. All licensed and legal operators in the United States have resources available to bettors, including educational guides on how to spot problem gaming, links to support services and tools to self-exclude for a set period of time. Support is available at the \u003c/i\u003e\u003ci\u003eNational Council on Problem Gaming\u003c/i\u003e\u003ci\u003e, \u003c/i\u003e\u003ci\u003e1-800-GAMBLER\u003c/i\u003e\u003ci\u003e and \u003c/i\u003e\u003ci\u003eAmerican Addiction Centers.\u003c/i\u003e\u003ci\u003e Be sure to only wager on gambling sites that are licensed and regulated by the gaming regulatory body in your state. That ensures games are fair, bets are honored, customers’ funds are secure and that there are legal protections for the consumer.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003e Sports betting and gambling are not legal in all locations. Be sure to comply with laws applicable where you reside.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/272480385",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Blake Krass\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:gamblingmc@gdcgroup.com\"\u003egamblingmc@gdcgroup.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eGambling.com\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Sponsored Content",
+      "lead_media": {
+        "id": "257731543",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/kansas-city/betting/jfcu1o/picture257731543",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "BetMGM - Generic Different - Promo Code - Wide.jpg",
+        "publication": "mcclatchy-partners",
+        "layout_option": "",
+        "home": "/web/v1/sections/87297",
+        "modified_date": 1667403834,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1643743280,
+        "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/kansas-city/betting/jfcu1o/picture257731543/alternates/FREE_1140/BetMGM%20-%20Generic%20Different%20-%20Promo%20Code%20-%20Wide.jpg",
+        "href": "/web/v1/content/257731543",
+        "additional_sections": [
+          "87297"
+        ],
+        "credit": "",
+        "dateline": "",
+        "alt": "BetMGM bonus code",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "mcclatchypartners",
+      "allow_comments": false,
+      "disable_amp": true,
+      "topic_tags": []
+    },
+    {
+      "id": "278261858",
+      "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/article278261858.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Exclusive: College Betting Scandal Q\u0026A With U.S. Integrity CEO Matt Holt",
+      "publication": "mcclatchy-partners",
+      "layout_option": "none",
+      "home": "/web/v1/sections/87287",
+      "home_section": {
+        "name": "Betting",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/"
+      },
+      "modified_date": 1692111600,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Exclusive: College Betting Scandal Q\u0026A With U.S. Integrity CEO Matt Holt",
+      "originating_url": "https://bookies.com/college-football/picks/exclusive-college-betting-scandal-q-a-with-us-integrity-ceo-matt-holt",
+      "meta_description": "One common denominator in all the college betting cases is U.S. Integrity. They alert teams, leagues and sportsbooks – to suspicious betting activity.",
+      "published_date": 1692111600,
+      "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/l5yxy3/picture278260823/alternates/FREE_1140/USATSI_20631876.jpg",
+      "authors": [
+        {
+          "name": "Bill Speros",
+          "email": "Gamblingmc@gdcgroup.com"
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "87287",
+        "88698"
+      ],
+      "credit": "Bookies.com",
+      "dateline": "",
+      "summary": "One common denominator in all the college betting cases is U.S. Integrity. They alert teams, leagues and sportsbooks – to suspicious betting activity.",
+      "content": "\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e\u003cp\u003eGambling-related investigations, penalties, fines, firings and the potential of jail time for athletes, have roiled college sports in 2023. \u003c/p\u003e\u003cp\u003eAlleged illegal college football betting by athletes at Iowa and Iowa State have resulted in seven current or former athletes being charged with records tampering. NCAA rules prohibit student-athletes from betting on any NCAA-backed sport at any level. Penalties can vary depending on the amount of the wagers and the events in question. \u003c/p\u003e\u003cp\u003eGambling is illegal in Iowa for those under 21 in Iowa, as is knowingly allowing someone under 21 to wager on betting apps. The Iowa and Iowa State athletes allegedly made illicit wagers via DraftKings and FanDuel mobile apps. Some used the names and information of family members in setting up their accounts. \u003c/p\u003e\u003cp\u003eIn May, Alabama’s baseball coach Brad Bohannon was fired after an investigation found the coach was on the phone with a someone in Ohio who was placing large wagers on Alabama to lose a game to LSU, set to be played at the Great American Ballpark in Cincinnati. \u003c/p\u003e\u003cp\u003eOne common denominator in all these cases is U.S. Integrity. The company is an FBI of Sports Betting. Its mission is to alert customers – teams, leagues, sportsbooks, and conferences – to suspicious betting activity. \u003c/p\u003e\u003cp\u003eThis year, representatives of U.S. Integrity will speak to athletes at each school in the SEC and Big 12 about the perils of betting, and the technology in place that makes illegal betting on an online platform virtually impossible to hide. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch3\u003e‘The System Is Working’\u003c/h3\u003e\u003cp\u003eU.S. Integrity CEO and Founder Matt Holt has been busy in 2023. Bookies.com caught up with Holt and spoke with him for about 30 minutes via Zoom from his company’s office in Las Vegas. His company ends up investigating about 1 in every 500 events in which betting is offered. \u003c/p\u003e\u003cp\u003eThe legalization of betting and the technology that surrounds it has made these sorts of investigations possible, if not inevitable. \u003c/p\u003e\u003cp\u003e\u003cb\u003e“There is no anonymous wagering. \u003c/b\u003eThere’s no hiding these bets,” Holt said. “And because that transparency and that heightened level of transparency is there, I do think it’s significantly harder,” Holt said. “We see some people say, ‘\u003cb\u003eOh my goodness, this is what’s wrong with legal sports betting.’ But we on the regulated compliance side say, ‘No, this is what’s right.’\u003c/b\u003e It proves the system is working. If you try to circumvent the rules, we will catch you. \u003c/p\u003e\u003cp\u003e“We’re hoping that this big wave of violations will be a deterrent, especially with all of the heightened educational efforts by the professional collegiate sports leagues between their educational efforts and the technological advances allowing us to catch people. We’re hoping both of those will be a deterrent moving forward. And we can get sort of back to a normalcy.”\u003c/p\u003e\u003cp\u003eHolt’s basic message to college athletes:\u003cb\u003e “Don’t do it. You will be caught.” \u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877363% --\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eHere is a Q\u0026A from our conversation. Some questions and answers have been edited for length and clarity. \u003c/i\u003e\u003c/p\u003e\u003ch3\u003eWhy have there been so may issues with collegiate sports betting in 2023?\u003c/h3\u003e\u003cp\u003e\u003cb\u003eHolt\u003c/b\u003e: There’s sort of a journey in states with regulated sports betting. When a new state launches, they have to write regs, get those regs (regulations) passed publicly. Then there’s a licensure process where they have to bulk up these staffs and do background checks and licensing on all these different companies that want to operate sports books. \u003c/p\u003e\u003cp\u003eBut 18 to 24 months later, you finish all the licensure background checks, and those temporary licenses become permanent licenses, and your regs are all written, and your laws are your laws. Now you have this great big staff, and what do they do? They can focus on enforcement and identification of issues.\u003c/p\u003e\u003cp\u003eWhat we’re tending to see is in the states where the NFL stuff happened, Colorado, Michigan, Tennessee, and where the college stuff’s happening, Iowa. Those states that have had legal sports betting more than two years. We’re going to see that continue once these states get through the initial two-year licensure regulatory (process). \u003c/p\u003e\u003cp\u003eThey’re going to have time to focus on enforcement and using the technological tools available, the U.S. Integrity dashboard and the GeoComply dashboard, which geolocates everyone. When you combine both, they are really strong tools in being able to identify abnormal or suspicious betting patterns, find out who’s doing it, and then go ahead and make the appropriate punitive actions.\u003c/p\u003e\u003ch3\u003eHow did the Alabama baseball case develop in of all places, Ohio? \u003c/h3\u003e\u003cp\u003e\u003cb\u003eHolt\u003c/b\u003e: We need to tip our hat to the actual operator who was diligent enough to identify that there was something wrong with the individual patron who was attempting to place those wagers, use the physical surveillance at the facility to gather physical evidence, (and) send the alerts out to us. \u003c/p\u003e\u003cp\u003eWe were able to disseminate those alerts in real time to other sportsbook operators and identify people who were involved with the patron attempting to make similar wagers in neighboring states like Indiana. All within a couple hours We’re able to gather all this intel back and in real time. It all started with the diligence of one of the licensed sportsbook operators in Ohio.\u003c/p\u003e\u003cp\u003e(In the Alabama case) we take an alert, anonymize it, disseminated it to every other licensed sportsbook operator in North America, and within hours had responses from people in Indiana saying, ‘Hey, we also had people attempting to place pretty abnormal and suspicious bets on this game as well.’ Come to find out all of those people knew each other (and) were from the same small town. We’re able to connect the dots pretty quickly. And then the Ohio Casino Control Commission did what they did and stepped in and handled the investigation pretty thoroughly, pretty promptly.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877363% --\u003e\u003c/p\u003e\u003ch3\u003eDo more of these cases come from outside tips or from internal information? \u003c/h3\u003e\u003cp\u003e\u003cb\u003eHolt\u003c/b\u003e: It’s us about 70% of the time, and it’s the operators about 30% of the time. In the Alabama case, it was the operator who initially identified the abnormal activity and was able to acquire physical evidence through surveillance.\u003c/p\u003e\u003ch3\u003eHow were the circumstances similar and different in Iowa?\u003c/h3\u003e\u003cp\u003e\u003cb\u003eHolt\u003c/b\u003e: That used a lot of geolocation. The Department of Criminal Investigations in Iowa (which began sports betting in 2019) noticed that there were logins happening from the stadiums, from the facilities, that just shouldn’t be happening. \u003c/p\u003e\u003cp\u003eAnytime you log into a regulated sports betting app, it’s no different than logging into Uber. You’re geolocated to a three-foot radius. They know exactly where you are. First, you’re seeing logins from players, especially collegiate players who aren’t supposed to be betting at all. \u003c/p\u003e\u003cp\u003eThey’re coming from an area where there are no fans, no security, no vendors. It’s just the team and coaches practicing. Right away you can start looking into something. Let’s make sure they’re all 21. The other thing that gets a lot of people in trouble is they think they’re being sneaky by having their girlfriend or their mom sign up for the account. \u003cb\u003eBut when it geolocates you to the men’s locker room and it comes up as ‘Mary Smith’ making the bets, well, ‘Mary Smith’ isn’t in the men’s locker room, and now it goes to fraudulently filling out accounts.\u003c/b\u003e\u003c/p\u003e\u003ch3\u003eU.S. Integrity has spoken to college athletes in the SEC, Pac 12, Big 12, among others, this year. What is your message?\u003c/h3\u003e\u003cp\u003e\u003cb\u003eHolt\u003c/b\u003e: Number one, don’t bet using regulated sports betting accounts. You will get caught. If you think that you’re going to not get caught because you’re using your friend’s, or your sister’s, or your girlfriend’s account, you will get caught. Number two, if you’re just trying to check the odds, don’t do it by using regulated sports betting sites. You are instantly geolocated when you log in. The message I always try to say is: ‘You will get caught.’ Do a risk analysis here. Is betting $20 worth your whole collegiate and potentially professional career? No, of course it’s not worth that. It’s hard at the time to realize that.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257943453% --\u003e\u003c/p\u003e\u003ch3\u003eHow does this extend to ‘inside information’?\u003c/h3\u003e\u003cp\u003e\u003cb\u003eHolt\u003c/b\u003e: We try to talk to them about when people are approaching you for information through different mechanisms, they’re not doing it out of the kindness of their heart or curiosity. They’re probably doing it to try to get inside information. Most of these kids would never approach the coaches with ‘Hey, I saw these guys gambling in the locker room or logged into betting apps.’ \u003c/p\u003e\u003cp\u003e It affects them all. Once investigators start digging into the program, they’re going to dig into everyone. We want to make sure they are aware of safe, anonymous places where they can report this type of activity. We’re not even going to ask for their name. Just provide whatever information you can, because at the end of the day, if you see it, if your teammates are logging in and betting on these apps, they’re putting everyone at risk on the team.\u003c/p\u003e\u003ch3\u003eHow does this vary by state?\u003c/h3\u003e\u003cp\u003e\u003cb\u003eHolt\u003c/b\u003e: We try to make sure athletes learn the laws or regulations in their state. In some states, it’s actually a felony to place wagers on your own events. You’re not just putting your collegiate career at risk. You can go to jail. What are the laws in your state? What is going to happen when you get caught? Nowadays, if you do this, you’re probably going to get caught. \u003c/p\u003e\u003cp\u003eTechnology is so good, and these phones are all basically tracking devices that when you do this type of activity via your mobile device, the likelihood of someone catching you is very high. Now it’s just a matter of do they want to continue to investigate, prosecute, et cetera, but actually catching the people, is really easy using technology nowadays, if they’re participating in that activity via mobile device.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877383% --\u003e\u003c/p\u003e\u003ch3\u003eHow detailed is the technology?\u003c/h3\u003e\u003cp\u003e\u003cb\u003eHolt\u003c/b\u003e: Geolocation is the one that we’re seeing recently when we talk about players at the NFL and Iowa and Iowa State.\u003c/p\u003e\u003cp\u003eWhen someone signs up for a betting account, they give everything their first name, last name, date of birth, social phone number, address, driver’s license. They have to tie it to a bank account or credit card or Venmo or PayPal. There are now all these different ways to track them.\u003c/p\u003e\u003ch3\u003eIs there is difference in the severity of these cases?\u003c/h3\u003e\u003cp\u003e\u003cb\u003eHolt\u003c/b\u003e: “The severity of these things ranges dramatically. In the media they all just get lumped in as ‘sports betting violations.’”\u003c/p\u003e\u003cp\u003e“There’s a huge difference between the basketball player who bets $20 on Monday night football when he really shouldn’t be betting at all or from a team facility, and the coach who’s trying to manipulate the outcome of a game, or a fighter who’s scripting and predetermining the outcome of a fight, and then trying to profit off that and commit fraudulent activity through regulated betting markets. Those things are really serious. We have to get rid of them. That’s where we really have to clean it up.”\u003c/p\u003e\u003ch3\u003eWhat sort of reaction do you get from the college athletes when you talk to them? \u003c/h3\u003e\u003cp\u003e\u003cb\u003eHolt\u003c/b\u003e: They don’t realize the extent to which they’re being tracked through their mobile devices. They think that their phone is some little black box in which nobody’s allowed. These regulated apps are tracking you within three feet, in addition to your banking and personal information. That’s the first ‘eyes wide open.’ \u003c/p\u003e\u003cp\u003eThe second ‘eyes wide open’ is that gambling is against the law in a lot of these states. It’s hard for people in the industry to keep up with what the laws are in each jurisdiction, never mind student athletes. Using real case studies and athletes they know, like Calvin Ridley. Athletes they may idolize, who they may want to be. Those recent and relevant examples of this is what can happen to you. That also gets their attention.\u003c/p\u003e\u003cp\u003eWe have to keep it relevant. We have to keep it fresh. We have to use real case studies and make sure the information is relevant to them.\u003c/p\u003e\u003ch3\u003e Is any of this going to make a difference?\u003c/h3\u003e\u003cp\u003e\u003cb\u003eHolt\u003c/b\u003e: The educational efforts from all of the collegiate and professional leagues that we’ve seen over the last six to 12 months are going to stop a lot of what we would call the petty violations. The guy betting $20 on a different sport at a place where he is not supposed to do it. Maybe he really didn’t know the rules or wasn’t really aware or didn’t know the ramifications. And now through education, they will, and we’re going to see people not being as a brazen about it or just I think we’ll see people being a lot more conscientious about that type of activity, at least.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877378% --\u003e\u003c/p\u003e\u003ch3\u003eResponsible Gambling\u003cbr/\u003e\u003cbr/\u003e\u003c/h3\u003e\u003cp\u003e\u003ci\u003e Always gamble responsibly. All licensed and legal operators in the United States have resources available to bettors, including educational guides on how to spot problem gaming, links to support services and tools to self-exclude for a set period of time. Support is available at the \u003c/i\u003e\u003ci\u003eNational Council on Problem Gaming\u003c/i\u003e\u003ci\u003e, \u003c/i\u003e\u003ci\u003e1-800-GAMBLER\u003c/i\u003e\u003ci\u003e and \u003c/i\u003e\u003ci\u003eAmerican Addiction Centers.\u003c/i\u003e\u003ci\u003e Be sure to only wager on gambling sites that are licensed and regulated by the gaming regulatory body in your state. That ensures games are fair, bets are honored, customers’ funds are secure and that there are legal protections for the consumer.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003e Sports betting and gambling are not legal in all locations. Be sure to comply with laws applicable where you reside.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:277445088% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278261858",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Bill Speros\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:Gamblingmc@gdcgroup.com\"\u003eGamblingmc@gdcgroup.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eBookies.com\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "From Our Partners",
+      "lead_media": {
+        "id": "278260823",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/l5yxy3/picture278260823",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "USATSI_20631876.jpg",
+        "publication": "mcclatchy-partners",
+        "layout_option": "",
+        "home": "/web/v1/sections/87287",
+        "modified_date": 1692105731,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692105731,
+        "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/l5yxy3/picture278260823/alternates/FREE_1140/USATSI_20631876.jpg",
+        "href": "/web/v1/content/278260823",
+        "additional_sections": [
+          "87287"
+        ],
+        "credit": "Tuscaloosa News / USA TODAY NETWORK",
+        "dateline": "",
+        "caption": "Alabama head coach Brad Bohannon sits on the bench before the game at Sewell-Thomas Stadium Sunday, April 3, 2022.",
+        "photographer": "Gary Cosby Jr.",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "mcclatchypartners",
+      "allow_comments": false,
+      "disable_amp": true,
+      "topic_tags": []
+    },
+    {
+      "id": "278155162",
+      "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/article278155162.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "UFC Vegas 78 Best Bets: Picks, Odds, and Predictions",
+      "publication": "mcclatchy-partners",
+      "layout_option": "none",
+      "home": "/web/v1/sections/87287",
+      "home_section": {
+        "name": "Betting",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/"
+      },
+      "modified_date": 1691863200,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "UFC Vegas 78 Best Bets: Picks, Odds, and Predictions",
+      "originating_url": "https://www.rotowire.com/mma/article/ufc-vegas-78-best-bets-picks-odds-and-predictions-73877",
+      "published_date": 1691863200,
+      "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/nl9iay/picture278155012/alternates/FREE_1140/USATSI_19560441.jpg",
+      "authors": [
+        {
+          "name": "Cole Shelton",
+          "email": "Gamblingmc@gdcgroup.com"
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "87287",
+        "88698"
+      ],
+      "credit": "Rotowire.com",
+      "dateline": "",
+      "summary": "",
+      "content": "\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e\u003cp\u003eThe UFC returns to the Apex in Las Vegas, Nevada on Saturday for UFC Vegas 78. The main event sees 10th-ranked welterweight Vicente Luque take on former UFC lightweight champion Rafael dos Anjos.\u003c/p\u003e\u003cp\u003eBelow, we’ll share my favorite play, an underdog, a prop and a two-fighter parlay. All odds are via the DraftKings Sportsbook and are accurate as of the post date of this article. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877378% --\u003e\u003c/p\u003e\u003ch3\u003eUFC Vegas 78 Best Bets\u003c/h3\u003e\u003cp\u003eHere is a recap of this weekend’s UFC Vegas 78 best bets:\u003c/p\u003e\u003cul\u003e\u003cli\u003eLuana Santos (-162)\u003c/li\u003e\u003cli\u003eA.J. Dobson (+120)\u003c/li\u003e\u003cli\u003eVicente Luque-Rafael dos Anjos goes the distance (+120)\u003c/li\u003e\u003cli\u003eMartin Buday \u0026 Marcus McGhee parlay (-116)\u003c/li\u003e\u003c/ul\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch3\u003eWeight Class: Women’s Flyweight\u003c/h3\u003e\u003cp\u003e\u003cb\u003eLuana Santos\u003c/b\u003e\u003cb\u003e (5-1) vs. \u003c/b\u003e\u003cb\u003eJuliana Miller\u003c/b\u003e\u003cb\u003e (3-2)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eLuana Santos makes her UFC debut against Julianna Miller, who won TUF, and I like Santos quite a bit in this spot.\u003c/p\u003e\u003cp\u003eIn her first fight after winning TUF, Miller took on Veronica Hardy and was dominant over all three rounds, as Hardy was able to take her down at will and control her, as she went 4-for-4 on takedowns.\u003c/p\u003e\u003cp\u003eSantos, meanwhile, is a solid grappler, and I expect the Brazilian to follow Hardy’s game plan and take Miller down at will, eventually winning a clear-cut decision.\u003c/p\u003e\u003cp\u003e\u003cb\u003eUFC Vegas 78 Best Bet: \u003c/b\u003e\u003cb\u003eLuana Santos\u003c/b\u003e\u003cb\u003e (-162)\u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877363% --\u003e\u003c/p\u003e\u003ch3\u003eWeight Class: Middleweight\u003c/h3\u003e\u003cp\u003e\u003cb\u003eA.J. Dobson\u003c/b\u003e\u003cb\u003e (6-2) vs. \u003c/b\u003e\u003cb\u003eTafon Nchukwi\u003c/b\u003e\u003cb\u003e (6-3)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eA.J. Dobson and Tafon Nchukwi are both fighting their job here, and to me, this is a pick’em fight. To get plus-money on Dobson ultimately makes it a play.\u003c/p\u003e\u003cp\u003eNchukwi is returning to middleweight after losing to Jun Yong Park in May of 2021. Since then, he moved up to light heavyweight and went 1-2, suffering back-to-back losses to Azamat Murzakanov and Carlos Ulberg (both by knockout).\u003c/p\u003e\u003cp\u003eAlthough Dobson is 0-2 in the UFC, he did have two tough opponents in Armen Petrosyan and Jacob Malkoun. Both Dobson and Nchukwi are there to be hit, and we worry about Nchuwki’s cardio and chin now that he is cutting even more weight.\u003c/p\u003e\u003cp\u003eDobson isn’t much of a heavy hitter, but we do think he can out-wrestle Nchuwki and hold him down to win a decision.\u003c/p\u003e\u003cp\u003e\u003cb\u003eUFC Vegas 78 Best Bet: \u003c/b\u003e\u003ca href=\"https://www.rotowire.com/mma/player/aj-dobson-2231\"\u003e\u003cb\u003eA.J. Dobson\u003c/b\u003e\u003c/a\u003e\u003cb\u003e (+120)\u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877378% --\u003e\u003c/p\u003e\u003ch3\u003eWeight Class: Welterweight\u003c/h3\u003e\u003cp\u003e\u003cb\u003eVicente Luque\u003c/b\u003e\u003cb\u003e (21-9-1) vs. \u003c/b\u003e\u003cb\u003eRafael dos Anjos\u003c/b\u003e\u003cb\u003e (32-14)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eThe main event of UFC Nashville is a banger, as Vicente Luque takes on Rafael dos Anjos. We’re going against the grain in this one and taking the fight to go the distance at plus money.\u003c/p\u003e\u003cp\u003eOutside of Luque being finished last time out by Geoff Neal, he has been extremely durable -- the only other time he was finished was in 2013 on the regional scene. Dos Anjos, meanwhile, can also take a punch, as he was finished in the fifth round at 155lbs against Rafael Fiziev, but before that, hadn’t been finished since 2016 -- not bad considering he had fought the likes of Kamaru Usman, Colby Covington, Leon Edwards and Paul Felder.\u003c/p\u003e\u003cp\u003eAfter Luque took a full year off, we expect him to be more patient while dos Anjos will try and wrestle him and control him on the ground. Ultimately, we’re banking that the year off has helped Luque’s chin, and RDA is already super durable, so expect this one to hit the scorecards.\u003c/p\u003e\u003cp\u003e\u003cb\u003eUFC Vegas 78 Best Bet: \u003c/b\u003e\u003cb\u003eVicente Luque\u003c/b\u003e\u003cb\u003e-\u003c/b\u003e\u003cb\u003eRafael dos Anjos\u003c/b\u003e\u003cb\u003e goes the distance (+120)\u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:266042956% --\u003e\u003c/p\u003e\u003ch3\u003eWeight Class: Heavyweight and Bantamweight\u003c/h3\u003e\u003cp\u003e\u003cb\u003eMartin Buday\u003c/b\u003e\u003cb\u003e (12-1) vs. \u003c/b\u003e\u003cb\u003eJosh Parisian\u003c/b\u003e\u003cb\u003e (15-6)\u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003cb\u003eMarcus McGhee\u003c/b\u003e\u003cb\u003e (7-1) vs. \u003c/b\u003e\u003cb\u003eJP Buys\u003c/b\u003e\u003cb\u003e (9-5)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eFor the parlay, we’re taking Martin Buday and Marcus McGhee to get their hands raised Saturday night.\u003c/p\u003e\u003cp\u003eBuday is taking on Josh Parisian, and this is a great matchup for Buday to improve to 4-0 in the UFC. Inside the Octagon, Buday has proven he has the cardio to go three rounds, and against Parisian, he should be able to wear on him in the clinch to get a decision. Buday has 100% takedown defense, so should be able to keep it standing. On the feet, he is the better striker, and his clinch game will lead to him tiring out Parisian and getting the decision.\u003c/p\u003e\u003cp\u003eThe other leg is Marcus McGhee taking on JP Buys, who’s 0-3 in the UFC and has been knocked down eight times in three fights. Safe to say we have worries about his chin. McGhee, meanwhile, is a solid striker and also has great takedown defense. That will be key against Buys, who will look to grapple.\u003c/p\u003e\u003cp\u003eOn the feet, we expect McGhee to be too much for Buys and eventually drop him. From there, he’ll either finish him off with a submission or ground-and-pound TKO.\u003c/p\u003e\u003cp\u003e\u003cb\u003eUFC Vegas 78 Best Bet: \u003c/b\u003e\u003cb\u003eMartin Buday\u003c/b\u003e\u003cb\u003e \u0026 \u003c/b\u003e\u003cb\u003eMarcus McGhee\u003c/b\u003e\u003cb\u003e parlay (-116\u003c/b\u003e\u003cb\u003e)\u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877383% --\u003e\u003c/p\u003e\u003ch3\u003eResponsible Gambling\u003cbr/\u003e\u003cbr/\u003e\u003c/h3\u003e\u003cp\u003e\u003ci\u003e Always gamble responsibly. All licensed and legal operators in the United States have resources available to bettors, including educational guides on how to spot problem gaming, links to support services and tools to self-exclude for a set period of time. Support is available at the \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://www.ncpgambling.org/\"\u003e\u003ci\u003eNational Council on Problem Gaming\u003c/i\u003e\u003c/a\u003e\u003ci\u003e, \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://www.1800gambler.net/\"\u003e\u003ci\u003e1-800-GAMBLER\u003c/i\u003e\u003c/a\u003e\u003ci\u003e and \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://americanaddictioncenters.org/\"\u003e\u003ci\u003eAmerican Addiction Centers.\u003c/i\u003e\u003c/a\u003e\u003ci\u003e Be sure to only wager on gambling sites that are licensed and regulated by the gaming regulatory body in your state. That ensures games are fair, bets are honored, customers’ funds are secure and that there are legal protections for the consumer.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003e Sports betting and gambling are not legal in all locations. Be sure to comply with laws applicable where you reside.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278155162",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Cole Shelton\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:Gamblingmc@gdcgroup.com\"\u003eGamblingmc@gdcgroup.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eRotowire.com\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "From Our Partners",
+      "lead_media": {
+        "id": "278155012",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/nl9iay/picture278155012",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "USATSI_19560441.jpg",
+        "publication": "mcclatchy-partners",
+        "layout_option": "",
+        "home": "/web/v1/sections/87287",
+        "modified_date": 1691721524,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1691721524,
+        "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/nl9iay/picture278155012/alternates/FREE_1140/USATSI_19560441.jpg",
+        "href": "/web/v1/content/278155012",
+        "additional_sections": [
+          "87287"
+        ],
+        "credit": "USA TODAY Sports",
+        "dateline": "",
+        "caption": "Rafael Dos Anjos (blue gloves)  reacts after fighting Bryan Barberena during UFC Fight Night at Amway Center in Orlandon Dec. 3, 2022.",
+        "photographer": "Nathan Ray Seebeck",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "mcclatchypartners",
+      "allow_comments": false,
+      "disable_amp": true,
+      "topic_tags": []
+    },
+    {
+      "id": "278117397",
+      "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/article278117397.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "NASCAR at the Brickyard Odds, Expert Picks \u0026 Best Bets For Verizon 200",
+      "publication": "mcclatchy-partners",
+      "layout_option": "none",
+      "home": "/web/v1/sections/87287",
+      "home_section": {
+        "name": "Betting",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/"
+      },
+      "modified_date": 1691794800,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "NASCAR at the Brickyard Odds, Expert Picks \u0026 Best Bets For Verizon 200",
+      "originating_url": "https://bookies.com/picks/nascar-at-the-brickyard-odds-expert-picks-best-bets-for-verizon-200",
+      "meta_description": "The odds for Sunday’s race at the Brickyard: Chase Elliott opened at +750, third on the board behind +400 Martin Truex Jr. and defending champ Tyler Reddick.",
+      "published_date": 1691794800,
+      "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/c44bjq/picture278116957/alternates/FREE_1140/USATSI_21155930.jpg",
+      "authors": [
+        {
+          "name": "David Caraviello",
+          "email": "Gamblingmc@gdcgroup.com"
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "87287",
+        "88698"
+      ],
+      "credit": "Bookies.com",
+      "dateline": "",
+      "summary": "The odds for Sunday’s race at the Brickyard: Chase Elliott opened at +750, third on the board behind +400 Martin Truex Jr. and defending champ Tyler Reddick.",
+      "content": "\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003cp\u003eThe bad news for Chase Elliott is that he has just three races remaining to score the victory he desperately needs to qualify for the NASCAR playoffs. \u003c/p\u003e\u003cp\u003eThe good news is that two of those events are on road courses, where Elliott is at his best. But either way, these are nervous times for bettors who took the Hendrick driver as a +500 championship futures wager in the preseason.\u003c/p\u003e\u003cp\u003eElliott missed six races after breaking his leg in a snowboarding accident in February, making it difficult if not impossible for him to make the playoffs based on points. A race win would get him in automatically—and toward that end, the seven-time road race winner is certainly circling Sunday’s event on the Indianapolis Motor Speedway road course.\u003c/p\u003e\u003cp\u003eOf course, Elliott has looked anything like a contender the past five weeks, over which his average finish is 16.8. And while he was third (at Chicago) and fifth (at Sonoma) in his past two starts on street or road circuits, he hasn’t won a NASCAR road race in over a calendar year. \u003c/p\u003e\u003cp\u003eThe NASCAR Odds for Sunday’s Verizon 200 at the Brickyard told the story: Elliott opened at +750 to win on the betting apps , third on the board behind +400 favorite Martin Truex Jr. and defending race winner Tyler Reddick.\u003c/p\u003e\u003ch2\u003eVerizon 200 At The Brickyard Odds\u003c/h2\u003e\u003ctable\u003e\u003ctbody\u003e\u003ctr\u003e\u003ctd\u003e\u003cb\u003eDriver\u003c/b\u003e\u003c/td\u003e\u003ctd\u003e\u003cb\u003eWin\u003c/b\u003e\u003c/td\u003e\u003ctd\u003e\u003cb\u003eTop 3\u003c/b\u003e\u003c/td\u003e\u003ctd\u003e\u003cb\u003eTop 5\u003c/b\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eMartin Truex, Jr.\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+400\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+110\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e-175\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eTyler Reddick\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+550\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e+150\u003c/td\u003e\u003ctd\u003e\u003cp\u003e-135\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eChase Elliot\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+750\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e+210\u003c/td\u003e\u003ctd\u003e\u003cp\u003e-105\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eShane Van Gisbergen\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+1000\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e+275\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+125\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eKyle Busch\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+1000\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e+275\u003c/td\u003e\u003ctd\u003e+125\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eKyle Larson\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+1100\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e+300\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+150\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eChristopher Bell\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e+1100\u003c/td\u003e\u003ctd\u003e+300\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+150\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eAJ Allmendinger\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e+1600\u003c/td\u003e\u003ctd\u003e+450\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+200\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003c/tbody\u003e\u003c/table\u003e\u003cp\u003e\u003ci\u003eOdds via DraftKings and current as of publication.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877378% --\u003e\u003c/p\u003e\u003ch2\u003e\u003cspan\u003eVerizon 200 At The Brickyard \u003c/span\u003eBetting Tips\u003c/h2\u003e\u003cp\u003eOne week after pulling the biggest upset of the NASCAR season as a +6000 winner at Richmond, Chris Buescher used some late pit strategy to a earn a +5000 longshot victory in Monday’s rain-delayed race at Michigan. \u003c/p\u003e\u003cp\u003eCan Buescher make it three straight as a +6500 bet to win Sunday on the Indy road course? He’s a capable road racer, with a career average finish of 14.4, which included a top-five at Sonoma earlier this season and a 10th at the Brickyard last year.\u003c/p\u003e\u003cp\u003eAnd then there’s our man Truex, whose runner-up performance at Michigan continued a red-hot summer that’s seen him notch top-10s in four straight and 10 of his last 13 starts.\u003c/p\u003e\u003cp\u003eChicago street race winner Shane Van Gisbergen returns to the same No. 91 Trackhouse car at Indy, where he’ll be joined by fellow Supercars driver Brodie Kostecki, who’ll drive a Richard Childress Racing entry. And 24 Hours of LeMans champion Kamui Kobayashi will pilot a third car for 23IX Racing.\u003c/p\u003e\u003cp\u003eReddick and A.J. Allmendinger won the first two editions of the Indy race after it was switched from the oval to the road course, where Allmendinger (4.0), Austin Cindric (5.5) and Bubba Wallace (9.0) own the best average finishes among drivers who have competed in both events. \u003c/p\u003e\u003cp\u003eOnly Allmeninger and Cindric have been top-10 in both races. As for Elliott? He placed fourth in the maiden event in 2021, and was challenging for the lead when he was swept up in multi-car crash in the final laps a year ago.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877363% --\u003e\u003c/p\u003e\u003ch2\u003e\u003cspan\u003eVerizon 200 At The Brickyard \u003c/span\u003eBest Bets\u003c/h2\u003e\u003ch3\u003eKyle Busch to Win\u003c/h3\u003e\u003cp\u003e\u003cb\u003eOdds: \u003c/b\u003e+1000 at DraftKings\u003c/p\u003e\u003cp\u003eYes, he’s finished deep in the field in three of his last four starts, crashing in two of them, and his best finish on the Indianapolis road course is 11th. \u003c/p\u003e\u003cp\u003eBut Busch is a great road racer who’s been exceptional on road layouts this season—fifth at Chicago (even after impaling his car in a tire barrier early on), second at Sonoma, and second at Circuit of the Americas. \u003c/p\u003e\u003cp\u003eBusch is well overdue for his first victory in a road race since Sonoma in 2015, and his performance on road courses this season should translate to Indianapolis.\u003c/p\u003e\u003ch3\u003eMartin Truex Jr. Top 3\u003cbr/\u003e\u003cbr/\u003e\u003c/h3\u003e\u003cp\u003e\u003cb\u003eOdds: \u003c/b\u003e+110 at DraftKings\u003c/p\u003e\u003cp\u003eTruex had the fastest car at Michigan, but Buescher had the clean air out front, and that ultimately made the difference Monday. Still, the runner-up result marked another profitable finish for the championship favorite, who’s in our betting profile every week now. \u003c/p\u003e\u003cp\u003eBookmakers are catching on, and Truex’s odds don’t offer the value they did a few weeks ago. But he remains a solid choice for NASCAR picks at Indy, especially after winning the road race at Sonoma in June..\u003c/p\u003e\u003ch3\u003eAustin Cindric Top 5\u003c/h3\u003e\u003cp\u003e\u003cb\u003eOdds: \u003c/b\u003e+350 at DraftKings\u003c/p\u003e\u003cp\u003eCindric may be a middle-of-the-pack runner most weeks, but he’s at his best on road courses, as he showed in last year’s runner-up finish at Indianapolis. Also, he was ninth in the inaugural NASCAR event on the grand prix layout in 2021. \u003c/p\u003e\u003cp\u003eHe’s shown flashes this season, too, placing sixth at both the Chicago street course and COTA. Cindric may be a Daytona 500 champ, but Indy—which the son of the Penske team president has been around since he was a kid—is his best track.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877383% --\u003e\u003c/p\u003e\u003ch2\u003e\u003cspan\u003eVerizon 200 At The Brickyard \u003c/span\u003eTime, Date and TV\u003c/h2\u003e\u003cp\u003e\u003cb\u003eWhen:\u003c/b\u003e Sunday, 2:30 p.m. EDT\u003c/p\u003e\u003cp\u003e\u003cb\u003eWhere: \u003c/b\u003eIndianapolis (Ind.) Motor Speedway\u003c/p\u003e\u003cp\u003e\u003cb\u003eTV:\u003c/b\u003e NBC\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch2\u003eResponsible Gambling\u003cbr/\u003e\u003cbr/\u003e\u003c/h2\u003e\u003cp\u003e\u003ci\u003e Always gamble responsibly. All licensed and legal operators in the United States have resources available to bettors, including educational guides on how to spot problem gaming, links to support services and tools to self-exclude for a set period of time. Support is available at the \u003c/i\u003e\u003ci\u003eNational Council on Problem Gaming\u003c/i\u003e\u003ci\u003e, \u003c/i\u003e\u003ci\u003e1-800-GAMBLER\u003c/i\u003e\u003ci\u003e and \u003c/i\u003e\u003ci\u003eAmerican Addiction Centers.\u003c/i\u003e\u003ci\u003e Be sure to only wager on gambling sites that are licensed and regulated by the gaming regulatory body in your state. That ensures games are fair, bets are honored, customers’ funds are secure and that there are legal protections for the consumer.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003e Sports betting and gambling are not legal in all locations. Be sure to comply with laws applicable where you reside.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:277444713% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278117397",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy David Caraviello\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:Gamblingmc@gdcgroup.com\"\u003eGamblingmc@gdcgroup.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eBookies.com\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "From Our Partners",
+      "lead_media": {
+        "id": "278116957",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/c44bjq/picture278116957",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "USATSI_21155930.jpg",
+        "publication": "mcclatchy-partners",
+        "layout_option": "",
+        "home": "/web/v1/sections/87287",
+        "modified_date": 1691627330,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1691627330,
+        "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/c44bjq/picture278116957/alternates/FREE_1140/USATSI_21155930.jpg",
+        "href": "/web/v1/content/278116957",
+        "additional_sections": [
+          "87287"
+        ],
+        "credit": "USA TODAY Sports",
+        "dateline": "",
+        "caption": "Cup Series driver Chase Elliott (9) during the FireKeepers Casino 400 at Michigan International Speedway on Aug. 6.",
+        "photographer": "Mike Dinovo",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "mcclatchypartners",
+      "allow_comments": false,
+      "disable_amp": true,
+      "topic_tags": []
+    },
+    {
+      "id": "264850999",
+      "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/nfl/article264850999.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Best Buffalo Bills Sportsbook Promos Codes \u0026 Bonuses",
+      "publication": "mcclatchy-partners",
+      "layout_option": "none",
+      "home": "/web/v1/sections/87347",
+      "home_section": {
+        "name": "NFL",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/nfl/"
+      },
+      "modified_date": 1691005588,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Best Buffalo Bills Sportsbook Promos Codes \u0026 Bonuses",
+      "originating_url": "https://www.miamiherald.com/betting/nfl/article264850999.html",
+      "meta_description": "Buffalo Bills fans can take advantage of the best New York sportsbook promo codes and bonus codes every week of the 2023-24 NFL season. We’ve checked out all the deals to find the finest ones.",
+      "published_date": 1690500600,
+      "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/nfl/7js2ag/picture270874652/alternates/FREE_1140/USATSI_19718296%20(1).jpg",
+      "authors": [
+        {
+          "name": "KC Joyner",
+          "email": "gamblingmc@gdcgroup.com"
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "87347",
+        "88708"
+      ],
+      "credit": "Gambling.com",
+      "dateline": "",
+      "summary": "Buffalo Bills fans can take advantage of the best New York sportsbook promo codes and bonus codes every week of the 2023-24 NFL season. We’ve checked out all the deals to find the finest ones.",
+      "content": "\u003cp\u003e\u003c!-- %asset:257883633% --\u003e\u003c/p\u003e\u003cp\u003eThe Bills came into the 2022 season as the favorite in the Super Bowl 57 odds and for most of the season, they looked the part. Their Week 6 victory over the Chiefs was supposed to guarantee the AFC championship would go through Orchard Park, virtually assuring a victory in front of Bills Mafia. \u003c/p\u003e\u003cp\u003eHowever, the Bills’ season came to a grinding halt in the Divisional Round when they fell to the Bengals, 27-10, at Highmark Stadium. Josh Allen, who was never the same after injuring his elbow in a Week 9 loss to the Jets, was just 25 of 42 and had a QBR of 55.6. Buffalo also struggled to mount a pass rush without Von Miller, who was lost for the season after tearing his ACL in a Thanksgiving victory over the Lions.\u003c/p\u003e\u003cp\u003eThe good news for the Bills is that the window is far from closed and Allen and Miller will be back at full strength in 2023. The sportsbooks are still bullish on the Bills, as Buffalo opened the offseason as the second favorite in the \u003ca href=\"https://www.miamiherald.com/betting/nfl/article262118452.html\" target=\"_blank\" rel=\"Follow\"\u003eSuper Bowl 58 odds\u003c/a\u003e at FanDuel.\u003c/p\u003e\u003cp\u003eWhile the 2023-24 season is still months away, Bills fans can bet on them now in the futures markets while using the \u003ca href=\"https://www.miamiherald.com/betting/article263584558.html\"\u003ebest New York promo codes\u003c/a\u003e to unlock the best welcome offers available.\u003c/p\u003e\u003ch2\u003eBest Buffalo Bills Promo Codes \u0026 Bonuses\u003c/h2\u003e\u003ctable\u003e\u003ctbody\u003e\u003ctr\u003e\u003ctd\u003e\u003cb\u003eBuffalo Bills Sportsbook Promo Code\u003c/b\u003e\u003c/td\u003e\u003ctd\u003e\u003cb\u003eBonus\u003c/b\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eCaesars Sportsbook NY: \u003ca href=\"https://miamiherald.bookies.com/caesars/offer/15651#listid=9747\u0026listtype=ranking-type-ks\u0026listlocation=_\u0026listversion=20220907152213\u0026list_position=2\u0026ct=oplistclk\u0026ctalocation=_\u0026k_referrer=https%3A%2F%2Fwww.kansascity.com%2Fbetting%2Farticle261739482.html\u0026cta_id=41770add-410a-4f12-962e-65822826db8e\" target=\"_blank\" rel=\"Follow\"\u003eMCBETFULL\u003c/a\u003e\u003c/td\u003e\u003ctd\u003e $1,250 First Bet on Caesars\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003ePointsBet NY: (\u003ca href=\"https://miamiherald.bookies.com/pointsbet/offer/15040#listid=9745\u0026listtype=ranking-type-il\u0026listlocation=_\u0026listversion=20220908132820\u0026list_position=3\u0026ct=oplistclk\u0026ctalocation=_\u0026k_referrer=https%3A%2F%2Fwww.miamiherald.com%2Fbetting%2Fnfl%2Farticle265545826.html\u0026cta_id=b9401e71-cb2e-4b09-8fc8-8afdf5ebeeaf\" target=\"_blank\" rel=\"Follow\"\u003eclick exclusive link\u003c/a\u003e)\u003c/td\u003e\u003ctd\u003e5 Second-Chance Bets up to $50 Each\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eBetRivers NY: \u003ca href=\"https://miamiherald.bookies.com/betrivers/offer/11528#listid=9745\u0026listtype=ranking-type-il\u0026listlocation=_\u0026listversion=20220908132820\u0026list_position=6\u0026ct=oplistclk\u0026ctalocation=_\u0026k_referrer=https%3A%2F%2Fwww.miamiherald.com%2Fbetting%2Fnfl%2Farticle265545826.html\u0026cta_id=6bd5000b-ee76-4752-99df-6198d7361f34\" target=\"_blank\" rel=\"Follow\"\u003eMCCRIV\u003c/a\u003e\u003c/td\u003e\u003ctd\u003e2nd Chance First Bet up to $500 ($100 in NY)\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eDraftKings NY: (\u003ca href=\"https://miamiherald.bookies.com/draftkings/offer/11523#listid=9745\u0026listtype=ranking-type-il\u0026listlocation=_\u0026listversion=20220908132820\u0026list_position=5\u0026ct=oplistclk\u0026ctalocation=_\u0026k_referrer=https%3A%2F%2Fwww.miamiherald.com%2Fbetting%2Fnfl%2Farticle265545826.html\u0026cta_id=1282f7d9-c2b9-4f2f-bfe4-7ca50da408f8\" target=\"_blank\" rel=\"Follow\"\u003eclick exclusive link\u003c/a\u003e)\u003c/td\u003e\u003ctd\u003eBet $5, Win 150 in Bonus Bets\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eFanDuel NY:(\u003ca href=\"https://miamiherald.bookies.com/fanduel/offer/11447#listid=9745\u0026listtype=ranking-type-il\u0026listlocation=_\u0026listversion=20220908132820\u0026list_position=4\u0026ct=oplistclk\u0026ctalocation=_\u0026k_referrer=https%3A%2F%2Fwww.miamiherald.com%2Fbetting%2Fnfl%2Farticle265545826.html\u0026cta_id=e8b445fd-9a1c-429d-a88e-665677f002a5\" target=\"_blank\" rel=\"Follow\"\u003eclick exclusive link\u003c/a\u003e)\u003c/td\u003e\u003ctd\u003eNo Sweat First Bet Up to $1,000\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eBetMGM NY: \u003ca href=\"https://miamiherald.bookies.com/betmgm/offer/15438#listid=9747\u0026listtype=ranking-type-ks\u0026listlocation=_\u0026listversion=20220907152213\u0026list_position=1\u0026ct=oplistclk\u0026ctalocation=_\u0026k_referrer=https%3A%2F%2Fwww.kansascity.com%2Fbetting%2Farticle261739482.html\u0026cta_id=336dfa30-4e99-4193-ab39-bcb9aff4b446\" target=\"_blank\" rel=\"Follow\"\u003eMCBET\u003c/a\u003e\u003c/td\u003e\u003ctd\u003eFirst-Bet Offer Up to $1,000 (not available in NY)\u003c/td\u003e\u003c/tr\u003e\u003c/tbody\u003e\u003c/table\u003e\u003ch2\u003eWhat is the Buffalo Bills Caesars Sportsbook NY Promo Code offer?\u003c/h2\u003e\u003cp\u003eThe strong suits for Caesars Sportsbook New York are its unmatched level of odds boosts and the award-winning Caesars Rewards program.\u003c/p\u003e\u003cp\u003eBettors who want to partake of these wagering elements can sign up for a \u003ca href=\"https://www.miamiherald.com/betting/article259669235.html\" target=\"_blank\" rel=\"Follow\"\u003eCaesars Sportsbook NY promo code\u003c/a\u003e MCBETFULL that gives new customers first-bet insurance up to $1,250 plus 1,000 tier credits and 1,000 rewards credits in the Caesars Rewards program.\u003c/p\u003e\u003cp\u003eThat means, you can make a bet of up to $1,250 on the Bills and if it loses, you will get an equal amount back as a bonus bet, allowing you a second chance to win on another wager.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257924923% --\u003e\u003c/p\u003e\u003ch2\u003eWhat if the Buffalo Bills DraftKings NY Promo Code offer?\u003c/h2\u003e\u003cp\u003eThe current DraftKings offer gives new customers $150 in bonus bets if they make a  $5 moneyline wager. The bonus will be paid as six $25 bonus bets, which must be used within seven days and have a 1x playthrough.\u003c/p\u003e\u003cp\u003eThis offer trumps the previous \u003ca href=\"https://www.miamiherald.com/betting/article260807422.html\" target=\"_blank\" rel=\"Follow\"\u003eDraftKings NY promo code\u003c/a\u003e deal of a deposit match of 20% up to a total of $1,000. That offer had a 25x playthrough, which is why the operator has shifted its attention to the “Bet \u0026 Get” style promotions in recent months.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:258391298% --\u003e\u003c/p\u003e\u003ch2\u003eWhat is the Buffalo Bills BetRivers NY Promo Code offer?\u003c/h2\u003e\u003cp\u003eThe \u003ca href=\"https://www.miamiherald.com/betting/article260681852.html\" target=\"_blank\" rel=\"Follow\"\u003eBetRivers NY promo code\u003c/a\u003e provides a 2nd Chance Bet up to $100 for new users. Should your first bet lose, you will be refunded, up to $100, within 24 hours. The bonus bet credit has a low 1X wagering requirement and you have 30 days to use it.\u003c/p\u003e\u003cp\u003eThis is great news for casual bettors who want to join in the action. You can explore the many Buffalo Bills betting markets available on the site for every single game.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:258391368% --\u003e\u003c/p\u003e\u003ch2\u003eWhat is the Buffalo Bills PointsBet NY Promo Code offer?\u003c/h2\u003e\u003cp\u003ePointsBet NY is offering new bettors a total of $250 in second-chance bets when signing up. The offer is essentially a five-part deal: up to a $50 second-chance bet for each of your first five days on the site.\u003c/p\u003e\u003cp\u003eOnly your first bet of the day counts into this promotion. If it wins, you will not get a second-chance bet even if your next bet loses that day. Also, these are for straight betting, not the enhanced PointsBetting that the operator has innovated that allows you to increase potential payouts (or losses) by how right (or wrong) you are about a wager.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:263975451% --\u003e\u003c/p\u003e\u003ch2\u003eWhat is the Buffalo Bills FanDuel NY Promo Code offer?\u003c/h2\u003e\u003cp\u003eFanDuel New York offers what might be the widest array of sports betting markets and wager types in the industry. The current \u003ca href=\"https://www.miamiherald.com/betting/article257659208.html\" target=\"_blank\" rel=\"Follow\"\u003eFanDuel promo code\u003c/a\u003e offers new customers a $1,000 insurance policy on their first bet, as the \u003ca href=\"https://www.miamiherald.com/betting/article260137030.html\" target=\"_blank\" rel=\"Follow\"\u003eFanDuel NY promo code\u003c/a\u003e will land first-time users a No Sweat First Bet of up to $1,000. That means you can bet on any market knowing that if you lose, you will be refunded the amount of your first bet in site credit.\u003c/p\u003e\u003cp\u003eThe credit will arrive within 72 hours of your bet settling, and you have 15 days to use the credit. There are no odds restrictions, and you just have to bet the credit once before being able to cash out the winnings. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:258391323% --\u003e\u003c/p\u003e\u003ch2\u003eWhat is the WynnBET NY promo code offer?\u003c/h2\u003e\u003cp\u003eWynnBet NY is a great change of pace, as it gives players a welcome meat-and-potatoes approach to betting that lets you make your bets quickly and get back to watching the games. This is arguably the best site for new bettors who don’t want lots of fuss, as its easy-to-use interface makes betting on the Bills simple.\u003c/p\u003e\u003cp\u003eBe on the lookout for odds boosts and promotions at WynnBET New York. The \u003ca href=\"https://www.miamiherald.com/betting/article260641137.html\" target=\"_blank\" rel=\"Follow\"\u003eWynnBET NY promo code\u003c/a\u003e \u003cb\u003eXMCCBET\u003c/b\u003e gives new users $100 in bonus bets on a $20 wager.\u003c/p\u003e\u003cp\u003e-\u003c!-- %asset:258798708% --\u003e\u003c/p\u003e\u003ch2\u003eWhat is the Buffalo Bills BetMGM NY promo code offer?\u003c/h2\u003e\u003cp\u003eBetMGM New York offer terrific ongoing promotions for new bettors and is arguably the best site for making parlay wagers, as it has a very user-friendly easy parlay system to create any type of customized parlay bet you can dream up.\u003c/p\u003e\u003cp\u003eIf you want to make these parlay wagers, just sign up for a \u003ca href=\"https://www.miamiherald.com/betting/article259877840.html\" target=\"_blank\" rel=\"Follow\"\u003eBetMGM NY bonus code\u003c/a\u003e \u003cb\u003eMCBET\u003c/b\u003e. You will see a terrific array Bills betting markets, odds boosts and opportunities to score bonus bets. While not currently available in NY, bettors in most other states where BetMGM is live can collect a first-bet offer of up to $1,000 when signing up. Use our link to visit BetMGM and be on the lookout for an enhanced NY offer soon.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257924913% --\u003e\u003c/p\u003e\u003ch2\u003eResponsible Gambling\u003c/h2\u003e\u003cp\u003e\u003ci\u003eAlways gamble responsibly. All licensed and legal operators in the United States have resources available to bettors, including educational guides on how to spot problem gaming, links to support services and tools to self-exclude for a set period of time. Support is available at the \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://www.ncpgambling.org/\"\u003e\u003ci\u003eNational Council on Problem Gaming\u003c/i\u003e\u003c/a\u003e\u003ci\u003e, \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://www.1800gambler.net/\"\u003e\u003ci\u003e1-800-GAMBLER\u003c/i\u003e\u003c/a\u003e\u003ci\u003e and \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://americanaddictioncenters.org/\"\u003e\u003ci\u003eAmerican Addiction Centers.\u003c/i\u003e\u003c/a\u003e\u003ci\u003e Be sure to only wager on gambling sites that are licensed and regulated by the gaming regulatory body in your state. That ensures games are fair, bets are honored, customers\u0026rsquor; funds are secure and that there are legal protections for the consumer.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eSports betting and gambling are not legal in all locations. Be sure to comply with laws applicable where you reside.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257883633% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/264850999",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy KC Joyner\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:gamblingmc@gdcgroup.com\"\u003egamblingmc@gdcgroup.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eGambling.com\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "From Our Partners",
+      "lead_media": {
+        "id": "270874652",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/nfl/7js2ag/picture270874652",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "USATSI_19718296 (1).jpg",
+        "publication": "mcclatchy-partners",
+        "layout_option": "",
+        "home": "/web/v1/sections/87347",
+        "modified_date": 1673049622,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1673049599,
+        "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/nfl/7js2ag/picture270874652/alternates/FREE_1140/USATSI_19718296%20(1).jpg",
+        "href": "/web/v1/content/270874652",
+        "additional_sections": [
+          "87347"
+        ],
+        "credit": "USA TODAY Sports",
+        "dateline": "",
+        "caption": "Buffalo Bills quarterback Josh Allen calls signals against the Chicago Bears last month at Soldier Field.",
+        "photographer": "Jamie Sabau",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "mcclatchypartners",
+      "allow_comments": false,
+      "disable_amp": true,
+      "topic_tags": []
+    },
+    {
+      "id": "265150826",
+      "url": "https://www.mcclatchy-partners.com/gdc-group/sacramento/betting/nfl/article265150826.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Best New York Jets Sportsbook Promos Codes, Top Bonuses \u0026 Boosts",
+      "publication": "mcclatchy-partners",
+      "layout_option": "none",
+      "home": "/web/v1/sections/87638",
+      "home_section": {
+        "name": "NFL",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/sacramento/betting/nfl/"
+      },
+      "modified_date": 1691005542,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Best New York Jets Sportsbook Promos Codes, Top Bonuses \u0026 Boosts",
+      "originating_url": "https://www.sacbee.com/betting/nfl/article265150826.html",
+      "meta_description": "You can use these New York Jets sportsbook promo codes to find some outstanding NFL futures offs being offered right now by the best online betting sites.",
+      "published_date": 1690459200,
+      "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/nfl/a4oepl/picture267253367/alternates/FREE_1140/USATSI_19205756%20(2)%20(1).jpg",
+      "authors": [
+        {
+          "name": "KC Joyner",
+          "email": "gamblingmc@gdcgroup.com"
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "87638",
+        "88708"
+      ],
+      "credit": "Gambling.com",
+      "dateline": "",
+      "summary": "You can use these New York Jets sportsbook promo codes to find some outstanding NFL futures offs being offered right now by the best online betting sites.",
+      "content": "\u003cp\u003e\u003c!-- %asset:257883633% --\u003e\u003c/p\u003e\u003cp\u003eThe Jets season ended in underwhelming fgashion, ass six straight losses turned a 7-4 mark into a 7-10 season. But it was not a complete loss as wide receiver Garrett Wilson was named Offensive Rookie of the Year, while cornerback Sauce Gardner won Defensive Rookie of the Year. The Jets expect to be one of the top bidders if and when the Packers put Aaron Rodgers on the trade market. \u003c/p\u003e\u003cp\u003eYou can used the \u003ca href=\"https://www.miamiherald.com/betting/article263584558.html\" target=\"_blank\" rel=\"Follow\"\u003ebest New York Sportsbook promos\u003c/a\u003e available right now to make a futures wager on the Jets while the odds are in your favor as they will change significantly if Gang Green is able to acquire the 4-time NFL MVP. \u003c/p\u003e\u003ch2\u003eBest New York Jets Promo Codes \u0026 Bonuses\u003c/h2\u003e\u003ctable\u003e\u003ctbody\u003e\u003ctr\u003e\u003ctd\u003e\u003cb\u003eNew York Jets Sportsbook Promo Code\u003c/b\u003e\u003c/td\u003e\u003ctd\u003e\u003cb\u003eBonus\u003c/b\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eCaesars Sportsbook NY: \u003ca href=\"https://miamiherald.bookies.com/caesars/offer/15651#listid=9747\u0026listtype=ranking-type-ks\u0026listlocation=_\u0026listversion=20220907152213\u0026list_position=2\u0026ct=oplistclk\u0026ctalocation=_\u0026k_referrer=https%3A%2F%2Fwww.kansascity.com%2Fbetting%2Farticle261739482.html\u0026cta_id=41770add-410a-4f12-962e-65822826db8e\" target=\"_blank\" rel=\"Follow\"\u003eMCBETFULL\u003c/a\u003e\u003c/td\u003e\u003ctd\u003e $1,250 First Bet on Caesars\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003ePointsBet NY: (\u003ca href=\"https://miamiherald.bookies.com/pointsbet/offer/15040#listid=9745\u0026listtype=ranking-type-il\u0026listlocation=_\u0026listversion=20220908132820\u0026list_position=3\u0026ct=oplistclk\u0026ctalocation=_\u0026k_referrer=https%3A%2F%2Fwww.miamiherald.com%2Fbetting%2Fnfl%2Farticle265545826.html\u0026cta_id=b9401e71-cb2e-4b09-8fc8-8afdf5ebeeaf\" target=\"_blank\" rel=\"Follow\"\u003eclick exclusive link\u003c/a\u003e)\u003c/td\u003e\u003ctd\u003e5 Second-Chance Bets up to $50 Each\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eBetRivers NY: \u003ca href=\"https://miamiherald.bookies.com/betrivers/offer/11528#listid=9745\u0026listtype=ranking-type-il\u0026listlocation=_\u0026listversion=20220908132820\u0026list_position=6\u0026ct=oplistclk\u0026ctalocation=_\u0026k_referrer=https%3A%2F%2Fwww.miamiherald.com%2Fbetting%2Fnfl%2Farticle265545826.html\u0026cta_id=6bd5000b-ee76-4752-99df-6198d7361f34\" target=\"_blank\" rel=\"Follow\"\u003eMCCRIV\u003c/a\u003e\u003c/td\u003e\u003ctd\u003e2nd Chance Bet up to $100\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eDraftKings NY: (\u003ca href=\"https://miamiherald.bookies.com/draftkings/offer/11523#listid=9745\u0026listtype=ranking-type-il\u0026listlocation=_\u0026listversion=20220908132820\u0026list_position=5\u0026ct=oplistclk\u0026ctalocation=_\u0026k_referrer=https%3A%2F%2Fwww.miamiherald.com%2Fbetting%2Fnfl%2Farticle265545826.html\u0026cta_id=1282f7d9-c2b9-4f2f-bfe4-7ca50da408f8\" target=\"_blank\" rel=\"Follow\"\u003eclick exclusive link\u003c/a\u003e)\u003c/td\u003e\u003ctd\u003eBet $5, Get $150 In Bonus Bets\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eFanDuel NY:(\u003ca href=\"https://miamiherald.bookies.com/fanduel/offer/11447#listid=9745\u0026listtype=ranking-type-il\u0026listlocation=_\u0026listversion=20220908132820\u0026list_position=4\u0026ct=oplistclk\u0026ctalocation=_\u0026k_referrer=https%3A%2F%2Fwww.miamiherald.com%2Fbetting%2Fnfl%2Farticle265545826.html\u0026cta_id=e8b445fd-9a1c-429d-a88e-665677f002a5\" target=\"_blank\" rel=\"Follow\"\u003eclick exclusive link\u003c/a\u003e)\u003c/td\u003e\u003ctd\u003eNo Sweat First Bet Up to $1,000\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eBetMGM NY: \u003ca href=\"https://miamiherald.bookies.com/betmgm/offer/15438#listid=9747\u0026listtype=ranking-type-ks\u0026listlocation=_\u0026listversion=20220907152213\u0026list_position=1\u0026ct=oplistclk\u0026ctalocation=_\u0026k_referrer=https%3A%2F%2Fwww.kansascity.com%2Fbetting%2Farticle261739482.html\u0026cta_id=336dfa30-4e99-4193-ab39-bcb9aff4b446\" target=\"_blank\" rel=\"Follow\"\u003eMCBET\u003c/a\u003e\u003c/td\u003e\u003ctd\u003eFirst Bet Offer Up to $1,000 (not available in NY)\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eWynnBET: \u003ca href=\"https://ny.wynnbet.com/register?btag=a_2283b_101c_Y9SBL2PYACPWBCEB\u0026promo_code=XMCCBET\u0026pid=incomeaccess_int\u0026af_siteid=2283\u0026c=Y9SBL2PYACPWBCEB\u0026af_sub1=a_2283b_101c_Y9SBL2PYACPWBCEB\u0026siteid=2283\" target=\"_blank\" rel=\"Follow\"\u003eXMCCBET\u003c/a\u003e\u003c/td\u003e\u003ctd\u003eBet $20, Get $100\u003c/td\u003e\u003c/tr\u003e\u003c/tbody\u003e\u003c/table\u003e\u003ch2\u003eWhat is the N.Y. Jets Caesars Sportsbook Promo Code offer? \u003c/h2\u003e\u003cp\u003eThe \u003ca href=\"https://www.miamiherald.com/betting/article259669235.html\" target=\"_blank\" rel=\"Follow\"\u003eCaesars Sportsbook NY promo code\u003c/a\u003e \u003cb\u003eMCBETFULL\u003c/b\u003e is the only triple play deal out there, as it provides new customers with $1,250 in first-bet insurance and then adds on 1,000 tier credits and 1,000 rewards credits in the award-winning Caesars Rewards program. The first-bet insurance $1,250 cap is generous among first-bet insurance offers, and it gives new customers multiple chances to get out to a successful start by providing them with a bonus-bet credit up to $1,250 if their initial wager settles as a loss.\u003c/p\u003e\u003cp\u003eThe tier and rewards credits open the door to the myriad perks and upgrades that are available via the Caesars Rewards program. Sports bettors who prefer the fast built-in upside that comes with odds boosts will be thrilled to find out that Caesars Sportsbook posts hundreds of odds boosts every week. These are posted in many sports betting markets, so you can count on odds boosts being available for many New York Jets games. Jets fans in New Jersey can use the \u003ca href=\"https://www.miamiherald.com/betting/article260908477.html\" target=\"_self\" rel=\"Follow\"\u003eCaesars Sportsbook NJ promo code\u003c/a\u003e MCBETFULL to join in on the action. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257924923% --\u003e\u003c/p\u003e\u003ch2\u003eWhat is the New York Jets BetRivers Promo Code\u003c/h2\u003e\u003cp\u003eThe \u003ca href=\"https://www.miamiherald.com/betting/article260681852.html\" target=\"_blank\" rel=\"Follow\"\u003eBetRivers New York promo code\u003c/a\u003e\u003cb\u003e \u003c/b\u003eis 2nd Chance first bet of up to $100. If your first bet loses, within 24 hours you will receive a bonus bet of equal amount, up to $100. There is only a 1X wagering requirement and you have 30 days to use it.\u003c/p\u003e\u003cp\u003eYou will also have the flexibility to convert these funds within your time frame, as there is a 30-day redemption window that you can get in motion whenever you like. This makes the BetRivers New York promo code a fantastic way for casual New York sports bettors to get started with a couple of smaller wagers on Jets games and then go for a bigger bet once the NFL season starts to show which teams are contenders and which are pretenders in 2023.\u003c/p\u003e\u003cp\u003eNew sports bettors in New Jersey can get a 2nd Chance Bet of up to $500 with the \u003ca href=\"https://www.miamiherald.com/betting/article257661343.html\" target=\"_blank\" rel=\"Follow\"\u003eBetRivers promo code\u003c/a\u003e offer.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:258391368% --\u003e\u003c/p\u003e\u003ch2\u003eWhat is the New York Jets DraftKings Promo Code\u003c/h2\u003e\u003cp\u003eThe \u003ca href=\"https://www.miamiherald.com/betting/article260807422.html\" target=\"_blank\" rel=\"Follow\"\u003eDraftKings New York promo code\u003c/a\u003e gives new users a chance at $150 in bonus bets on a $5 wager. All they need to do is bet at least $5 on any pre-game moneyline and they’ll win $150 in bonus bets if their team wins. These bonus bets aren’t piled into one single bet credit, as DraftKings New York will send you six $25 bonus-bet credits. These bets have a 1X playthrough, so a single successful bet will turn a bonus-bet credit into cash in your account.\u003c/p\u003e\u003cp\u003eThe $150 value is tremendous, but don’t underestimate the power of getting six bonus bets. It means that a Jets fan can place a wager on an any New York contest, post a bet on the teams facing the Bills, Patriots and Dolphins and still retain two bonus bets to be used on the most favorable matchups at DraftKings New York. New Jersey bettors can use the \u003ca href=\"https://www.miamiherald.com/betting/article260818897.html\" target=\"_self\" rel=\"Follow\"\u003eDraftKings NJ promo code\u003c/a\u003e to unlock some very appealing bonuses.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:258391298% --\u003e\u003c/p\u003e\u003ch2\u003eWhat is the New York Jets FanDuel Promo Code offer?\u003c/h2\u003e\u003cp\u003eFanDuel changes its welcome offer more than any other sportsbook. It recently offered new customers $150 in bonus bets just for signing up and making a $5 bet. Its flagship offer, however, is a No Sweat First Bet up to $1,000 , which you can access now with the \u003ca href=\"https://www.miamiherald.com/betting/article260137030.html\" target=\"_blank\" rel=\"Follow\"\u003eFanDuel NY promo code\u003c/a\u003e offer. \u003c/p\u003e\u003cp\u003eThe No Sweat First Bet acts as an insurance policy for your first bet. If you lose that initial wager, FanDuel will issue you a bonus-bet credit in the amount of your initial wager up to $1,000. FanDuel gives you 15 days to use the credit, and any winnings from the credits can be withdrawn immediately. \u003c/p\u003e\u003cp\u003eThe \u003ca href=\"https://www.miamiherald.com/betting/article260903077.html\" target=\"_self\" rel=\"Follow\"\u003eFanDuel NJ promo code\u003c/a\u003e unlocks the No Sweat First Bet and more to bettors in the Garden State.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:258391323% --\u003e\u003c/p\u003e\u003ch2\u003eWhat is the New York Jets PointsBet Promo Code\u003c/h2\u003e\u003cp\u003eThe PointsBet New York promo code is one of the most innovative and valuable introductory offers on the market, as it gives new customers five second-chance bets worth up to $50 each. Sports bettors who want to maximize the value of this offer need to be prepared to wager for five consecutive days, as the second-chance bets are available once per day for the first five days after signing up for this promotion. The second-chance bet applies to the initial fixed-odds wager made on a given day and provides a bonus-bet credit equal to the value of your first bet, up to $50, if that initial wager lands in the loss column.\u003c/p\u003e\u003cp\u003eThe best to utilize this deal is to time up the sign-up date with the start of a football weekend so that you can place bets on games each day for the entire weekend. You can play for upside in those wagers, all while knowing there is built-in downside protection of up to $250 in bonus-bet credits for those bets. The \u003ca href=\"https://www.miamiherald.com/betting/article257658763.html\" target=\"_blank\" rel=\"Follow\"\u003ePointsBet promo code\u003c/a\u003e offer is also available in New Jersey. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:263975451% --\u003e\u003c/p\u003e\u003ch2\u003eWhat is the New York Jets WynnBET Promo Code offer?\u003c/h2\u003e\u003cp\u003eThe \u003ca href=\"https://www.miamiherald.com/betting/article264226481.html\" target=\"_blank\" rel=\"Follow\"\u003eWynnBET New York promo code\u003c/a\u003e \u003cb\u003eXMCCBET\u003c/b\u003e gives new customers in the Empire State an appealing Bet $20, Get $100 offer. New customers who deposit and place a qualifying wager of $20 at odds of -120 or greater will receive a $100 bonus bet credit as soon as the qualifying wager settles. \u003c/p\u003e\u003cp\u003eJets fans in New Jersey, where WynnBet also offers an online casino, can unlock a $50 sportsbook credit and a $50 casino credit on an initial $100 wager. \u003c/p\u003e\u003ch2\u003eWhat is the New York Jets BetMGM Bonus Code offer?\u003c/h2\u003e\u003cp\u003eA strong case can be made that BetMGM NY is the top sports betting app for those who love parlay wagers, as it has an incredibly user-friendly easy parlay creator that allows players to customize parlays in myriad ways. If you want to create some of those parlays yourself, just sign up for the \u003ca href=\"https://www.miamiherald.com/betting/article259877840.html\" target=\"_blank\" rel=\"Follow\"\u003eBetMGM NY bonus code\u003c/a\u003e \u003cb\u003eMCBET\u003c/b\u003e. \u003c/p\u003e\u003cp\u003eAfter your sign-up is complete, you will be able to access the easy parlay system and benefit from the multiple forms of parlay insurance that BetMGM NY offers as well as ongoing promotions. The BetMGM New York bonus code MCBET is not active for a welcome offer in the state of New York at the moment, but the \u003ca href=\"https://www.miamiherald.com/betting/article261064692.html\" target=\"_blank\" rel=\"Follow\"\u003eBetMGM NJ bonus code\u003c/a\u003e MCBET provides New Jersey bettors a first-bet offer up to $1,000.\u003c/p\u003e\u003cp\u003eThere will likely be more BetMGM NY offers in the future, so be sure to bookmark our link so that you can stay updated on any future deals.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257924913% --\u003e\u003c/p\u003e\u003ch2\u003eResponsible Gambling\u003c/h2\u003e\u003cp\u003e\u003ci\u003eAlways gamble responsibly. All licensed and legal operators in the United States have resources available to bettors, including educational guides on how to spot problem gaming, links to support services and tools to self-exclude for a set period of time. Support is available at the \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://www.ncpgambling.org/\"\u003e\u003ci\u003eNational Council on Problem Gaming\u003c/i\u003e\u003c/a\u003e\u003ci\u003e, \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://www.1800gambler.net/\"\u003e\u003ci\u003e1-800-GAMBLER\u003c/i\u003e\u003c/a\u003e\u003ci\u003e and \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://americanaddictioncenters.org/\"\u003e\u003ci\u003eAmerican Addiction Centers.\u003c/i\u003e\u003c/a\u003e\u003ci\u003e Be sure to only wager on gambling sites that are licensed and regulated by the gaming regulatory body in your state. That ensures games are fair, bets are honored, customers\u0026rsquor; funds are secure and that there are legal protections for the consumer.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eSports betting and gambling are not legal in all locations. Be sure to comply with laws applicable where you reside.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257883633% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/265150826",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy KC Joyner\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:gamblingmc@gdcgroup.com\"\u003egamblingmc@gdcgroup.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eGambling.com\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "From Our Partners",
+      "lead_media": {
+        "id": "267253367",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/nfl/a4oepl/picture267253367",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "USATSI_19205756 (2) (1).jpg",
+        "publication": "mcclatchy-partners",
+        "layout_option": "",
+        "home": "/web/v1/sections/87347",
+        "modified_date": 1665673792,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1665673792,
+        "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/nfl/a4oepl/picture267253367/alternates/FREE_1140/USATSI_19205756%20(2)%20(1).jpg",
+        "href": "/web/v1/content/267253367",
+        "additional_sections": [
+          "87347"
+        ],
+        "credit": "USA TODAY Sports",
+        "dateline": "",
+        "caption": "New York Jets running back Breece Hall runs with the ball against the Miami Dolphins during the second half Sunday at MetLife Stadium.",
+        "photographer": "Ed Mulholland",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "mcclatchypartners",
+      "allow_comments": false,
+      "disable_amp": true,
+      "topic_tags": []
+    },
+    {
+      "id": "265055219",
+      "url": "https://www.mcclatchy-partners.com/gdc-group/sacramento/betting/nfl/article265055219.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Best New York Giants Sportsbook Promos Codes, Bonuses \u0026 Boosts",
+      "publication": "mcclatchy-partners",
+      "layout_option": "none",
+      "home": "/web/v1/sections/87638",
+      "home_section": {
+        "name": "NFL",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/sacramento/betting/nfl/"
+      },
+      "modified_date": 1691005506,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Best New York Giants Sportsbook Promos Codes, Bonuses \u0026 Boosts",
+      "originating_url": "https://www.sacbee.com/betting/nfl/article265055219.html",
+      "meta_description": "The Giants were one of the biggest surprises in the NFL last season and will look to take another step in 2023. You can use the best Giants sportsbook promo codes to lock in a futures wager on them now!",
+      "published_date": 1690486380,
+      "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/nfl/d57n0l/picture270708162/alternates/FREE_1140/USATSI_19709148%20(1).jpg",
+      "authors": [
+        {
+          "name": "KC Joyner",
+          "email": "gamblingmc@gdcgroup.com"
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "87638",
+        "88708"
+      ],
+      "credit": "Gambling.com",
+      "dateline": "",
+      "summary": "The Giants were one of the biggest surprises in the NFL last season and will look to take another step in 2023. You can use the best Giants sportsbook promo codes to lock in a futures wager on them now!",
+      "content": "\u003cp\u003e\u003c!-- %asset:257883633% --\u003e\u003c/p\u003e\u003cp\u003eThe New York Giants got back into the postseason for the first time since 2016 last season, beating the 13-4 Minnesota Vikings in the Wild Card Round. First-year head coach Brian Daboll was named the NFL Coach of the Year after leading the Giants to a 9-7-1 mark. The Giants were just 4-13 the previous year. \u003c/p\u003e\u003cp\u003eNew bettors who are bullish on the Giants can get +6500 odds right now on Big Blue at most of the sports betting sites, which are currently offering the following \u003ca rel=\"Follow\" target=\"_blank\" href=\"https://www.miamiherald.com/betting/article263584558.html\"\u003eNew York sportsbook promo codes\u003c/a\u003e:\u003c/p\u003e\u003ch2\u003eBest New York Giants Promo Codes \u0026 Bonuses\u003c/h2\u003e\u003ctable\u003e\u003ctbody\u003e\u003ctr\u003e\u003ctd\u003e\u003cb\u003eNew York Giants Sportsbook Promo Code\u003c/b\u003e\u003c/td\u003e\u003ctd\u003e\u003cb\u003eBonus\u003c/b\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eCaesars Sportsbook NY: \u003ca rel=\"Follow\" target=\"_blank\" href=\"https://miamiherald.bookies.com/caesars/offer/15651#listid=9747\u0026listtype=ranking-type-ks\u0026listlocation=_\u0026listversion=20220907152213\u0026list_position=2\u0026ct=oplistclk\u0026ctalocation=_\u0026k_referrer=https%3A%2F%2Fwww.kansascity.com%2Fbetting%2Farticle261739482.html\u0026cta_id=41770add-410a-4f12-962e-65822826db8e\"\u003eMCBETFULL\u003c/a\u003e\u003c/td\u003e\u003ctd\u003e $1,250 First Bet on Caesars\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003ePointsBet NY: (\u003ca rel=\"Follow\" target=\"_blank\" href=\"https://miamiherald.bookies.com/pointsbet/offer/15040#listid=9745\u0026listtype=ranking-type-il\u0026listlocation=_\u0026listversion=20220908132820\u0026list_position=3\u0026ct=oplistclk\u0026ctalocation=_\u0026k_referrer=https%3A%2F%2Fwww.miamiherald.com%2Fbetting%2Fnfl%2Farticle265545826.html\u0026cta_id=b9401e71-cb2e-4b09-8fc8-8afdf5ebeeaf\"\u003eclick exclusive link\u003c/a\u003e)\u003c/td\u003e\u003ctd\u003e5 Second-Chance Bets up to $50 Each\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eBetRivers NY: \u003ca rel=\"Follow\" target=\"_blank\" href=\"https://miamiherald.bookies.com/betrivers/offer/11528#listid=9745\u0026listtype=ranking-type-il\u0026listlocation=_\u0026listversion=20220908132820\u0026list_position=6\u0026ct=oplistclk\u0026ctalocation=_\u0026k_referrer=https%3A%2F%2Fwww.miamiherald.com%2Fbetting%2Fnfl%2Farticle265545826.html\u0026cta_id=6bd5000b-ee76-4752-99df-6198d7361f34\"\u003eMCCRIV\u003c/a\u003e\u003c/td\u003e\u003ctd\u003e2nd Chance Bet up to $100\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eDraftKings NY: (\u003ca rel=\"Follow\" target=\"_blank\" href=\"https://miamiherald.bookies.com/draftkings/offer/11523#listid=9745\u0026listtype=ranking-type-il\u0026listlocation=_\u0026listversion=20220908132820\u0026list_position=5\u0026ct=oplistclk\u0026ctalocation=_\u0026k_referrer=https%3A%2F%2Fwww.miamiherald.com%2Fbetting%2Fnfl%2Farticle265545826.html\u0026cta_id=1282f7d9-c2b9-4f2f-bfe4-7ca50da408f8\"\u003eclick exclusive link\u003c/a\u003e)\u003c/td\u003e\u003ctd\u003eBet $5, Get $150\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eFanDuel NY: (\u003ca rel=\"Follow\" target=\"_blank\" href=\"https://miamiherald.bookies.com/fanduel/offer/11447#listid=9745\u0026listtype=ranking-type-il\u0026listlocation=_\u0026listversion=20220908132820\u0026list_position=4\u0026ct=oplistclk\u0026ctalocation=_\u0026k_referrer=https%3A%2F%2Fwww.miamiherald.com%2Fbetting%2Fnfl%2Farticle265545826.html\u0026cta_id=e8b445fd-9a1c-429d-a88e-665677f002a5\"\u003eclick exclusive link\u003c/a\u003e)\u003c/td\u003e\u003ctd\u003eNo Sweat First Bet Up to $1,000\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eBetMGM NY: \u003ca rel=\"Follow\" target=\"_blank\" href=\"https://miamiherald.bookies.com/betmgm/offer/15438#listid=9747\u0026listtype=ranking-type-ks\u0026listlocation=_\u0026listversion=20220907152213\u0026list_position=1\u0026ct=oplistclk\u0026ctalocation=_\u0026k_referrer=https%3A%2F%2Fwww.kansascity.com%2Fbetting%2Farticle261739482.html\u0026cta_id=336dfa30-4e99-4193-ab39-bcb9aff4b446\"\u003eMCBET\u003c/a\u003e\u003c/td\u003e\u003ctd\u003eFirst-Bet Offer up to $1,000 (not available in NY)\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eWynnBET NY: \u003ca href=\"https://ny.wynnbet.com/register?btag=a_2283b_101c_2313MXSVVGDU4Z39\u0026promo_code=XMCCBET\u0026pid=incomeaccess_int\u0026af_siteid=2283\u0026c=2313MXSVVGDU4Z39\u0026af_sub1=a_2283b_101c_2313MXSVVGDU4Z39\u0026siteid=2283\" target=\"_blank\" rel=\"Follow\"\u003eXMCCBET\u003c/a\u003e\u003c/td\u003e\u003ctd\u003eBet $20, Get $100\u003c/td\u003e\u003c/tr\u003e\u003c/tbody\u003e\u003c/table\u003e\u003ch2\u003eWhat is the N.Y. Giants Caesars Sportsbook Promo Code offer? \u003c/h2\u003e\u003cp\u003eThe New York Giants \u003ca rel=\"Follow\" target=\"_blank\" href=\"https://www.miamiherald.com/betting/article259669235.html\"\u003eCaesars Sportsbook NY promo code\u003c/a\u003e \u003cb\u003eMCBETFULL\u003c/b\u003e lands new customers first-bet insurance up to $1,250 as well as 1,000 tier credits and 1,000 rewards credits in the incredible Caesars Rewards program that has won multiple awards for best players club. The first-bet insurance provides a second chance for new customers to get out to a profitable start, as it provides a bonus-bet credit up to $1,250 in the event of a first bet that settles as a loss. That same offer is available to Garden State bettors via the \u003ca rel=\"Follow\" target=\"_blank\" href=\"https://www.miamiherald.com/betting/article260908477.html\"\u003eCaesars Sportsbook NJ promo code\u003c/a\u003e MCBETFULL.\u003c/p\u003e\u003cp\u003eThe tier credits and rewards credits will get you started down the path of many perks and upgrades at Caesars Sportsbook NY and Caesars Hotels and Resorts. Bettors who like the fast and easy upside of odds boosts will really enjoy Caesars Sportsbook New York, as it posts dozens of odds boosts every week and will offer them on many Giants games this year. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257924923% --\u003e\u003c/p\u003e\u003ch2\u003eWhat is the New York Giants PointsBet Promo Code?\u003c/h2\u003e\u003cp\u003ePointsBet NY is an innovative newcomer to the online sportsbook world, and that innovation extends to the New York Giants PointsBet NY promo code that lands first-time customers five second-chance bets up to $50 each. The key here is to be ready to wager for five straight days after signing up with PointsBet New York, as this deal provides one second-chance bet a day for five days in a row. This second-chance bet applies to the very first bet you make on a day and can return up to $50 in bonus-bet credits if the first daily wager settles as a loss. The \u003ca rel=\"Follow\" target=\"_blank\" href=\"https://www.miamiherald.com/betting/article257658763.html\"\u003ePointsBet sportsbook promo code\u003c/a\u003e is also available in New Jersey.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:263975451% --\u003e\u003c/p\u003e\u003ch2\u003eWhat is the New York Giants BetRivers Promo Code?\u003c/h2\u003e\u003cp\u003eThe New York Giants \u003ca rel=\"Follow\" target=\"_blank\" href=\"https://www.miamiherald.com/betting/article260681852.html\"\u003eBetRivers New York promo code\u003c/a\u003e\u003cb\u003e \u003c/b\u003eis a 2nd Chance Bet up to $100. If your first wager loses, you will be refunded up to $100 in site credit. That credit comes with a favorable 1X wagering requirement, and there is a 30-day window to use that bonus bet. This means the BetRivers NY promo code is a perfect fit for those sports bettors who want to dip their proverbial toes into the wagering waters of betting on Giants games but don’t wish to wager too much. New users in New Jersey can take advantage of a 2nd Chance Bet up to $500 with the \u003ca rel=\"Follow\" target=\"_blank\" href=\"https://www.miamiherald.com/betting/article257661343.html\"\u003eBetRivers promo code\u003c/a\u003e. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:258391368% --\u003e\u003c/p\u003e\u003ch2\u003eWhat is the New York Giants DraftKings Promo Code?\u003c/h2\u003e\u003cp\u003eNew customers can partake of a 30-1 upside offer with the New York Giants \u003ca rel=\"Follow\" target=\"_blank\" href=\"https://www.miamiherald.com/betting/article260807422.html\"\u003eDraftKings New York promo code\u003c/a\u003e, as signing up for this deal will allow them to place a $5 moneyline bet on any pre-game moneyline and get $150 in bonus bets. Those bonus bets will be in the form of six $25 bet credits that have a highly favorable 1X playthrough. This means a win with any bonus-bet credit will send withdrawable cash winnings to your new DraftKings NY account.\u003c/p\u003e\u003cp\u003eThere is another upside element to the six bonus bets in that Giants fans can use them to place bets on multiple contests in a given week. Those fans could wager on a Giants game, then place bets on whoever is playing the Eagles or Cowboys that week and still have bonus-bet credits left over to wager at the wide assortment of sports betting markets that are posted at DraftKings New York. Additional \u003ca rel=\"Follow\" target=\"_blank\" href=\"https://www.miamiherald.com/betting/article260818897.html\"\u003eDraftKings NJ promo code\u003c/a\u003e offers can be accessed by Big Blue backers in New Jersey. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:258391298% --\u003e\u003c/p\u003e\u003ch2\u003eWhat is the New York Giants FanDuel Promo Code offer?\u003c/h2\u003e\u003cp\u003eThe New York Giants FanDuel NY promo code offers a No Sweat First Bet of up to $1,000. If you lose your first wager, FanDuel will refund the amount of that wager up to $1,000 in bonus bets.\u003c/p\u003e\u003cp\u003eFanDuel believes gives customers plenty of time to use that credit, as it provides a 15-day redemption window that is more than twice as long as the typical redemption window for bonus bets. This will allow Giants fans the chance to use these bonus bets on multiple contests at the vast array of sports betting markets available at FanDuel and provide ample time to search for the most profitable wagers on the board. Giant fans in New Jersey can get their hands on some great \u003ca rel=\"Follow\" target=\"_blank\" href=\"https://www.miamiherald.com/betting/article260903077.html\"\u003eFanDuel NJ promo code\u003c/a\u003e offers, too. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:258391323% --\u003e\u003c/p\u003e\u003ch2\u003eWhat is the New York Giants BetMGM Bonus Code offer?\u003c/h2\u003e\u003cp\u003eBetMGM is arguably the best online sportsbook for parlay wagers, as it has a simple to use parlay creation system that allows sports bettors to make almost any type of parlay wager they can dream up.\u003c/p\u003e\u003cp\u003eTo make those parlay wagers, just sign up for the New York Giants \u003ca rel=\"Follow\" target=\"_blank\" href=\"https://www.miamiherald.com/betting/article259877840.html\"\u003eBetMGM NY bonus code\u003c/a\u003e \u003cb\u003eMCBET\u003c/b\u003e. Once you are signed up, you will see plenty of current and future betting options for the Giants, as well as multiple promotions that include elements such as parlay insurance. \u003c/p\u003e\u003cp\u003eThe BetMGM NY bonus code flagship offer is not currently available in the state of New York, but in New Jersey, you can take advantage of the \u003ca rel=\"Follow\" target=\"_blank\" href=\"https://www.miamiherald.com/betting/article261064692.html\"\u003eBetMGM NJ bonus code\u003c/a\u003e MCBET and benefit from a first-bet offer up to $1,000. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257924913% --\u003e\u003c/p\u003e\u003ch2\u003eResponsible Gambling\u003c/h2\u003e\u003cp\u003e\u003ci\u003eAlways gamble responsibly. All licensed and legal operators in the United States have resources available to bettors, including educational guides on how to spot problem gaming, links to support services and tools to self-exclude for a set period of time. Support is available at the \u003c/i\u003e\u003ca href=\"https://www.ncpgambling.org/\" target=\"_blank\"\u003e\u003ci\u003eNational Council on Problem Gaming\u003c/i\u003e\u003c/a\u003e\u003ci\u003e, \u003c/i\u003e\u003ca href=\"https://www.1800gambler.net/\" target=\"_blank\"\u003e\u003ci\u003e1-800-GAMBLER\u003c/i\u003e\u003c/a\u003e\u003ci\u003e and \u003c/i\u003e\u003ca href=\"https://americanaddictioncenters.org/\" target=\"_blank\"\u003e\u003ci\u003eAmerican Addiction Centers.\u003c/i\u003e\u003c/a\u003e\u003ci\u003e Be sure to only wager on gambling sites that are licensed and regulated by the gaming regulatory body in your state. That ensures games are fair, bets are honored, customers\u0026rsquor; funds are secure and that there are legal protections for the consumer.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eSports betting and gambling are not legal in all locations. Be sure to comply with laws applicable where you reside.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257883633% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/265055219",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy KC Joyner\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:gamblingmc@gdcgroup.com\"\u003egamblingmc@gdcgroup.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eGambling.com\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "From Our Partners",
+      "lead_media": {
+        "id": "270708162",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/nfl/d57n0l/picture270708162",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "USATSI_19709148 (1).jpg",
+        "publication": "mcclatchy-partners",
+        "layout_option": "",
+        "home": "/web/v1/sections/87347",
+        "modified_date": 1672766053,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1672766053,
+        "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/nfl/d57n0l/picture270708162/alternates/FREE_1140/USATSI_19709148%20(1).jpg",
+        "href": "/web/v1/content/270708162",
+        "additional_sections": [
+          "87347"
+        ],
+        "credit": "USA TODAY Sports",
+        "dateline": "",
+        "caption": "New York Giants wide receiver Richie James flips after catching a touchdown pass against the Indianapolis Colts during the first half Sunday at MetLife Stadium.",
+        "photographer": "John Jones",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "mcclatchypartners",
+      "allow_comments": false,
+      "disable_amp": true,
+      "topic_tags": []
+    },
+    {
+      "id": "277707323",
+      "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/article277707323.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "UFC Best Bets: Picks, Odds, and Predictions for UFC 291",
+      "publication": "mcclatchy-partners",
+      "layout_option": "none",
+      "home": "/web/v1/sections/87287",
+      "home_section": {
+        "name": "Betting",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/"
+      },
+      "modified_date": 1690653600,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "UFC Best Bets: Picks, Odds, and Predictions for UFC 291",
+      "originating_url": "https://www.rotowire.com/mma/article/ufc-291-best-bets-picks-odds-and-predictions-73582",
+      "meta_description": "The UFC travels to Salt Lake City, Utah on Saturday. The main event sees a rematch between Dustin Poirier and Justin Gaethje for the BMF belt.",
+      "published_date": 1690653600,
+      "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/88tkqn/picture277708613/alternates/FREE_1140/Gaethje.jpg",
+      "authors": [
+        {
+          "name": "Cole Shelton",
+          "email": "Gamblingmc@gdcgroup.com"
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "87287",
+        "88698"
+      ],
+      "credit": "Rotowire.com",
+      "dateline": "",
+      "summary": "The UFC travels to Salt Lake City, Utah on Saturday. The main event sees a rematch between Dustin Poirier and Justin Gaethje for the BMF belt.",
+      "content": "\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e\u003cp\u003eThe UFC returns to Salt Lake City, Utah on Saturday, July 29 for UFC 291. In the main event, Dustin Poirier takes on Justin Gaethje in a highly-anticipated rematch for the vacant BMF belt.\u003c/p\u003e\u003cp\u003eBelow, we’ll share our favorite play, an underdog, a prop, and a two-fighter parlay. All odds are via the DraftKings Sportsbook and are accurate as of the post date of this article. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877378% --\u003e\u003c/p\u003e\u003ch3\u003eUFC 291 Best Bets\u003c/h3\u003e\u003cp\u003eHere is a recap of this weekend’s UFC 291 best bets:\u003c/p\u003e\u003cul\u003e\u003cli\u003eStephen Thompson (-150)\u003c/li\u003e\u003cli\u003eVinicius Salvador (+125)\u003c/li\u003e\u003cli\u003eDustin Poirier and Justin Gaethje fight to start Round 3 (-165)\u003c/li\u003e\u003cli\u003eMiranda Maverick \u0026 Gabriel Bonfim parlay (-133)\u003c/li\u003e\u003c/ul\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch3\u003eWeight Class: Flyweight\u003c/h3\u003e\u003cp\u003e\u003cb\u003eDustin Poirier (29-7) vs. Justin Gaethje (24-4)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eIn the main event of UFC 291, Dustin Poirier and Justin Gaethje are set for their highly-anticipated rematch, and the BMF belt is up for grabs.\u003c/p\u003e\u003cp\u003eIn the first fight, the two went at it right away, and it still made it to the fourth round. In the rematch, we like the fight to start round three, as we think it will be a slower-paced fight. Both men know if they lose, they likely won’t get another crack at the lightweight title.\u003c/p\u003e\u003cp\u003eAdditionally, both Poirier and Gaethje are super durable when it comes to striking. The way to beat them is by submission, or by an overwhelming amount of damage late in the fight.\u003c/p\u003e\u003cp\u003eIn Poirier’s last 10 fights, he has started the third round in seven -- including the Gaethje fight. In Gaethje’s last five, three fights have started the third round.\u003c/p\u003e\u003cp\u003e\u003cb\u003eUFC 291 Best Bet: Dustin Poirier \u0026 Justin Gaethje fight begins Round 3 (-165)\u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877363% --\u003e\u003c/p\u003e\u003ch3\u003eWeight Class: Flyweight\u003c/h3\u003e\u003cp\u003e\u003cb\u003eVinicius Salvador\u003c/b\u003e\u003cb\u003e (14-5) vs. \u003c/b\u003e\u003cb\u003eC.J. Vergara\u003c/b\u003e\u003cb\u003e (11-4-1)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eThere aren’t many underdogs on Saturday’s UFC 291 card we like, but Vinicius Salvador is one we can get behind.\u003c/p\u003e\u003cp\u003eSalvador lost a close decision in his debut, while C.J. Vergara is 2-2 in his UFC career, but we haven’t been sold on him. Last time out, he beat Daniel Lacerda, who gasses out badly in his fights. Even in that matchup, Vergara almost got finished.\u003c/p\u003e\u003cp\u003eBoth Salvador and Vergara throw a ton of volume, and both get hit quite a bit. However, we think Salvador is the better striker and also has the wrestling advantage.\u003c/p\u003e\u003cp\u003eTo me, this is a coin-flip type of fight, so on a fight we believe is 50-50, we will always go with the underdog. When push comes to shove, we like Salvador’s striking better than Vergara.\u003c/p\u003e\u003cp\u003e\u003cb\u003eUFC 291 Best Bet: \u003c/b\u003e\u003cb\u003eVinicius Salvador\u003c/b\u003e\u003cb\u003e (+125)\u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877378% --\u003e\u003c/p\u003e\u003ch3\u003eWeight Class: Welterweight\u003c/h3\u003e\u003cp\u003e\u003cb\u003eStephen Thompson\u003c/b\u003e\u003cb\u003e (17-6-1) vs. \u003c/b\u003e\u003cb\u003eMichel Pereira\u003c/b\u003e\u003cb\u003e (28-11)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eFor my betting favorite, I’m backing Stephen Thompson to beat Michel Pereira at UFC 291.\u003c/p\u003e\u003cp\u003eThe way to beat Thompson as of late has been to wrestle him and hold him down, as we saw Gilbert Burns and Belal Muhammad do. However, strikers have struggled to beat him, as we saw Thompson beat Kevin Holland, and before the losses, he dispatched of both Geoff Neal and Vicente Luque.\u003c/p\u003e\u003cp\u003ePereira, meanwhile, is a similar striker to Thompson, but he has more of a wild style. His cardio is a big concern, however, as we saw him gas out recently. At elevation in Utah, it is even more of a concern.\u003c/p\u003e\u003cp\u003eIn this matchup, we expect Pereira to try and wrestle Thompson, but ‘Wonderboy’ should be able to keep it standing. On the feet, he is harder to hit, and we expect Thompson to take over in the second and third rounds to get the decision win.\u003c/p\u003e\u003cp\u003e\u003cb\u003eUFC 291 Best Bet: \u003c/b\u003e\u003cb\u003eStephen Thompson\u003c/b\u003e\u003cb\u003e (-150)\u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:266042956% --\u003e\u003c/p\u003e\u003ch3\u003eWeight Class: Flyweight and Featherweight\u003c/h3\u003e\u003cp\u003e\u003cb\u003eMiranda Maverick\u003c/b\u003e\u003cb\u003e (11-5) vs. \u003c/b\u003e\u003cb\u003ePriscila Cachoeira\u003c/b\u003e\u003cb\u003e (12-4)\u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003cb\u003eGabriel Bonfim\u003c/b\u003e\u003cb\u003e (14-0) vs. \u003c/b\u003e\u003cb\u003eTrevin Giles\u003c/b\u003e\u003cb\u003e (16-4)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eFor my parlay, I’m backing Miranda Maverick and Gabriel Bonfim to get their hands raised Saturday at UFC 291.\u003c/p\u003e\u003cp\u003eMaverick had a disappointing fight last time out back in June and now steps on short notice against Priscila Cachoeira, which is a good matchup for her. Maverick is durable, which is the way Cachoeira wins her fights too, but we expect Maverick to be able to use her wrestling to get the win.\u003c/p\u003e\u003cp\u003eMaverick averages 2.24 takedowns per 15 minutes, while Cachoeira struggles to keep the fight standing. On the mat, she struggles to get back up, and we like Maverick to eventually get a submission.\u003c/p\u003e\u003cp\u003eFor the other leg, I’m backing Gabriel Bonfim to beat Trevin Giles in the prelim headliner. Bonfim throws a ton of volume, but his wrestling is the real deal. Meanwhile, Giles’ chin is still a concern for me, as we have seen him get knocked out a couple of times. His takedown defense will be tested here, as we saw Gerald Meerschaert and Zak Cummings tap him out. we expect Bonfim to get the fight to the mat and sink in a choke in the first or second round.\u003c/p\u003e\u003cp\u003e\u003cb\u003eUFC 291 Best Bet: \u003c/b\u003e\u003cb\u003eMiranda Maverick\u003c/b\u003e\u003cb\u003e \u0026 \u003c/b\u003e\u003cb\u003eGabriel Bonfim\u003c/b\u003e\u003cb\u003e parlay (-133)\u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877383% --\u003e\u003c/p\u003e\u003ch3\u003eResponsible Gambling\u003cbr/\u003e\u003cbr/\u003e\u003c/h3\u003e\u003cp\u003e\u003ci\u003e Always gamble responsibly. All licensed and legal operators in the United States have resources available to bettors, including educational guides on how to spot problem gaming, links to support services and tools to self-exclude for a set period of time. Support is available at the \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://www.ncpgambling.org/\"\u003e\u003ci\u003eNational Council on Problem Gaming\u003c/i\u003e\u003c/a\u003e\u003ci\u003e, \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://www.1800gambler.net/\"\u003e\u003ci\u003e1-800-GAMBLER\u003c/i\u003e\u003c/a\u003e\u003ci\u003e and \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://americanaddictioncenters.org/\"\u003e\u003ci\u003eAmerican Addiction Centers.\u003c/i\u003e\u003c/a\u003e\u003ci\u003e Be sure to only wager on gambling sites that are licensed and regulated by the gaming regulatory body in your state. That ensures games are fair, bets are honored, customers’ funds are secure and that there are legal protections for the consumer.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003e Sports betting and gambling are not legal in all locations. Be sure to comply with laws applicable where you reside.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/277707323",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Cole Shelton\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:Gamblingmc@gdcgroup.com\"\u003eGamblingmc@gdcgroup.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eRotowire.com\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "From Our Partners",
+      "lead_media": {
+        "id": "277708613",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/88tkqn/picture277708613",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "Gaethje.jpg",
+        "publication": "mcclatchy-partners",
+        "layout_option": "",
+        "home": "/web/v1/sections/87287",
+        "modified_date": 1690472892,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1690472892,
+        "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/88tkqn/picture277708613/alternates/FREE_1140/Gaethje.jpg",
+        "href": "/web/v1/content/277708613",
+        "additional_sections": [
+          "87287"
+        ],
+        "credit": "USA TODAY Sports",
+        "dateline": "",
+        "caption": "Rafael Fiziev reacts after fighting Justin Gaethje (not pictured) during UFC 286 at O2 Arena.",
+        "alt": "Dustin Poirier vs. Justin Gaethje",
+        "photographer": "Per Haljestam",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "mcclatchypartners",
+      "allow_comments": false,
+      "disable_amp": true,
+      "topic_tags": []
+    },
+    {
+      "id": "277667193",
+      "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/article277667193.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "NASCAR Cook Out 400 Odds, Expert Picks \u0026 Predictions For Richmond Raceway",
+      "publication": "mcclatchy-partners",
+      "layout_option": "none",
+      "home": "/web/v1/sections/87287",
+      "home_section": {
+        "name": "Betting",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/"
+      },
+      "modified_date": 1690632000,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "NASCAR Cook Out 400 Odds, Expert Picks \u0026 Predictions For Richmond Raceway",
+      "originating_url": "https://bookies.com/picks/nascar-cook-out-400-odds-expert-picks-betting-preview-for-this-weekend",
+      "meta_description": "Check out the latest NASCAR Cook Out 400 Odds for Sunday’s race at Richmond Raceway and our expert NASCAR picks, tips \u0026 predictions for the race.",
+      "published_date": 1690632000,
+      "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/1rky20/picture277667543/alternates/FREE_1140/USATSI_20378615.jpg",
+      "authors": [
+        {
+          "name": "David Caraviello",
+          "email": "gamblingmc@gdcgroup.com"
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "87287",
+        "88698"
+      ],
+      "credit": "Bookies.com",
+      "dateline": "",
+      "summary": "Check out the latest NASCAR Cook Out 400 Odds for Sunday’s race at Richmond Raceway and our expert NASCAR picks, tips \u0026 predictions for the race.",
+      "content": "\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003cp\u003eWith back-to-back top-five finishes, Kevin Harvick finally seems to be emerging from the skid that’s gripped him all summer. And Sunday afternoon brings another opportunity for the soon-to-be-retired driver to claim one more race victory before he trades his helmet for a television headset.\u003c/p\u003e\u003cp\u003eHarvick is the defending champion of the summer event at Richmond Raceway, where he led 48 laps to claim the 400-lapper on the .75-mile track. Then as now, Harvick appeared to be deep in the doldrums before breaking out for back-to-back wins that locked in a playoff berth. \u003c/p\u003e\u003cp\u003eHarvick heads to Richmond this week on the heels of consecutive fourth-place results at New Hampshire and Pocono, his first single-digit finishes since Darlington in early May. Is Harvick capable of winning at Richmond again this time around? Although his +750 opening odds were tied for fourth highest on the board, the No. 4 car has led just 10 laps in his past six races.\u003c/p\u003e\u003cp\u003eWith 12 top-10s in his last 14 starts at Richmond, we have no issues with incorporating Harvick into our NASCAR picks portfolio this week — although taking him as a top-five or top-10 option might seem the most sensible wager.\u003c/p\u003e\u003ch2\u003eNASCAR Cook Out 400 Odds\u003c/h2\u003e\u003ctable\u003e\u003ctbody\u003e\u003ctr\u003e\u003ctd\u003e\u003cstrong\u003eDriver\u003c/strong\u003e\u003c/td\u003e\u003ctd\u003e\u003cstrong\u003eWin\u003c/strong\u003e\u003c/td\u003e\u003ctd\u003e\u003cstrong\u003eTop 3\u003c/strong\u003e\u003c/td\u003e\u003ctd\u003e\u003cstrong\u003eTop 5\u003c/strong\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eMartin Truex Jr.\u003c/td\u003e\u003ctd\u003e+450\u003c/td\u003e\u003ctd\u003e+130\u003c/td\u003e\u003ctd\u003e-150\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eKyle Larson\u003c/td\u003e\u003ctd\u003e+500\u003c/td\u003e\u003ctd\u003e+140\u003c/td\u003e\u003ctd\u003e-135\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eDenny Hamlin\u003c/td\u003e\u003ctd\u003e+650\u003c/td\u003e\u003ctd\u003e+180\u003c/td\u003e\u003ctd\u003e-115\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eKevin Harvick\u003c/td\u003e\u003ctd\u003e+750\u003c/td\u003e\u003ctd\u003e+200\u003c/td\u003e\u003ctd\u003e+110\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eChristopher Bell\u003c/td\u003e\u003ctd\u003e+750\u003c/td\u003e\u003ctd\u003e+200\u003c/td\u003e\u003ctd\u003e+110\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eKyle Busch\u003c/td\u003e\u003ctd\u003e+850\u003c/td\u003e\u003ctd\u003e+250\u003c/td\u003e\u003ctd\u003e+120\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eWilliam Byron\u003c/td\u003e\u003ctd\u003e+900\u003c/td\u003e\u003ctd\u003e+260\u003c/td\u003e\u003ctd\u003e+120\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003eJoey Logano\u003c/td\u003e\u003ctd\u003e+1200\u003c/td\u003e\u003ctd\u003e+350\u003c/td\u003e\u003ctd\u003e+150\u003c/td\u003e\u003c/tr\u003e\u003c/tbody\u003e\u003c/table\u003e\u003cp\u003e\u003ci\u003eOdds via DraftKings and current as of publication.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877378% --\u003e\u003c/p\u003e\u003ch2\u003eNASCAR Cook Out 400 Betting Tips\u003c/h2\u003e\u003cp\u003eKyle Busch leads all active drivers with six career victories at Richmond, the most recent coming in 2018. A 14th-place finish at the short track this past spring snapped a run of 10 straight top-10 results at Richmond for Busch, who’s finished back in the pack in his last two starts this season. \u003c/p\u003e\u003cul\u003e\u003cli\u003eThe best average finish at Richmond belongs to Christopher Bell, a 5.7 built on five results of sixth or better in six career starts at the track.\u003c/li\u003e\u003cli\u003ePocono winner Denny Hamlin and Harvick each own four career Richmond victories, while NASCAR odds leader Martin Truex Jr. has three, and Brad Keselowski, Kyle Larson, and Joey Logano have two apiece. \u003c/li\u003e\u003cli\u003eThe past six Richmond races have been won by six different drivers, capped by Larson, who led 93 laps on his way to victory in the spring. \u003c/li\u003e\u003cli\u003e\u003cb\u003eHendrick’s No. 9 car has been top-5 in four of its last six at Richmond\u003c/b\u003e—three times with Chase Elliott and once with sub Josh Berry, who drove it to a runner-up result while Elliott was rehabbing his broken leg in the spring.\u003c/li\u003e\u003cli\u003eDrivers who are good at Richmond tend to be consistently good there—Hamlin has been top-10 in 12 of his last 14, Busch in 13 of his last 15, Larson in seven of his last 10, Logano in five of his last six. \u003c/li\u003e\u003c/ul\u003e\u003cp\u003e\u003c!-- %asset:257877363% --\u003e\u003c/p\u003e\u003ch2\u003eNASCAR Cook Out 400 Best Bets\u003c/h2\u003e\u003ch3\u003eChristopher Bell to Win (+750)\u003c/h3\u003e\u003cp\u003eBell pulled out of a three-race skid with a sixth-place result last week at Pocono. He’ll have a great opportunity to build on that success at Richmond, where he hasn’t finished worse than sixth since 2020.\u003c/p\u003e\u003cp\u003eBell led 26 laps in his fourth-place effort in April, was the runner-up at Richmond in the summer of 2022, and led 63 laps en route to placing sixth that previous spring. In the first three races at Richmond in the current next-gen car, only Harvick and Larson have earned more points than Bell.\u003c/p\u003e\u003ch3\u003eMartin Truex Jr. Top 3 (+130)\u003cbr/\u003e\u003cbr/\u003e\u003c/h3\u003e\u003cp\u003eThe hottest driver in NASCAR cashed again for us last week with his third-place run at Pocono, continuing a sizzling summer stretch for the points leader and championship favorite. Throw out the street race in Chicago, and Truex has finished top-five in six of his last seven starts. And he’s excellent at Richmond, with top-fives in eight of his last nine there, a stretch that includes three wins.\u003c/p\u003e\u003ch3\u003eTy Gibbs Top 5 (+350)\u003c/h3\u003e\u003cp\u003eIt’s a JGR sweep for the picks this week. Joe Gibbs’ grandson broke through with a season-best fifth-place finish at Pocono last weekend, his second top-10 in his past four starts. Also, he finished ninth in the spring race at Richmond earlier this season. You must pick your spots with a rookie who hasn’t shown a lot of sustained success, but Gibbs presents good value for\u003cb\u003e \u003c/b\u003eNASCAR betting this weekend at a track where Joe Gibbs Racing cars have won six times since 2018.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877383% --\u003e\u003c/p\u003e\u003ch2\u003eNASCAR Cook Out 400 Time, Date and TV\u003c/h2\u003e\u003cp\u003e\u003cb\u003eWhen\u003c/b\u003e: Sunday, 3 p.m. ET\u003c/p\u003e\u003cp\u003e\u003cb\u003eWhere\u003c/b\u003e: Richmond Raceway\u003c/p\u003e\u003cp\u003e\u003cb\u003eTV\u003c/b\u003e: USA\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch2\u003eResponsible Gambling\u003cbr/\u003e\u003cbr/\u003e\u003c/h2\u003e\u003cp\u003e\u003ci\u003e Always gamble responsibly. All licensed and legal operators in the United States have resources available to bettors, including educational guides on how to spot problem gaming, links to support services and tools to self-exclude for a set period of time. Support is available at the \u003c/i\u003e\u003ci\u003eNational Council on Problem Gaming\u003c/i\u003e\u003ci\u003e, \u003c/i\u003e\u003ci\u003e1-800-GAMBLER\u003c/i\u003e\u003ci\u003e and \u003c/i\u003e\u003ci\u003eAmerican Addiction Centers.\u003c/i\u003e\u003ci\u003e Be sure to only wager on gambling sites that are licensed and regulated by the gaming regulatory body in your state. That ensures games are fair, bets are honored, customers’ funds are secure and that there are legal protections for the consumer.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003e Sports betting and gambling are not legal in all locations. Be sure to comply with laws applicable where you reside.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:277444713% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/277667193",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy David Caraviello\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:gamblingmc@gdcgroup.com\"\u003egamblingmc@gdcgroup.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eBookies.com\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "From Our Partners",
+      "lead_media": {
+        "id": "277667543",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/1rky20/picture277667543",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "USATSI_20378615.jpg",
+        "publication": "mcclatchy-partners",
+        "layout_option": "",
+        "home": "/web/v1/sections/87287",
+        "modified_date": 1690377752,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1690377752,
+        "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/1rky20/picture277667543/alternates/FREE_1140/USATSI_20378615.jpg",
+        "href": "/web/v1/content/277667543",
+        "additional_sections": [
+          "87287"
+        ],
+        "credit": "USA TODAY Sports",
+        "dateline": "",
+        "caption": "Overall view of Richmond Raceway from the  Toyota Owners 400 earlier this year.",
+        "photographer": "John David Mercer",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "mcclatchypartners",
+      "allow_comments": false,
+      "disable_amp": true,
+      "topic_tags": []
+    },
+    {
+      "id": "277669278",
+      "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/article277669278.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "2023 3M Open Odds \u0026 PGA Picks: Best Bets at TPC Twin Cities",
+      "publication": "mcclatchy-partners",
+      "layout_option": "none",
+      "home": "/web/v1/sections/87287",
+      "home_section": {
+        "name": "Betting",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/"
+      },
+      "modified_date": 1690383600,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "2023 3M Open Odds \u0026 PGA Picks: Best Bets at TPC Twin Cities",
+      "originating_url": "https://www.rotowire.com/golf/article/2023-3m-open-betting-picks-odds-predictions-and-best-bets-73570",
+      "meta_description": "Check out the best 2023 3M odds you should back with our PGA picks, expert betting tips and best bets for this week’s tournament at TPC Twin Cities.",
+      "published_date": 1690383600,
+      "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/p8u7vo/picture277669258/alternates/FREE_1140/USATSI_21062006.jpg",
+      "authors": [
+        {
+          "name": "Ryan Pohle",
+          "email": "Gambling.com"
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "87287",
+        "88698"
+      ],
+      "credit": "Rotowire",
+      "dateline": "",
+      "summary": "Check out the best 2023 3M odds you should back with our PGA picks, expert betting tips and best bets for this week’s tournament at TPC Twin Cities.",
+      "content": "\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e\u003cp\u003eThe PGA Tour heads back stateside for the fifth installment of the 3M Open at TPC Twin Cities in Blaine, Minnesota.\u003c/p\u003e\u003cp\u003eFollowing a pair of events in Europe -- including an Open Championship that Brian Harman ran away with -- many of the Tour’s best players will rest for the final two weeks of the regular season to prepare for the FedExCup Playoffs. This week’s field is headlined by a trio of co-favorites -- Tony Finau, Sungjae Im and Cameron Young -- at 16-1 odds. Last year, tournament favorite Finau -- at 12-1 -- defeated Im and Emiliano Grillo by three shots and notched his third PGA Tour victory.\u003c/p\u003e\u003ch2\u003e2023 3M Open Betting Tips\u003c/h2\u003e\u003ch3\u003eCourse Characteristics\u003c/h3\u003e\u003cp\u003e\u003ci\u003ePar 71, 7,431 yards\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eAverage Strokes Gained Rankings: All 3M Open Champions\u003c/i\u003e\u003c/p\u003e\u003cul\u003e\u003cli\u003eSG: Off-the-Tee: \u003cb\u003e29.0\u003c/b\u003e\u003c/li\u003e\u003cli\u003eSG: Approach: \u003cb\u003e7.0\u003c/b\u003e\u003c/li\u003e\u003cli\u003eSG: Around-the-Green: \u003cb\u003e30.8\u003c/b\u003e\u003c/li\u003e\u003cli\u003eSG: Putting: \u003cb\u003e22.0\u003c/b\u003e\u003c/li\u003e\u003cli\u003eSG: Tee-to-Green: \u003cb\u003e11.3\u003c/b\u003e\u003c/li\u003e\u003cli\u003eDriving Distance: \u003cb\u003e23.5\u003c/b\u003e\u003c/li\u003e\u003cli\u003eDriving Accuracy: \u003cb\u003e28.0\u003c/b\u003e\u003c/li\u003e\u003c/ul\u003e\u003cp\u003eUnlike most courses in this part of the country, water is abundant and comes into play on 13 holes, which can lead to high scores. There are plenty of birdies to be had if you can avoid the wet stuff -- particularly if the wind doesn’t kick up -- and the winning score has ranged from 15- to 21-under-par. \u003c/p\u003e\u003cp\u003eAlthough the rough isn’t penal, accuracy off the tee will be important to avoid the water hazards. Approach play looks to be the key statistic, with the winner ranking fourth or better in three of the four years this tournament has been held. We’re looking for players with quality all-around games and also targeting those who fare well in the 150-200 yard range, with a lot of approach shots coming from that distance. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch3\u003eMarvelous in Minnesota\u003c/h3\u003e\u003cp\u003eThe following five golfers, with a minimum of eight rounds played, have the lowest scoring average at TPC Twin Cities.\u003c/p\u003e\u003cul\u003e\u003cli\u003eSungjae Im: 67.5\u003c/li\u003e\u003cli\u003eTony Finau: 67.7\u003c/li\u003e\u003cli\u003eEmiliano Grillo: 68.3\u003c/li\u003e\u003cli\u003eAdam Hadwin: 68.5\u003c/li\u003e\u003cli\u003eAdam Long: 68.8\u003c/li\u003e\u003c/ul\u003e\u003cp\u003eThis will be Im’s third trip to the Twin Cities, and in addition to his T2 last year he finished in a share of 15th in 2019. Following a consistent start to the year in which he posted five top-10s by the beginning of May, Im has failed to record one since. He showed some signs of life at Royal Liverpool with a T20, and he will look to carry the momentum into this week from his perch atop the betting board. \u003c/p\u003e\u003cp\u003eAlso in a bit of a funk is the defending champion, Finau. Since winning in Mexico at the end of April he has failed to record a top-20, and he enters having missed consecutive cuts for the first time in over two years. Nevertheless, Finau has historically played well in the Midwest and in these lesser events, so this is a great spot for him to get back on track.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877363% --\u003e\u003c/p\u003e\u003ch3\u003eThe Proper Approach\u003c/h3\u003e\u003cp\u003eThese players, on a per-round basis, gained the most strokes on approach over their last 20 rounds.\u003c/p\u003e\u003cul\u003e\u003cli\u003eMark Hubbard: 1.17\u003c/li\u003e\u003cli\u003eHideki Matsuyama: 1.08\u003c/li\u003e\u003cli\u003eLucas Glover: 0.96\u003c/li\u003e\u003cli\u003eChez Reavie: 0.95\u003c/li\u003e\u003cli\u003eAaron Rai: 0.87\u003c/li\u003e\u003c/ul\u003e\u003cp\u003eHubbard continues to be one of the best iron players on Tour, ranking 13th in SG: Approach this season. He’s heated up this summer, posting four top-10s over his last seven events. Hubbard finished T16 in his lone appearance here in 2021, and at 55-1, he seems to be slightly overlooked by the oddsmakers. \u003c/p\u003e\u003cp\u003ePriced just slightly better at 45-1 is Rai, who will making his first appearance here. His strengths -- driving accuracy and iron play -- should make him a solid course fit. He ranked top-5 in SG: Approach in two of his last four tournaments and notched a top-10 in both. If his irons are true this week, he could contend for his first PGA Tour win.\u003c/p\u003e\u003ch2\u003e2023 3M Open Best Bets\u003c/h2\u003e\u003ch3\u003eOutright Picks\u003c/h3\u003e\u003cp\u003e\u003cb\u003eSepp Straka\u003c/b\u003e\u003cb\u003e (22-1)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eBettors often don’t like taking a golfer who won recently, but we did watch Finau go back-to-back in the Midwest last year. Straka followed up his win at the John Deere Classic with a T2 at The Open, and sometimes you just have to ride the wave. He was second in SG: Approach last week, and we know he’s capable of getting hot and going low. \u003c/p\u003e\u003cp\u003e\u003cb\u003eSahith Theegala\u003c/b\u003e\u003cb\u003e (45-1)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eTheegala missed both cuts in Europe -- only his second and third of the season -- and will welcome a return to the United States. While he hasn’t stood out this summer, he still has one of the best short games on Tour and seven top-10s this season. He’s one of the best players among those who have not won and should leave that group soon.\u003c/p\u003e\u003cp\u003e\u003cb\u003eLucas Glover\u003c/b\u003e\u003cb\u003e (45-1)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eSpeaking of going with the hot hand, Glover has stormed to life this month after an uninspiring start to the year. He found something with the flat stick in Detroit and managed his third straight top-10 last week despite losing strokes on the greens. He also has a top-10 in this event.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877383% --\u003e\u003c/p\u003e\u003ch3\u003eTop-10 Wagers\u003c/h3\u003e\u003cp\u003e\u003cb\u003eVincent Norrman\u003c/b\u003e\u003cb\u003e (11-2)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eAfter hitting a top-10 bet with Young last week, I’ll try to keep rolling with Norrman, who picked up his first PGA Tour win two weeks ago at the Barbasol Championship. The 25-year-old rookie is an impressive 13th in Birdie or Better Percentage and sixth in eagles made this season. He has quietly put together seven top-25 finishes over a 13-start span.\u003c/p\u003e\u003cp\u003e\u003cb\u003ePeter Kuest\u003c/b\u003e\u003cb\u003e (9-1)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eThe 25-year-old’s rise from Monday qualifiers to Special Temporary Membership has been quick and impressive. He posted a top-5 at the Rocket Mortgage Classic earlier this month and already has three top-20s over seven starts. He’s shown excellent length off the tee and is capable of making birdies in bunches.\u003c/p\u003e\u003cp\u003e\u003cb\u003eRyan Gerard\u003c/b\u003e\u003cb\u003e (12-1)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eGerard has notched a couple top-5s, one at another water-filled course in PGA National and the other last week. He’s a solid 67th in SG: Tee-to-Green this season -- not bad for someone who was playing on the PGA Tour Canada at this time last year. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877378% --\u003e\u003c/p\u003e\u003ch3\u003eHead-To-Head Matchups\u003cbr/\u003e\u003cbr/\u003e\u003c/h3\u003e\u003cp\u003e\u003cb\u003eJustin Thomas\u003c/b\u003e\u003cb\u003e (-120)\u003c/b\u003e over Ludvig Aberg\u003c/p\u003e\u003cp\u003eThe last time we saw Thomas shoot a round in the 80s in a major championship, he bounced back with a top-10 at the Travelers the following week. We should see an extremely motivated JT over the next two weeks, as he is trying to secure spots both in the playoffs and on the Ryder Cup team. Aberg has been strong off the tee but shaky with his wedges and in the short game. \u003c/p\u003e\u003cp\u003e\u003cb\u003eStephan Jaeger\u003c/b\u003e\u003cb\u003e (-110)\u003c/b\u003e over Ryan Fox\u003c/p\u003e\u003cp\u003eFox has been solid but unspectacular thus far -- he has made 9-of-10 cuts but doesn’t have a top-10. He’s also very sporadic off the tee, hitting less than half of fairways, and that could get him into trouble here. Jaeger is also a cut-making machine, having played the weekend in 10 straight starts. He posted a top-10 recently at the Deere. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch2\u003eResponsible Gambling\u003cbr/\u003e\u003cbr/\u003e\u003c/h2\u003e\u003cp\u003e\u003ci\u003e Always gamble responsibly. All licensed and legal operators in the United States have resources available to bettors, including educational guides on how to spot problem gaming, links to support services and tools to self-exclude for a set period of time. Support is available at the \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://www.ncpgambling.org/\"\u003e\u003ci\u003eNational Council on Problem Gaming\u003c/i\u003e\u003c/a\u003e\u003ci\u003e, \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://www.1800gambler.net/\"\u003e\u003ci\u003e1-800-GAMBLER\u003c/i\u003e\u003c/a\u003e\u003ci\u003e and \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://americanaddictioncenters.org/\"\u003e\u003ci\u003eAmerican Addiction Centers.\u003c/i\u003e\u003c/a\u003e\u003ci\u003e Be sure to only wager on gambling sites that are licensed and regulated by the gaming regulatory body in your state. That ensures games are fair, bets are honored, customers’ funds are secure and that there are legal protections for the consumer.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003e Sports betting and gambling are not legal in all locations. Be sure to comply with laws applicable where you reside.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:277444783% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/277669278",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Ryan Pohle\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:Gambling.com\"\u003eGambling.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eRotowire\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "From Our Partners",
+      "lead_media": {
+        "id": "277669258",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/p8u7vo/picture277669258",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "USATSI_21062006.jpg",
+        "publication": "mcclatchy-partners",
+        "layout_option": "",
+        "home": "/web/v1/sections/87287",
+        "modified_date": 1690380927,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1690380927,
+        "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/p8u7vo/picture277669258/alternates/FREE_1140/USATSI_21062006.jpg",
+        "href": "/web/v1/content/277669258",
+        "additional_sections": [
+          "87287"
+        ],
+        "credit": "USA TODAY Sports",
+        "dateline": "",
+        "caption": "Tony Finau acknowledges the crowd on the 17th green during the first round of The Open Championship golf tournament at Royal Liverpool.",
+        "photographer": "Kyle Terada",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "mcclatchypartners",
+      "allow_comments": false,
+      "disable_amp": true,
+      "topic_tags": []
+    },
+    {
+      "id": "277520923",
+      "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/article277520923.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "UFC London Best Bets: Picks, Odds, and Predictions",
+      "publication": "mcclatchy-partners",
+      "layout_option": "none",
+      "home": "/web/v1/sections/87287",
+      "home_section": {
+        "name": "Betting",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/"
+      },
+      "modified_date": 1690048800,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "UFC London Best Bets: Picks, Odds, and Predictions",
+      "originating_url": "https://www.rotowire.com/mma/article/ufc-london-best-bets-picks-odds-and-predictions-73427",
+      "meta_description": "The UFC heads to England on Saturday. The main event sees Tom Aspinall make his return from injury against Marcin Tybura at heavyweight.",
+      "published_date": 1690048800,
+      "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/xgt8s5/picture277520553/alternates/FREE_1140/USATSI_14118563.jpg",
+      "authors": [
+        {
+          "name": "Cole Shelton",
+          "email": "Gamblingmc@gdcgroup.com"
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "87287",
+        "88698"
+      ],
+      "credit": "Rotowire.com",
+      "dateline": "",
+      "summary": "The UFC heads to England on Saturday. The main event sees Tom Aspinall make his return from injury against Marcin Tybura at heavyweight.",
+      "content": "\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e\u003cp\u003eThe UFC heads across the pond to London, England on Saturday, July 22 for UFC London. The main event sees Tom Aspinall make his return from injury against Marcin Tybura at heavyweight.\u003c/p\u003e\u003cp\u003eBelow, I’ll share my favorite play, an underdog, a prop, and a two-fighter parlay. All odds are via the DraftKings Sportsbook and are accurate as of the post date of this article.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877378% --\u003e\u003c/p\u003e\u003ch3\u003eUFC London Best Bets\u003c/h3\u003e\u003cp\u003eHere is a recap of this weekend’s UFC London best bets:\u003c/p\u003e\u003cul\u003e\u003cli\u003eJafel Filho (-125)\u003c/li\u003e\u003cli\u003eJai Herbert (+135)\u003c/li\u003e\u003cli\u003eMolly McCann ITD (+130)\u003c/li\u003e\u003cli\u003eTom Aspinall \u0026 Nathaniel Wood parlay (-119)\u003c/li\u003e\u003c/ul\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch3\u003eWeight Class: Flyweight\u003c/h3\u003e\u003cp\u003e\u003cb\u003eJafel Filho\u003c/b\u003e\u003cb\u003e (14-3) vs. \u003c/b\u003e\u003cb\u003eDaniel Barez\u003c/b\u003e\u003cb\u003e (16-5)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eOpening up the card is a flyweight bout, and we like Jafel Filho to get the win over Daniel Barez as the short favorite. Filho was very impressive in his UFC debut despite losing to Muhammad Mokaev by submission late in the fight, as he was arguably winning up until that point. Filho had success with his grappling and nearly forced Mokaev to tap due to a nasty kneebar. \u003c/p\u003e\u003cp\u003eBarez, meanwhile, will be making his UFC debut after winning four straight fights following a loss to Carlos Hernandez on the Contender Series. Barez’s striking defense is a concern, as he is there to be hit, while both Filho and Barez like to wrestle and grapple, which adds some intrigue to this fight.\u003c/p\u003e\u003cp\u003eOn the feet, qw think Filho is the better striker and will be able to land some quality shots. If Filho is on his back, it could be a concern, but he showed off impressive scrambles against Mokaev, which is why we expect him to get out of danger and edge out a decision.\u003c/p\u003e\u003cp\u003e\u003cb\u003eUFC London Best Bet: \u003c/b\u003e\u003cb\u003eJafel Filho\u003c/b\u003e\u003cb\u003e (-125\u003c/b\u003e\u003cb\u003e)\u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877363% --\u003e\u003c/p\u003e\u003ch3\u003eWeight Class: Lightweight\u003c/h3\u003e\u003cp\u003e\u003cb\u003eJai Herbert\u003c/b\u003e\u003cb\u003e (12-4-1) vs. \u003c/b\u003e\u003cb\u003eFares Ziam\u003c/b\u003e\u003cb\u003e (13-4)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eFor our underdog, we’re backing Jai Herbert, as we’re surprised he is the underdog. Frankly, we have yet to be sold on Ziam.\u003c/p\u003e\u003cp\u003eAlthough Herbert is 1-1-1 in his last three, his draw should’ve been a win, as we thought he won despite losing a point. Furthermore, his loss came by KO to Ilia Topuria, who will likely be fighting for the featherweight title sooner rather than later. In that fight, Herbert dropped Topuria and nearly finished him.\u003c/p\u003e\u003cp\u003eZiam, meanwhile, is 3-2 in the UFC but has shown he struggles on the ground, as Terrance McKinney was able to quickly submit him. Although Herbert isn’t known for his grappling and wrestling, it wouldn’t be a surprise to see him take it there.\u003c/p\u003e\u003cp\u003eWe expect this fight to play out primarily on the feet. To me, Herbert is the better striker with more power. This is a coin flip type of fight, so to get plus-money on Herbert -- who also has the grappling edge -- makes this a play for us.\u003c/p\u003e\u003cp\u003e\u003cb\u003eUFC London Best Bet: \u003c/b\u003e\u003cb\u003eJai Herbert\u003c/b\u003e\u003cb\u003e (+135\u003c/b\u003e\u003cb\u003e)\u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877378% --\u003e\u003c/p\u003e\u003ch3\u003eWeight Classes: Women’s Flyweight\u003c/h3\u003e\u003cp\u003e\u003cb\u003eMolly McCann\u003c/b\u003e\u003cb\u003e (13-5) vs. \u003c/b\u003e\u003cb\u003eJulija Stoliarenko\u003c/b\u003e\u003cb\u003e (10-7-1)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eFor some reason, Julija Stoliarenko is moving down to flyweight after fainting on the scales when she tried to make 135 lbs. We think there is a good chance this fight doesn’t happen, as Stoliarenko might miss weight.\u003c/p\u003e\u003cp\u003eBut, if it does happen, we really like Molly McCann to get a stoppage win here, as Stoliarenko will be depleted from the weight cut and already hasn’t been the most durable fighter.\u003c/p\u003e\u003cp\u003eStoliarenko is 1-5 in the UFC and is coming off a first-round TKO loss to Chelsea Chandler. McCann meanwhile, has finished her last two wins and she has a ton of power for flyweight. Although we think McCann gets a TKO win, we’ll play it safe and take McCann by inside the distance here, as we don’t trust Stoliarenko’s weight cut or durability.\u003c/p\u003e\u003cp\u003e\u003cb\u003eUFC London Best Bet: \u003c/b\u003e\u003cb\u003eMolly McCann\u003c/b\u003e\u003cb\u003e to win inside the distance (+130\u003c/b\u003e\u003cb\u003e)\u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:266042956% --\u003e\u003c/p\u003e\u003ch3\u003eWeight Class: Heavyweight and Featherweight\u003c/h3\u003e\u003cp\u003e\u003cb\u003eTom Aspinall\u003c/b\u003e\u003cb\u003e (12-3) vs. \u003c/b\u003e\u003cb\u003eMarcin Tybura\u003c/b\u003e\u003cb\u003e (24-7)\u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003cb\u003eNathaniel Wood\u003c/b\u003e\u003cb\u003e (19-5) vs. \u003c/b\u003e\u003cb\u003eAndre Fili\u003c/b\u003e\u003cb\u003e (22-9)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eFor our parlay, we’re backing Tom Aspinall to beat Marcin Tybura in the main event, as well as Nathaniel Wood to beat Andre Fili at featherweight.\u003c/p\u003e\u003cp\u003eAspinall is coming off a major knee injury last July and is now set for a favorable matchup against Tybura. Tybura is a grinder who will look to push Aspinall up against the fence and try and grind out a decision. However, Aspinall has solid grappling, so we expect him to keep it standing. In the second or third round he’ll land heavy shots to get a TKO win.\u003c/p\u003e\u003cp\u003eThe other leg is Nathaniel Wood looking to build off of his 2-0 featherweight run, as he previously defeated Charles Jourdain and Charles Rosa. Wood is one of the top prospects in the sport, and he gets a big name fight against Fili, who has struggled as of late (1-2 with one No Contest in his last four). We expect Wood to use his wrestling to get Fili on the ground, and on the feet, the Brit is more active, which is why we like him to win a decision.\u003c/p\u003e\u003cp\u003e\u003cb\u003eUFC London Best Bets: \u003c/b\u003e\u003cb\u003eTom Aspinall\u003c/b\u003e\u003cb\u003e \u0026 \u003c/b\u003e\u003cb\u003eNathaniel Wood\u003c/b\u003e\u003cb\u003e parlay (-119\u003c/b\u003e\u003cb\u003e)\u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877383% --\u003e\u003c/p\u003e\u003ch3\u003eResponsible Gambling\u003cbr/\u003e\u003cbr/\u003e\u003c/h3\u003e\u003cp\u003e\u003ci\u003e Always gamble responsibly. All licensed and legal operators in the United States have resources available to bettors, including educational guides on how to spot problem gaming, links to support services and tools to self-exclude for a set period of time. Support is available at the \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://www.ncpgambling.org/\"\u003e\u003ci\u003eNational Council on Problem Gaming\u003c/i\u003e\u003c/a\u003e\u003ci\u003e, \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://www.1800gambler.net/\"\u003e\u003ci\u003e1-800-GAMBLER\u003c/i\u003e\u003c/a\u003e\u003ci\u003e and \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://americanaddictioncenters.org/\"\u003e\u003ci\u003eAmerican Addiction Centers.\u003c/i\u003e\u003c/a\u003e\u003ci\u003e Be sure to only wager on gambling sites that are licensed and regulated by the gaming regulatory body in your state. That ensures games are fair, bets are honored, customers’ funds are secure and that there are legal protections for the consumer.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003e Sports betting and gambling are not legal in all locations. Be sure to comply with laws applicable where you reside.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/277520923",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Cole Shelton\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:Gamblingmc@gdcgroup.com\"\u003eGamblingmc@gdcgroup.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eRotowire.com\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "From Our Partners",
+      "lead_media": {
+        "id": "277520553",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/xgt8s5/picture277520553",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "USATSI_14118563.jpg",
+        "publication": "mcclatchy-partners",
+        "layout_option": "",
+        "home": "/web/v1/sections/87287",
+        "modified_date": 1689905241,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1689905241,
+        "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/xgt8s5/picture277520553/alternates/FREE_1140/USATSI_14118563.jpg",
+        "href": "/web/v1/content/277520553",
+        "additional_sections": [
+          "87287"
+        ],
+        "credit": "USA TODAY Sports",
+        "dateline": "",
+        "caption": "Marcin Tybura  (red gloves) fights Serghei Spivac (blue gloves) during UFC Fight Night in Norfolk, Va. on Feb. 29, 2020.",
+        "photographer": "Peter Casey",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "mcclatchypartners",
+      "allow_comments": false,
+      "disable_amp": true,
+      "topic_tags": []
+    },
+    {
+      "id": "277519508",
+      "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/article277519508.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "NASCAR Pocono Odds, Predictions \u0026 Best Bets for Highpoint.com 400",
+      "publication": "mcclatchy-partners",
+      "layout_option": "none",
+      "home": "/web/v1/sections/87287",
+      "home_section": {
+        "name": "Betting",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/"
+      },
+      "modified_date": 1689980400,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "NASCAR Pocono Odds, Predictions \u0026 Best Bets for Highpoint.com 400",
+      "originating_url": "https://bookies.com/picks/nascar-pocono-odds-predictions-best-bets-for-highpoint-com-400",
+      "meta_description": "Martin Truex Jr. has moved to the top of the championship futures list and opened as the co-favorite to win Sunday’s race at Pocono Raceway.",
+      "published_date": 1689980400,
+      "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/dyfrnj/picture277519438/alternates/FREE_1140/USATSI_21048803.jpg",
+      "authors": [
+        {
+          "name": "David Caraviello",
+          "email": "Gamblingmc@gdcgroup.com"
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "87287",
+        "88698"
+      ],
+      "credit": "Bookies.com",
+      "dateline": "",
+      "summary": "Martin Truex Jr. has moved to the top of the championship futures list and opened as the co-favorite to win Sunday’s race at Pocono Raceway.",
+      "content": "\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003cp\u003eNASCAR bettors are living in the summer of Martin Truex Jr.\u003c/p\u003e\u003cp\u003eThe Joe Gibbs Racing driver scored his third victory in as many months in Monday’s rain-delayed event at New Hampshire, he’s moved to the top of the championship futures list and opened as the co-favorite to win Sunday at Pocono Raceway. \u003c/p\u003e\u003cp\u003eAnd more important for sports bettors, he’s been incredibly reliable as a NASCAR betting option since his Dover victory on May 1, with just a few occasional bobbles over that span.\u003c/p\u003e\u003cp\u003eWe backed Truex as a top-three option at +180 last week in Loudon, and he won the race. We took him top-three at +210 in Nashville, and he finished second. We took him top-five at +400 (yeah, for real) in Sonoma, and he won. \u003c/p\u003e\u003cp\u003eIf there’s been a rub here, it’s the two times we most recently backed Truex to win, at Gateway and Atlanta—in the former, he finished fifth, in the latter he was running near the front before the rain threatened and jumbled everything up.\u003c/p\u003e\u003cp\u003eSo yeah, you’d better believe Truex is in our NASCAR picks portfolio this week at Pocono. He’s been winning races, he has bettors swimming in profit, and his week-to-week consistency has been unparalleled. \u003c/p\u003e\u003cp\u003eSo grab your sunglasses and a frosty beverage, and let the summer of Martin Truex Jr. continue.\u003c/p\u003e\u003ch2\u003eHighpoint.com 400 Odds\u003c/h2\u003e\u003ctable\u003e\u003ctbody\u003e\u003ctr\u003e\u003ctd\u003e\u003cb\u003eDriver\u003c/b\u003e\u003c/td\u003e\u003ctd\u003e\u003cb\u003eWin\u003c/b\u003e\u003c/td\u003e\u003ctd\u003e\u003cb\u003eTop 3\u003c/b\u003e\u003c/td\u003e\u003ctd\u003e\u003cb\u003eTop 5\u003c/b\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eMartin Truex, Jr.\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+550\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+150\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e-135\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eKyle Busch\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+550\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e+150\u003c/td\u003e\u003ctd\u003e\u003cp\u003e-135\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eDenny Hamlin\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+550\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e+150\u003c/td\u003e\u003ctd\u003e\u003cp\u003e-135\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eKyle Larson\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+750\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e+200\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+110\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eWilliam Byron\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+900\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e+250\u003c/td\u003e\u003ctd\u003e+120\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eRyan Blaney\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+1100\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e+300\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+150\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eRoss Chastain\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e+1200\u003c/td\u003e\u003ctd\u003e+350\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+160\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eChase Elliott\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e+1200\u003c/td\u003e\u003ctd\u003e+350\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+160\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003c/tbody\u003e\u003c/table\u003e\u003cp\u003e\u003ci\u003eOdds via DraftKings and current as of publication.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877378% --\u003e\u003c/p\u003e\u003ch2\u003e\u003cspan\u003eHighpoint.com 400 \u003c/span\u003eBetting Tips\u003c/h2\u003e\u003cp\u003ePocono has proven very hit-and-miss for Truex, where he won in 2015 and 2018, and has finished top-10 in four of his last six starts. Among active drivers, the standard-setter in Long Pond has been Denny Hamlin, who leads everyone with six career victories on the high-speed triangle. \u003c/p\u003e\u003cp\u003eHamlin appeared to claim his seventh Pocono victory after crossing the finish line first last season—but he was disqualified by NASCAR because of illegal modifications made to the front of the car. Kyle Busch—also DQ’d last year after a runner-up finish—owns four Pocono victories, the most recent coming in 2021, while the disqualification denied him an 11th top-10 in his last 12 races in Long Pond. \u003c/p\u003e\u003cp\u003eAfter Truex, seven active drivers own one career Pocono win: Kevin Harvick, Ryan Blaney, Alex Bowman, Brad Keseloswki, Chris Buescher, Joey Logano and Chase Elliott. Following Hamlin’s DQ, Elliott was credited with the victory last year despite never leading a lap. In fact, Elliott hasn’t led a lap at Pocono since 2019, and he’s led just one over the past month.\u003c/p\u003e\u003cp\u003eWho might be a potential upset candidate? Buescher pulled at a shocker by winning at Pocono in 2016, but has exactly one top-10 there since. \u003c/p\u003e\u003cp\u003eHis RFK teammate Brad Keselowski, third at Pocono with Penske Racing in 2021, is coming off his two best consecutive weeks of the season with a sixth at Atlanta and a fifth at Loudon (which we snagged at +275). \u003c/p\u003e\u003cp\u003eBubba Wallace has recorded two straight top-10s at Pocono, while Daniel Suarez placed a DQ-aided third a year ago.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877363% --\u003e\u003c/p\u003e\u003ch2\u003e\u003cspan\u003eHighpoint.com 400 \u003c/span\u003eBest Bets\u003c/h2\u003e\u003ch3\u003eKyle Larson to Win\u003c/h3\u003e\u003cp\u003e\u003cb\u003eOdds: \u003c/b\u003e+750\u003cb\u003e \u003c/b\u003eat DraftKings\u003c/p\u003e\u003cp\u003eLarson has recovered from his late-spring slump to post top-10s in five of his last six starts, the exception being the street race in Chicago. He’s led laps the last two weeks, though his strong Atlanta car was swept up in a crash. \u003c/p\u003e\u003cp\u003eLarson has never won at Pocono, but he’s been ninth or better in four straight races there, and twice been a runner-up. He’s also led laps in three of his last five Pocono starts, always a positive sign.\u003c/p\u003e\u003ch3\u003eMartin Truex Jr. Top 3\u003cbr/\u003e\u003cbr/\u003e\u003c/h3\u003e\u003cp\u003e\u003cb\u003eOdds: \u003c/b\u003e+150 at DraftKings\u003c/p\u003e\u003cp\u003eTruex’s 254 laps led at Loudon on Monday was further evidence of the exceptional run he’s been on all summer. No, Pocono isn’t his best track, and yes, it’s been a while since he won at Long Pond, even though his average finish in his last six Pocono races has been 9.1.\u003c/p\u003e\u003cp\u003eTaking Truex as a week-to-week top-three or top-five option has proven profitable, and we’re not stopping now, even if his value isn’t the best.\u003c/p\u003e\u003ch3\u003eBrad Keselowski Top 5\u003c/h3\u003e\u003cp\u003e\u003cb\u003eOdds: \u003c/b\u003e+450 at DraftKings\u003c/p\u003e\u003cp\u003eSpeaking of value, there’s Keselowski, who is in the midst of the best run of his two-year RFK tenure. We’re hesitant to take him as a +3500 long shot to win, given that he complained after his fifth-place result at Loudon that the RFK cars didn’t yet have the speed to compete up front. \u003c/p\u003e\u003cp\u003eBut we like what we’ve seen the past two weeks. And Keselowski feasted on Pocono in his Penske days, ripping off top-10s in 11 of 13 starts at one point.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877383% --\u003e\u003c/p\u003e\u003ch2\u003e\u003cspan\u003eHighpoint.com 400 \u003c/span\u003eTime, Date and TV\u003c/h2\u003e\u003cp\u003e\u003cb\u003eWhen:\u003c/b\u003e Sunday, 2:30 p.m. EDT\u003c/p\u003e\u003cp\u003e\u003cb\u003eWhere: \u003c/b\u003ePocono Raceway, Long Pond, Pa.\u003c/p\u003e\u003cp\u003e\u003cb\u003eTV:\u003c/b\u003e USA\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch2\u003eResponsible Gambling\u003cbr/\u003e\u003cbr/\u003e\u003c/h2\u003e\u003cp\u003e\u003ci\u003e Always gamble responsibly. All licensed and legal operators in the United States have resources available to bettors, including educational guides on how to spot problem gaming, links to support services and tools to self-exclude for a set period of time. Support is available at the \u003c/i\u003e\u003ci\u003eNational Council on Problem Gaming\u003c/i\u003e\u003ci\u003e, \u003c/i\u003e\u003ci\u003e1-800-GAMBLER\u003c/i\u003e\u003ci\u003e and \u003c/i\u003e\u003ci\u003eAmerican Addiction Centers.\u003c/i\u003e\u003ci\u003e Be sure to only wager on gambling sites that are licensed and regulated by the gaming regulatory body in your state. That ensures games are fair, bets are honored, customers’ funds are secure and that there are legal protections for the consumer.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003e Sports betting and gambling are not legal in all locations. Be sure to comply with laws applicable where you reside.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:277444713% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/277519508",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy David Caraviello\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:Gamblingmc@gdcgroup.com\"\u003eGamblingmc@gdcgroup.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eBookies.com\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "From Our Partners",
+      "lead_media": {
+        "id": "277519438",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/dyfrnj/picture277519438",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "USATSI_21048803.jpg",
+        "publication": "mcclatchy-partners",
+        "layout_option": "",
+        "home": "/web/v1/sections/87287",
+        "modified_date": 1689901589,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1689901589,
+        "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/dyfrnj/picture277519438/alternates/FREE_1140/USATSI_21048803.jpg",
+        "href": "/web/v1/content/277519438",
+        "additional_sections": [
+          "87287"
+        ],
+        "credit": "USA TODAY Sports",
+        "dateline": "",
+        "caption": "Martin Truex Jr. (19) celebrates winning the Crayon 301 at New Hampshire Motor Speedway on July 17.",
+        "photographer": "Eric Canha",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "mcclatchypartners",
+      "allow_comments": false,
+      "disable_amp": true,
+      "topic_tags": []
+    },
+    {
+      "id": "277443053",
+      "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/article277443053.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "2023 Open Championship Betting: Picks, Odds, Predictions and Best Bets",
+      "publication": "mcclatchy-partners",
+      "layout_option": "none",
+      "home": "/web/v1/sections/87287",
+      "home_section": {
+        "name": "Betting",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/"
+      },
+      "modified_date": 1689807600,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "2023 Open Championship Betting: Picks, Odds, Predictions and Best Bets",
+      "originating_url": "https://www.rotowire.com/golf/article/2023-open-championship-betting-picks-odds-predictions-and-best-bets-73417",
+      "meta_description": "It’s the 151st edition of The Open Championship and Rory McIlroy is looking to go back-to-back after winning the Genesis Scottish Open last weekend.",
+      "published_date": 1689807600,
+      "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/9i7pns/picture277442578/alternates/FREE_1140/USATSI_21047985.jpg",
+      "authors": [
+        {
+          "name": "Ryan Pohle",
+          "email": "Gamblingmc@gdcgroup.com"
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "87287",
+        "88698"
+      ],
+      "credit": "Gambling.com",
+      "dateline": "",
+      "summary": "It’s the 151st edition of The Open Championship and Rory McIlroy is looking to go back-to-back after winning the Genesis Scottish Open last weekend.",
+      "content": "\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e\u003cp\u003eIt’s time for the final major of the year -- the 151st edition of The Open Championship. The event will be played at Royal Liverpool Golf Club in Hoylake, England for the 13th time, and the first since Rory McIlroy won in 2014. \u003c/p\u003e\u003cp\u003eSpeaking of McIlroy, he’s one of the main storylines this week, as he looks to go back-to-back after posting a birdie on the final two holes to win the Genesis Scottish Open by one shot. He’s the second favorite at 8-1 odds, narrowly behind world No. 1 Scottie Scheffler, who is listed at 7-1. \u003c/p\u003e\u003cp\u003eLast year, Cameron Smith -- at 25-1 -- picked up the first major his career, taking home the Claret Jug with a one-stroke victory over Cameron Young at St Andrews.\u003c/p\u003e\u003cp\u003e\u003ci\u003eAll odds via DraftKings.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877378% --\u003e\u003c/p\u003e\u003ch3\u003e2023 Open Championship Odds \u0026 Best Bets\u003c/h3\u003e\u003ch3\u003eOwning The Open Championship\u003c/h3\u003e\u003cp\u003eThese five golfers, with a minimum of eight rounds played, have the lowest scoring average at the Open Championship since 2017.\u003c/p\u003e\u003cul\u003e\u003cli\u003eViktor Hovland: 68.5\u003c/li\u003e\u003cli\u003eJordan Spieth: 68.7\u003c/li\u003e\u003cli\u003eRory McIlroy: 69.3\u003c/li\u003e\u003cli\u003eTommy Fleetwood: 69.5\u003c/li\u003e\u003cli\u003eTony Finau: 69.7\u003c/li\u003e\u003c/ul\u003e\u003cp\u003eThis will be only the third Open Championship appearance for Hovland, but he’s quickly proven to be a force at the year’s closing major. After finishing T12 in his debut, he faded in the final pairing last year to ultimately finish tied for fourth. He bounced back from a disappointing result at the PGA Championship to win the Memorial two weeks later and looks close to picking up a major trophy in short order. Also faring well in this event is Finau, who has finished no worse than T28 over eight Open appearances, with a solo third in 2019. Something will have to give between that and his recent play, as he has failed to record a top-20 in six starts since winning the Mexico Open. At 60-1 odds, it’s difficult to find a better long shot with a reasonable chance to pull off the win.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch3\u003eDialed In From Distance\u003c/h3\u003e\u003cp\u003eThe following golfers, on a per-round basis, gained the most strokes off the tee and on approach combined over their last 20 rounds.\u003c/p\u003e\u003cul\u003e\u003cli\u003eScottie Scheffler: 3.03\u003c/li\u003e\u003cli\u003eRory McIlroy: 2.07\u003c/li\u003e\u003cli\u003eJon Rahm: 1.67\u003c/li\u003e\u003cli\u003eCollin Morikawa: 1.56\u003c/li\u003e\u003cli\u003ePatrick Cantlay: 1.51\u003c/li\u003e\u003c/ul\u003e\u003cp\u003eIf you’ve been fading Scheffler expecting his run of extraordinary play to come to an end, you’ve been left waiting for quite some time, as he extended his streak of top-5 finishes to seven at last week’s Genesis Scottish Open. He has looked comfortable in his brief experience on links courses, finishing T8 and T21 in his two Open Championship appearances. The only player to appear on both lists is McIlroy, and among the majors, he seems to like the Open setups the best, notching six top-5 results. Coming off a win last week and a win the last time this event was held here, expectations are high as he tries to finally break his nine-year drought without a major. McIlroy’s ball striking is in excellent form, as he ranked top-10 in both Strokes Gained: Off-the-Tee and Approach last week.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877363% --\u003e\u003c/p\u003e\u003ch3\u003eOutright Picks\u003c/h3\u003e\u003cp\u003e\u003cb\u003eJon Rahm\u003c/b\u003e\u003cb\u003e (13-1)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eLike many of the best players in the game, Rahm’s game elevates on the biggest stages. He won two of his last nine majors and has finished top-10 at a 39 percent clip, including a T3 finish at the 2021 Open. His form hasn’t been quite as good as we’re used to, but he does have four wins this year and has rested up for this event. He also had a top-10 at the U.S. Open.\u003c/p\u003e\u003cp\u003e\u003cb\u003eBrooks Koepka\u003c/b\u003e\u003cb\u003e (18-1)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eCan you ever go wrong taking Koepka at a major, especially when you consider he’s won 13.5% of those he has appeared in? In his three majors this year he has gone T2, win and T17, and the last result felt like a disappointment. He played well earlier this month, notching a third-place finish in the LIV Golf event at Valderrama. Sign me up -- especially at odds like this.\u003c/p\u003e\u003cp\u003e\u003cb\u003eCollin Morikawa\u003c/b\u003e\u003cb\u003e (35-1)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eMorikawa is coming off a playoff loss to Rickie Fowler at the Rocket Mortgage Classic in which he finished top-25 in every Strokes Gained category. An all-around game is always useful at Open Championship setups, so it’s no surprise he’s a former champion. He’s too tempting to pass up at this price.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877383% --\u003e\u003c/p\u003e\u003ch3\u003eTop 10 Wagers\u003c/h3\u003e\u003cp\u003e\u003cb\u003eCameron Young\u003c/b\u003e\u003cb\u003e (11-2)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eYoung seems to be an overlooked player this week despite finishing runner-up in his Open Championship debut a year ago. Despite his struggles this spring, he showed well in his last start, holding the 36-hole lead at the John Deere Classic before ultimately finishing T6.\u003c/p\u003e\u003cp\u003e\u003cb\u003eSi Woo Kim\u003c/b\u003e\u003cb\u003e (8-1)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eKim is coming off his best Open championship showing last year, one in which he finished T-15. He has sprung to life occasionally with top-5 finishes in both May and June. His strengths of driving accuracy (seventh) and approach (24th) should set him up for success at Royal Liverpool.\u003c/p\u003e\u003cp\u003e\u003cb\u003eLucas Herbert\u003c/b\u003e\u003cb\u003e (12-1)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eHerbert quietly recorded a pair of top-15s in majors last year -- one of which came at St Andrews -- so he’s not overwhelmed by the added pressure. The Australian has experienced success on links courses, winning the Irish Open and finishing T4 at the Scottish Open in 2021..\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877378% --\u003e\u003c/p\u003e\u003ch3\u003eHead-To-Head Matchups\u003cbr/\u003e\u003cbr/\u003e\u003c/h3\u003e\u003cp\u003e\u003cb\u003eSam Burns\u003c/b\u003e\u003cb\u003e (+100)\u003c/b\u003e over Matt Fitzpatrick\u003c/p\u003e\u003cp\u003eFitzpatrick said recently that he wasn’t in his best form and that the Open is his weakest major. The numbers back that up, as it’s the only major in which he has failed to record a top-10. Meanwhile, Burns has made the cut in both of his Open appearances, and he also posted a top-20 in three of his last five starts.\u003c/p\u003e\u003cp\u003e\u003cb\u003eCorey Conners\u003c/b\u003e\u003cb\u003e (-120)\u003c/b\u003e over Ryan Fox\u003c/p\u003e\u003cp\u003eFox’s results in the Open are mediocre, as he has made four of six cuts with only one finish better than T39. His form is reasonably good, as he posted a top-15 last week. However, Conners also closed with a 66 to notch a top-20 result. Conners is the much better golfer between the two and is only a slight favorite. His ball-striking prowess should come in handy here, and he finished T28 and T15 in his last two Open appearances.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch2\u003eResponsible Gambling\u003cbr/\u003e\u003cbr/\u003e\u003c/h2\u003e\u003cp\u003e\u003ci\u003e Always gamble responsibly. All licensed and legal operators in the United States have resources available to bettors, including educational guides on how to spot problem gaming, links to support services and tools to self-exclude for a set period of time. Support is available at the \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://www.ncpgambling.org/\"\u003e\u003ci\u003eNational Council on Problem Gaming\u003c/i\u003e\u003c/a\u003e\u003ci\u003e, \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://www.1800gambler.net/\"\u003e\u003ci\u003e1-800-GAMBLER\u003c/i\u003e\u003c/a\u003e\u003ci\u003e and \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://americanaddictioncenters.org/\"\u003e\u003ci\u003eAmerican Addiction Centers.\u003c/i\u003e\u003c/a\u003e\u003ci\u003e Be sure to only wager on gambling sites that are licensed and regulated by the gaming regulatory body in your state. That ensures games are fair, bets are honored, customers’ funds are secure and that there are legal protections for the consumer.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003e Sports betting and gambling are not legal in all locations. Be sure to comply with laws applicable where you reside.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/277443053",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Ryan Pohle\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:Gamblingmc@gdcgroup.com\"\u003eGamblingmc@gdcgroup.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eGambling.com\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "From Our Partners",
+      "lead_media": {
+        "id": "277442578",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/9i7pns/picture277442578",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "USATSI_21047985.jpg",
+        "publication": "mcclatchy-partners",
+        "layout_option": "",
+        "home": "/web/v1/sections/87287",
+        "modified_date": 1689718101,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1689718101,
+        "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/9i7pns/picture277442578/alternates/FREE_1140/USATSI_21047985.jpg",
+        "href": "/web/v1/content/277442578",
+        "additional_sections": [
+          "87287"
+        ],
+        "credit": "USA TODAY Sports",
+        "dateline": "",
+        "caption": "Rory McIlroy hits his tee shot on the fourth hole during a practice round of The Open Championship golf tournament at Royal Liverpool on Monday.",
+        "photographer": "Kyle Terada",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "mcclatchypartners",
+      "allow_comments": false,
+      "disable_amp": true,
+      "topic_tags": []
+    },
+    {
+      "id": "277319023",
+      "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/article277319023.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "NASCAR Crayon 301 Predictions: Free Expert Picks \u0026 Best Bets For This Weekend",
+      "publication": "mcclatchy-partners",
+      "layout_option": "none",
+      "home": "/web/v1/sections/87287",
+      "home_section": {
+        "name": "Betting",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/"
+      },
+      "modified_date": 1689444000,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "NASCAR Crayon 301 Predictions: Free Expert Picks \u0026 Best Bets For This Weekend",
+      "originating_url": "https://bookies.com/picks/nascar-crayon-301-predictions-free-expert-picks-best-bets-for-this-weekend",
+      "meta_description": "Defending champion Christopher Bell opened as the NASCAR betting odds favorite for Sunday’s Crayon 301, after blowing out the field to win by over 5 seconds a year ago.",
+      "published_date": 1689444000,
+      "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/16cai/picture277318033/alternates/FREE_1140/USATSI_20868066.jpg",
+      "authors": [
+        {
+          "name": "David Caraviello",
+          "email": "Gamblingmc@gdcgroup.com"
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "87287",
+        "88698"
+      ],
+      "credit": "Gambling.com",
+      "dateline": "",
+      "summary": "Defending champion Christopher Bell opened as the NASCAR betting odds favorite for Sunday’s Crayon 301, after blowing out the field to win by over 5 seconds a year ago.",
+      "content": "\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003cp\u003eHard to believe that you have to venture all the way up to the Granite State to find some vintage NASCAR, but that’s the case. After two races on ovals new to the schedule (Gateway and Nashville), a road course (Sonoma), a first-ever street race (Chicago), and an event on a recently reconfigured tri-oval (Atlanta), drivers will find blessedly few unknowns at New Hampshire Motor Speedway, a layout largely unchanged since its introduction in 1993. \u003c/p\u003e\u003cp\u003eIndeed, the board-flat Magic Mile has long challenged teams with its tight corners and heavy emphasis on car setup. Defending race champion Christopher Bell opened as the NASCAR betting odds favorite for Sunday’s event, after blowing out the field to win by over 5 seconds a year ago. \u003c/p\u003e\u003cp\u003eAs that margin indicates, New Hampshire is a place where teams can hit upon the right combination and totally check out—like Kyle Busch did in winning by 3 seconds in 2017, and Matt Kenseth did in winning by a ridiculous 8.9 seconds in 2015.\u003c/p\u003e\u003cp\u003eAs much as anywhere else, crew chiefs matter at New Hampshire—calling the shots last year (and currently) for Bell is Adam Stevens, who was also atop Busch’s pit box for his dominant Loudon victory in 2017. Having a crew chief who knows how to contend at NHMS is a decided advantage and another factor that bettors should consider when determining NASCAR picks for this weekend in the Granite State.\u003c/p\u003e\u003ch2\u003eCrayon 301 Odds\u003c/h2\u003e\u003ctable\u003e\u003ctbody\u003e\u003ctr\u003e\u003ctd\u003e\u003cb\u003eDriver\u003c/b\u003e\u003c/td\u003e\u003ctd\u003e\u003cb\u003eWin\u003c/b\u003e\u003c/td\u003e\u003ctd\u003e\u003cb\u003eTop 3\u003c/b\u003e\u003c/td\u003e\u003ctd\u003e\u003cb\u003eTop 5\u003c/b\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eChristopher Bell\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+550\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+160\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e-110\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eMartin Truex, Jr.\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+650\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e+180\u003c/td\u003e\u003ctd\u003e\u003cp\u003e-120\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eDenny Hamlin\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+700\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e+200\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+110\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eKyle Larson\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+900\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e+250\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+110\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eKyle Busch\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+900\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e+250\u003c/td\u003e\u003ctd\u003e+110\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eKevin Harvick\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+900\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e+250\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+110\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eChase Elliott\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e+1100\u003c/td\u003e\u003ctd\u003e+300\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+150\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003ctr\u003e\u003ctd\u003e\u003cp\u003eWilliam Byron\u003c/p\u003e\u003c/td\u003e\u003ctd\u003e+1200\u003c/td\u003e\u003ctd\u003e+350\u003c/td\u003e\u003ctd\u003e\u003cp\u003e+200\u003c/p\u003e\u003c/td\u003e\u003c/tr\u003e\u003c/tbody\u003e\u003c/table\u003e\u003cp\u003e\u003ci\u003eOdds via DraftKings and current as of publication.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877378% --\u003e\u003c/p\u003e\u003ch2\u003eCrayon 301 Betting Tips\u003c/h2\u003e\u003cp\u003eKevin Harvick leads all active drivers with four career wins at New Hampshire, the most recent coming in 2019. But the soon-to-be-retired former champion has been in a tailspin the past three weeks, over which his best result is 24th. \u003c/p\u003e\u003cp\u003eOwning three NHMS victories apiece are Busch and Denny Hamlin, the latter of whom owns a series-best average finish of 9.5 at the track, where he’s been top-10 in four straight. Busch meanwhile last won there in 2017 and has crashed out of two of his last three starts at the Magic Mile.\u003c/p\u003e\u003cp\u003eBrad Keselowski and Joey Logano own two New Hampshire wins each—with Keselowski finishing top-10 in seven of his last eight there, including a seventh-place run last season in his current Roush-powered ride. \u003c/p\u003e\u003cp\u003eLogano hasn’t won at New Hampshire since 2014, though he has been top-10 in five of his last six at the track. Owning one NHMS win each are Bell and Aric Almirola, the latter of whom pulled a shocker in a 2021 race that started on a wet track and ended early due to darkness.\u003c/p\u003e\u003cp\u003eAlmirola, whose 2021 victory snapped a 98-race winless streak, is one of few outliers at a technically difficult track that over its history has largely been the domain of serious championship contenders. \u003c/p\u003e\u003cp\u003eThe best driver without a victory there is Martin Truex Jr., who owns an average finish of 11.7 and top-10s in seven of his last eight starts. Chase Elliott, the distant runner-up to Bell last season, has been top-10 in three of his last five. The top longshot candidate might be +2800 Bubba Wallace, who was third a year ago.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877363% --\u003e\u003c/p\u003e\u003ch2\u003eCrayon 301 Best Bets\u003c/h2\u003e\u003ch3\u003eKyle Busch to Win\u003c/h3\u003e\u003cp\u003e\u003cb\u003eOdds: \u003c/b\u003e+900\u003cb\u003e \u003c/b\u003eat DraftKings\u003c/p\u003e\u003cp\u003endeed, it’s been a while since Busch has hoisted the giant live lobster that winners have forced upon them at New Hampshire, but it’s still tough to argue with his recent results: seven consecutive finishes of ninth or better, a span that includes a victory at Gateway and is all the more impressive given the variety of tracks he’s competed on recently. \u003c/p\u003e\u003cp\u003eBusch is also the most technically savvy driver on the circuit, making him a great complement to crew chief Randall Burnett, who claimed a top-10 with Tyler Reddick at Loudon in 2020.\u003c/p\u003e\u003ch3\u003eMartin Truex Jr. Top 3\u003cbr/\u003e\u003cbr/\u003e\u003c/h3\u003e\u003cp\u003e\u003cb\u003eOdds: \u003c/b\u003e+180 at DraftKings\u003c/p\u003e\u003cp\u003eTruex was an absolute beast at Atlanta—until the rain began to loom, and pit stops were knocked off-cycle, and the skies opened. The resulting 29th-place finish was no indication of how well he ran last Sunday, or how well he’s been running since early spring. \u003c/p\u003e\u003cp\u003eTruex led 172 laps and finished fourth in the race claimed by Bell last season at New Hampshire, where he’s been a solid contender for a decade and done everything but win. Crew chief James Small has been on hand for two of Truex’s top-five finishes at Loudon.\u003c/p\u003e\u003ch3\u003eBrad Keselowski Top 5\u003c/h3\u003e\u003cp\u003e\u003cb\u003eOdds: \u003c/b\u003e+275 at DraftKings\u003c/p\u003e\u003cp\u003eMuch like Truex, Keselowski was a force at Atlanta last week until the weather shuffled everything, though he still managed to hang on for a sixth-place finish. It was another sign of progress for a driver still searching for his first win with the team he now co-owns.\u003c/p\u003e\u003cp\u003e New Hampshire, where Keselowski has placed in the top 10 in nearly 70% of his career starts, has long been one of his best tracks. Crew chief Matt McCall guided BK to a seventh-place finish at Loudon last season, and also owns a Granite State top-10 from his time with Jamie McMurray.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877383% --\u003e\u003c/p\u003e\u003ch2\u003e\u003cspan\u003eCrayon 301 \u003c/span\u003eTime, Date and TV\u003c/h2\u003e\u003cp\u003e\u003cb\u003eWhen:\u003c/b\u003e Sunday, 2:30 p.m. EDT\u003c/p\u003e\u003cp\u003e\u003cb\u003eWhere: \u003c/b\u003eNew Hampshire Motor Speedway, Loudon, N.H.\u003c/p\u003e\u003cp\u003e\u003cb\u003eTV:\u003c/b\u003e USA\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch2\u003eResponsible Gambling\u003cbr/\u003e\u003cbr/\u003e\u003c/h2\u003e\u003cp\u003e\u003ci\u003e Always gamble responsibly. All licensed and legal operators in the United States have resources available to bettors, including educational guides on how to spot problem gaming, links to support services and tools to self-exclude for a set period of time. Support is available at the \u003c/i\u003e\u003ci\u003eNational Council on Problem Gaming\u003c/i\u003e\u003ci\u003e, \u003c/i\u003e\u003ci\u003e1-800-GAMBLER\u003c/i\u003e\u003ci\u003e and \u003c/i\u003e\u003ci\u003eAmerican Addiction Centers.\u003c/i\u003e\u003ci\u003e Be sure to only wager on gambling sites that are licensed and regulated by the gaming regulatory body in your state. That ensures games are fair, bets are honored, customers’ funds are secure and that there are legal protections for the consumer.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003e Sports betting and gambling are not legal in all locations. Be sure to comply with laws applicable where you reside.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/277319023",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy David Caraviello\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:Gamblingmc@gdcgroup.com\"\u003eGamblingmc@gdcgroup.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eGambling.com\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "From Our Partners",
+      "lead_media": {
+        "id": "277318033",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/16cai/picture277318033",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "USATSI_20868066.jpg",
+        "publication": "mcclatchy-partners",
+        "layout_option": "",
+        "home": "/web/v1/sections/87287",
+        "modified_date": 1689341130,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1689341130,
+        "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/16cai/picture277318033/alternates/FREE_1140/USATSI_20868066.jpg",
+        "href": "/web/v1/content/277318033",
+        "additional_sections": [
+          "87287"
+        ],
+        "credit": "USA TODAY Sports",
+        "dateline": "",
+        "caption": "Christopher Bell performs a practice lap before qualifications at Sonoma Raceway on June 10.",
+        "photographer": "Stan Szeto",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "mcclatchypartners",
+      "allow_comments": false,
+      "disable_amp": true,
+      "topic_tags": []
+    },
+    {
+      "id": "277287383",
+      "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/article277287383.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "UFC Best Bets: Picks, Odds, and Predictions for UFC Vegas 77",
+      "publication": "mcclatchy-partners",
+      "layout_option": "none",
+      "home": "/web/v1/sections/87287",
+      "home_section": {
+        "name": "Betting",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/"
+      },
+      "modified_date": 1689268800,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "UFC Best Bets: Picks, Odds, and Predictions for UFC Vegas 77",
+      "originating_url": "https://www.rotowire.com/mma/article/ufc-best-bets-picks-odds-and-predictions-for-ufc-vegas-77-73303",
+      "meta_description": "MMA returns to Las Vegas on Saturday for UFC Vegas 77. The main event sees ex-champ Holly Holm take on Mayra Bueno Silva in the women’s bantamweight division.",
+      "published_date": 1689268800,
+      "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/qa8dn0/picture277286688/alternates/FREE_1140/USATSI_20320853.jpg",
+      "authors": [
+        {
+          "name": "Cole Shelton",
+          "email": "Gamblingmc@gdcgroup.com"
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "87287",
+        "88698"
+      ],
+      "credit": "Rotowire.com",
+      "dateline": "",
+      "summary": "MMA returns to Las Vegas on Saturday for UFC Vegas 77. The main event sees ex-champ Holly Holm take on Mayra Bueno Silva in the women’s bantamweight division.",
+      "content": "\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e\u003cp\u003eMMA returns to the UFC Apex in Las Vegas on Saturday, July 15 for UFC Vegas 77. The main event sees former champ Holly Holm take on Mayra Bueno Silva in the women’s bantamweight division.\u003c/p\u003e\u003cp\u003eBelow, I’ll share my favorite play, an underdog, a prop, and a two-fighter parlay. All odds are via the DraftKings Sportsbook and are accurate as of the post date of this article\u003cspan\u003e.\u003c/span\u003e\u003c/p\u003e\u003ch3\u003eUFC Vegas 77 Best Bets\u003c/h3\u003e\u003cp\u003eHere is a recap of this weekend’s UFC Vegas 77 best bets:\u003c/p\u003e\u003cul\u003e\u003cli\u003eHolly Holm (-165)\u003c/li\u003e\u003cli\u003eTerrance McKinney (+115)\u003c/li\u003e\u003cli\u003eNorma Dumont by decision (+110)\u003c/li\u003e\u003cli\u003eEvan Elder \u0026 Viktoriia Dudakova (-103)\u003c/li\u003e\u003c/ul\u003e\u003ch3\u003eWeight Class: Women’s Bantamweight\u003c/h3\u003e\u003cp\u003e\u003cb\u003eHolly Holm\u003c/b\u003e\u003cb\u003e (15-6) vs. \u003c/b\u003e\u003cb\u003eMayra Bueno Silva\u003c/b\u003e\u003cb\u003e (10-2-1)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eIn the main event, we’re backing Holly Holm to get a win over Mayra Bueno Silva. I’ll acknowledge Bueno Silva’s talent, but we just don’t think is a top-three fighter in this division like Holm is.\u003c/p\u003e\u003cp\u003eBueno Silva is coming off two quality submission wins over Lina Lansberg and Stephanie Egger, but those fighters are nowhere near the caliber of Holm. Simply put, we think this is too much, too soon for Bueno Silva.\u003c/p\u003e\u003cp\u003eHolm is arguably the best striker at 135 lbs, while Bueno Silva has a negative striking differential, showing she is there to be hit. Holm has good takedown defense too, so we expect her to keep it standing and piece up Bueno Silva to win a decision. A late TKO is also possible if the Brazilian’s cardio can’t go five rounds.\u003c/p\u003e\u003cp\u003e\u003cb\u003eUFC Vegas 77 Best Bet: \u003c/b\u003e\u003cb\u003eHolly Holm\u003c/b\u003e\u003cb\u003e (-165\u003c/b\u003e\u003cb\u003e)\u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877363% --\u003e\u003c/p\u003e\u003ch3\u003eWeight Class: Lightweight\u003c/h3\u003e\u003cp\u003e\u003cb\u003eTerrance McKinney\u003c/b\u003e\u003cb\u003e (13-5) vs. \u003c/b\u003e\u003cb\u003eNazim Sadykhov\u003c/b\u003e\u003cb\u003e (8-1)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eTerrance McKinney is one of the most dangerous fighters in this division, so we’re surprised he is the betting underdog here against Nazim Sadykhov. \u003c/p\u003e\u003cp\u003eMcKinney is coming off a disappointing KO loss in January, but he told me he switched camps and is now working with Kevin Holland, which is a move we like. Sadykhov, meanwhile, is 1-0 in the UFC, but was down 20-18 to Evan Elder before the fight was stopped due to a cut.\u003c/p\u003e\u003cp\u003eWe wouldn’t be surprised if McKinney wrestled, but to us, we think his striking will be too much for Sadykhov. Look for him to land something big and get a first-round KO, but the safest play is to just take him straight up.\u003c/p\u003e\u003cp\u003e\u003cb\u003eUFC Vegas 77 Best Bet: \u003c/b\u003e\u003cb\u003eTerrance McKinney\u003c/b\u003e\u003cb\u003e (+115\u003c/b\u003e\u003cb\u003e)\u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877378% --\u003e\u003c/p\u003e\u003ch3\u003eWeight Classes: Women’s Featherweight\u003c/h3\u003e\u003cp\u003e\u003cb\u003eNorma Dumont\u003c/b\u003e\u003cb\u003e (9-2) vs. \u003c/b\u003e\u003cb\u003eChelsea Chandler\u003c/b\u003e\u003cb\u003e (5-1)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eNorma Dumont and Chelsea Chandler are both super durable, and this is a fight we expect to go to the distance. However, the “fight to goes the distance” number is pretty steep at -200. To get better value, we’ll take Dumont by decision at plus-money, as we expect her to get the win.\u003c/p\u003e\u003cp\u003eChandler is 1-0 in the UFC, but she beat Julija Stoliarenko, so it is hard to take away much from that fight. Instead, we looked through her earlier fights and found she is extremely durable and hard to get out of there. However, she also is there to be hit.\u003c/p\u003e\u003cp\u003eChandler and Dumont are similar fighters, but we think the Brazilian is the better wrestler and striker, and we expect her to edge out a decision in a competitive fight.\u003c/p\u003e\u003cp\u003e\u003cb\u003eUFC Vegas 77 Best Bet: \u003c/b\u003e\u003cb\u003eNorma Dumont\u003c/b\u003e\u003cb\u003e by decision (+110\u003c/b\u003e\u003cb\u003e)\u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257805393% --\u003e\u003c/p\u003e\u003ch3\u003eWeight Class: Lightweight and Strawweight\u003c/h3\u003e\u003cp\u003e\u003cb\u003eEvan Elder\u003c/b\u003e\u003cb\u003e (7-2) vs. \u003c/b\u003e\u003cb\u003eGenaro Valdez\u003c/b\u003e\u003cb\u003e (10-2)\u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003cb\u003eViktoriia Dudakova\u003c/b\u003e\u003cb\u003e (6-0) vs. \u003c/b\u003e\u003cb\u003eIstela Nunes\u003c/b\u003e\u003cb\u003e (6-4)\u003c/b\u003e\u003c/p\u003e\u003cp\u003eFor my parlay, we’re taking Evan Elder and Viktoriia Dudakova to get their hands raised Saturday.\u003c/p\u003e\u003cp\u003eElder is 0-2 in the UFC, but had he not endured a fight-stopping cut, he was well on his way to beating Nazim Sadykhov. Valdez, meanwhile, is 0-2 with the promotion. He was knocked out by Matt Frevola, in addition to losing to Natan Levy.\u003c/p\u003e\u003cp\u003eWe just don’t trust Valdez’s striking defense and chin, as we expect Elder to land big shots and get a TKO win.\u003c/p\u003e\u003cp\u003eFor the other leg, we’re taking UFC debutant Viktoriia Dudakova, who is 24 and looks to be the real deal. The UFC is high on the Russian, and they are giving her Istela Nunes -- an 0-3 fighter in the UFC who simply hasn’t looked good.\u003c/p\u003e\u003cp\u003eNunes was submitted by Ariane Carnelossi, dropped a decision to Sam Hughes and lost by TKO to Yazmin Jauregui. In this fight, we expect Dudakova to get Nunes down early and sink in a first-round submission, as we don’t think Nunes will have much for Dudakova here.\u003c/p\u003e\u003cp\u003e\u003cb\u003eUFC Vegas 77 Best Bets: \u003c/b\u003e\u003cb\u003eEvan Elder\u003c/b\u003e\u003cb\u003e \u0026 \u003c/b\u003e\u003cb\u003eViktoriia Dudakova\u003c/b\u003e\u003cb\u003e (-103\u003c/b\u003e\u003cb\u003e)\u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257877363% --\u003e\u003c/p\u003e\u003ch3\u003eResponsible Gambling\u003cbr/\u003e\u003cbr/\u003e\u003c/h3\u003e\u003cp\u003e\u003ci\u003e Always gamble responsibly. All licensed and legal operators in the United States have resources available to bettors, including educational guides on how to spot problem gaming, links to support services and tools to self-exclude for a set period of time. Support is available at the \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://www.ncpgambling.org/\"\u003e\u003ci\u003eNational Council on Problem Gaming\u003c/i\u003e\u003c/a\u003e\u003ci\u003e, \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://www.1800gambler.net/\"\u003e\u003ci\u003e1-800-GAMBLER\u003c/i\u003e\u003c/a\u003e\u003ci\u003e and \u003c/i\u003e\u003ca target=\"_blank\" href=\"https://americanaddictioncenters.org/\"\u003e\u003ci\u003eAmerican Addiction Centers.\u003c/i\u003e\u003c/a\u003e\u003ci\u003e Be sure to only wager on gambling sites that are licensed and regulated by the gaming regulatory body in your state. That ensures games are fair, bets are honored, customers’ funds are secure and that there are legal protections for the consumer.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003e Sports betting and gambling are not legal in all locations. Be sure to comply with laws applicable where you reside.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257733543% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/277287383",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Cole Shelton\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:Gamblingmc@gdcgroup.com\"\u003eGamblingmc@gdcgroup.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eRotowire.com\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "From Our Partners",
+      "lead_media": {
+        "id": "277286688",
+        "url": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/qa8dn0/picture277286688",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "USATSI_20320853.jpg",
+        "publication": "mcclatchy-partners",
+        "layout_option": "",
+        "home": "/web/v1/sections/87287",
+        "modified_date": 1689266475,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1689266475,
+        "thumbnail": "https://www.mcclatchy-partners.com/gdc-group/miami/betting/qa8dn0/picture277286688/alternates/FREE_1140/USATSI_20320853.jpg",
+        "href": "/web/v1/content/277286688",
+        "additional_sections": [
+          "87287"
+        ],
+        "credit": "USA TODAY Sports",
+        "dateline": "",
+        "caption": "Holly Holm (red gloves) fights Yana Santos (not pictured) during UFC Fight Night at AT\u0026T Center on March 25.",
+        "photographer": "Aaron Meullion",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "mcclatchypartners",
+      "allow_comments": false,
+      "disable_amp": true,
+      "topic_tags": []
+    }
+  ]
+}

--- a/data/nationalsports.json
+++ b/data/nationalsports.json
@@ -1,0 +1,1580 @@
+{
+  "items": [
+    {
+      "id": "278317263",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278317263.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "McLaurin Praises Rookie Forbes: ‘He’s a Competitor!’",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692220502,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.si.com/nfl/commanders/news/washington-commanders-emmanuel-forbes-terry-mclaurin-training-camp-preseason-baltimore-ravens",
+      "meta_description": "Terry McLaurin is recognizing the work Washington Commanders rookie Emmanuel Forbes is putting in during training camp.",
+      "published_date": 1692219600,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/5ou0py/picture277368838/alternates/FREE_1140/2d7882fc-f063-481c-8894-0c37ac5e65be",
+      "authors": [
+        {
+          "name": "Jeremy Brener",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "89950"
+      ],
+      "credit": "Sports Illustrated Washington Football News, Analysis and More",
+      "dateline": "",
+      "summary": "Terry McLaurin is recognizing the work Washington Commanders rookie Emmanuel Forbes is putting in during training camp.",
+      "content": "\u003cp\u003eWhile Terry McLaurin is the leader of the \u003ca href=\"https://www.si.com/nfl/commanders/news/washington-commanders-training-camp-joint-practice-baltimore-ravens-fight\"\u003eWashington Commanders\u003c/a\u003e offense, first-round rookie cornerback Emmanuel Forbes hopes to emerge as the equivalent on the defense.\u003c/p\u003e\u003cp\u003eMcLaurin, one of the best receivers in the NFL, has recognized the progress Forbes has made in his first training camp.\u003c/p\u003e\u003cp\u003e“He's gotten better each and every day,\" McLaurin said. \"I've always tried to encourage him because he's a guy who really likes to learn. He's a sponge and I don't like to lose reps, so I'm gonna give it to him every time I get the opportunity but he's a competitor as well.\" \u003c/p\u003e\u003cp\u003eThe biggest positive going for Forbes is his playmaking ability. He recorded an NCAA record for pick-sixes with six during his three years at Mississippi State. Forbes may struggle with his size (6-0, 166 pounds), but he has NFL-like tendencies that the \u003ca href=\"https://www.si.com/nfl/commanders/news/washington-commanders-baltimore-ravens-daron-payne-lamar-jackson-joint-practices-training-camp\"\u003eCommanders\u003c/a\u003e hope will translate on the professional level.\u003c/p\u003e\u003cp\u003e\"You could tell he's learning from Kendall and being more patient and understanding route concepts and we're gonna need that,\" McLaurin said. \"And I think one thing that's a strength of his is his ball skills. So, you could definitely see he's getting his hand more on balls from interceptions and PBUs [pass breakups] which on defense, I know they're emphasizing that.”\u003c/p\u003e\u003cp\u003eForbes recorded a tackle in the \u003ca href=\"https://www.si.com/nfl/commanders/news/washington-commanders-terry-mclaurin-sam-howell-building-trust-training-camp-baltimore-ravens\"\u003eCommanders\u003c/a\u003e' 17-15 win against the Cleveland Browns, but he's getting far more burn in practice going against McLaurin every day.\u003c/p\u003e\u003cp\u003eOn Monday night, Forbes should have the opportunity to line up against Baltimore Ravens receivers Odell Beckham Jr. and fellow rookie Zay Flowers when the Commanders host them at FedEx Field. Kickoff is scheduled for 8 p.m.\u003c/p\u003e\u003chr/\u003e\u003cp\u003e\u003cstrong\u003e\u003cem\u003eFollow \u003ca href=\"https://twitter.com/JeremyBrener\"\u003eJeremy Brener on Twitter\u003c/a\u003e\u003c/em\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003cstrong\u003e\u003cem\u003eWant the latest in breaking news and insider information on the \u003ca href=\"https://www.si.com/nfl/team/washington-football\"\u003eWashington Commanders\u003c/a\u003e? \u003ca href=\"https://www.si.com/nfl/commanders/\"\u003eClick Here\u003c/a\u003e.\u003c/em\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003cstrong\u003e\u003cem\u003eFollow Commander Country on \u003ca href=\"https://twitter.com/CommandersFN\"\u003eTwitter\u003c/a\u003e.\u003c/em\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003cstrong\u003e\u003cem\u003eWant even more Washington Commanders news? \u003ca href=\"https://www.si.com/nfl/team/washington-football\"\u003eCheck out the SI.com team page here\u003c/a\u003e.\u003c/em\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eCopyright ABG-SI LLC. SPORTS ILLUSTRATED is a registered trademark of ABG-SI LLC. All Rights Reserved.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278317263",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Jeremy Brener\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eSports Illustrated Washington Football News, Analysis and More\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Terry McLaurin is recognizing the work Washington Commanders rookie Emmanuel Forbes is putting in during training camp.",
+      "lead_media": {
+        "id": "277368838",
+        "url": "https://www.mcclatchy-wires.com/incoming/5ou0py/picture277368838",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "2d7882fc-f063-481c-8894-0c37ac5e65be",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692220436,
+        "expires": 1693429200,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1689524382,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/5ou0py/picture277368838/alternates/FREE_1140/2d7882fc-f063-481c-8894-0c37ac5e65be",
+        "href": "/web/v1/content/277368838",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "SI Washington Football Team",
+      "copyright": "SI Washington Football Team",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278317213",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278317213.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Lakers News: Critic Has Harsh Words For LA Hall Of Famer’s Latest Post-NBA Job",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692220444,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.si.com/nba/lakers/news/critic-has-harsh-words-for-la-hall-of-famers-latest-post-nba-job-ak1987",
+      "meta_description": "No punches were pulled in this assessment.",
+      "published_date": 1692219600,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/7rpwpa/picture274634111/alternates/FREE_1140/7a37e1c4-9ac5-4252-ab30-9dfe7b32a8e5",
+      "authors": [
+        {
+          "name": "Alex Kirschenbaum",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "88873"
+      ],
+      "credit": "All Lakers | News, Rumors, Videos, Schedule, Roster, Salaries And More",
+      "dateline": "",
+      "summary": "No punches were pulled in this assessment.",
+      "content": "\u003cp\u003eHall of Fame Los Angeles Lakers center Shaquille O'Neal has been moonlighting as a DJ in his spare time for decades. Per \u003ca href=\"https://www.mercurynews.com/2023/08/12/nba-star-shaquille-oneal-shoots-and-misses-with-dj-set-at-outside-lands/\"\u003eJim Harrington of The Mercury News\u003c/a\u003e, the 7'1\" superstar may have been better as a rapper.\u003c/p\u003e\u003cp\u003eFollowing a densely populated set at Chicago's Lollapalooza, O'Neal submitted an encore performance on Friday, August 11th at the Outside Lands music festival in San Francisco's Golden Gate Park, which Harrington attended.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278275893% --\u003e\u003c/p\u003e\u003cblockquote\u003e\u003cp\u003e“Shaquille O’Neal is better at shooting free throws than he is at DJing,” Harrington wrote. “And for those who didn’t follow his Basketball Hall of Fame career, the big guy was certainly no Steph Curry when it came to the stripe.\"\u003c/p\u003e\u003c/blockquote\u003e\u003cblockquote\u003e\u003cp\u003e“O’Neal’s grooves were weak, mismatching his samples and sounds in ways that were rarely compelling,\" Harrington continued. \"His reliance on big beats was more tiring than inspiring. And he truly seemed at a loss on how to command a crowd, instead settling for what appeared to be an attempt at setting a new world record for repeating the phrase ‘hands up’ the most times in a single performance.\u003c/p\u003e\u003c/blockquote\u003e\u003cp\u003eAt another point in the review, Harrington mistakenly claims that The Big Diesel only won three championships between his tenures with the Lakers and Miami Heat. He won three in a row just with Los Angeles, from 2000-2002, and may well have won a fourth in 2004 had Karl Malone been healthy and O'Neal and Kobe Bryant not hated each other. Following an offseason trade to the Heat, O'Neal teamed up with another Hall of Fame shooting guard, Dwyane Wade, and soon won his \u003cem\u003efourth\u003c/em\u003e and final championship, in 2006.\u003c/p\u003e\u003cp\u003e\u003cem\u003eAre you following us on \u003c/em\u003e\u003cem\u003e\u003ca href=\"https://twitter.com/thelakers248\"\u003eTwitter\u003c/a\u003e\u003c/em\u003e\u003cem\u003e, \u003c/em\u003e\u003cem\u003e\u003ca href=\"https://www.facebook.com/groups/lakers248\"\u003eFacebook\u003c/a\u003e\u003c/em\u003e\u003cem\u003e, or \u003c/em\u003e\u003cem\u003e\u003ca href=\"https://www.youtube.com/@Lakers248/videos\"\u003eYouTube\u003c/a\u003e\u003c/em\u003e\u003cem\u003e yet? Join the conversation as we discuss the latest Lakers news and rumors with fans like you!\u003c/em\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eCopyright ABG-SI LLC. SPORTS ILLUSTRATED is a registered trademark of ABG-SI LLC. All Rights Reserved.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278317213",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Alex Kirschenbaum\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eAll Lakers | News, Rumors, Videos, Schedule, Roster, Salaries And More\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "No punches were pulled in this assessment.",
+      "lead_media": {
+        "id": "274634111",
+        "url": "https://www.mcclatchy-wires.com/incoming/7rpwpa/picture274634111",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "7a37e1c4-9ac5-4252-ab30-9dfe7b32a8e5",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692220375,
+        "expires": 1693429200,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1682285700,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/7rpwpa/picture274634111/alternates/FREE_1140/7a37e1c4-9ac5-4252-ab30-9dfe7b32a8e5",
+        "href": "/web/v1/content/274634111",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "SI Los Angeles Lakers",
+      "copyright": "SI Los Angeles Lakers",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278317208",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278317208.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Tom Allen Says Indiana Kickers ‘Not to our Standard,’ Nico Radicic Returning From Injury",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692220442,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.si.com/college/indiana/football/indiana-football-kickers-havent-met-tom-allen-standard-nico-radicic-returning-from-injury",
+      "meta_description": "Tom Allen was disappointed in the showing from Indiana kickers Chris Freeman and Alejandro Quintero during Saturday's scrimmage, and he expects freshman Nico Radicic to compete for the starting job after missing recent practices due to injury.",
+      "published_date": 1692218582,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/ckfgdo/picture278316913/alternates/FREE_1140/a41966b3-9f00-47d6-9327-8c2eb864d24b",
+      "authors": [
+        {
+          "name": "Jack Ankony",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "88918"
+      ],
+      "credit": "Sports Illustrated Indiana Hoosiers News, Analysis and More",
+      "dateline": "",
+      "summary": "Tom Allen was disappointed in the showing from Indiana kickers Chris Freeman and Alejandro Quintero during Saturday's scrimmage, and he expects freshman Nico Radicic to compete for the starting job after missing recent practices due to injury.",
+      "content": "\u003cp\u003eBLOOMINGTON, Ind. – Included on the long list of position battles throughout the Indiana football roster are the kickers.\u003c/p\u003e\u003cp\u003eTrue freshman Nico Radicic did not participate in Saturday's scrimmage – Tom Allen said he was \"nursing something\" – which left Chris Freeman and Alejandro Quintero as the remaining kickers. Both attempted field goals and extra points, but Allen walked away unsatisfied.\u003c/p\u003e\u003cp\u003e\"I did not feel like we got what we wanted out of [the kickers] on Saturday,\" Allen said at Wednesday's press conference. \"That's an area that's definitely an area of emphasis for us right now ... Not to our standard this past weekend. Those guys know that.\"\u003c/p\u003e\u003cp\u003eCharles Campbell was a reliable field goal and extra-point kicker for the Hoosiers in each of the last three seasons, but he transfered to Tennessee following the 2022 campaign. Campbell's five field goals of 50-plus yards rank second in program history, and he went 39-for-51 on field goals while never missing an extra point.\u003c/p\u003e\u003cp\u003eSo far, it's been a struggle to replace his steady leg. \u003c/p\u003e\u003cp\u003eIndiana brought in Radicic this offseason, and he's long felt like the logical replacement for Campbell. Out of Coppell, Texas, Radicic was tabbed a five-star prospect and the No. 4 kicker in the nation among 2023 recruits, per \u003ca href=\"https://www.si.com/college/indiana/football/five-star-texas-kicker-nicolas-radicic-commits-to-indiana-football-program\"\u003eKohl's Professional Camps\u003c/a\u003e. He was one of two kickers chosen to play in the 2023 All-American Bowl, along with Illinois' David Olano.\u003c/p\u003e\u003cp\u003e\"He once again showed that he is one of the more pure ball strikers in his class,\" \u003ca href=\"https://www.kohlskicking.com/national-player-ratings/kickers/2023\"\u003eKohl's Professional Camps wrote about Radicic.\u003c/a\u003e \"His timing and athleticism allow him to maximize his energy into the football and create great hang-time and distance in all three disciplines. Radicic was one of the top performers during the 2021 Kohl's Winter Ranking camps. He hit multiple field goals that are at the college level and also demonstrated that he has the leg strength on punts to be a great combo specialist. Radicic has the talent to play in college at the Power Five level!\"\u003c/p\u003e\u003cp\u003eBut to due to his inconsistent availability in practice, Radicic hasn't yet separated himself in the kicking competition. Indiana has given opportunities to Freeman and Quintero, but neither has taken advantage. They both lack experience, too.\u003c/p\u003e\u003cp\u003eFreeman has been in the program since the 2020 season, but he's primarily been utilized as a kickoff specialist. After a redshirt year in 2020, Freeman performed four kickoffs in 2021 and made both extra-point attempts against Idaho. He handled kickoff duties in all 12 games in 2022, but he hasn't attempted a field goal in his collegiate career.\u003c/p\u003e\u003cp\u003eQuintero, listed as a punter on the roster, joined the Hoosiers before the 2022 season after beginning his career at Blinn College in Bryan, Texas. He appeared in one game for the Hoosiers, sending a kickoff through the end zone for a touchback against Idaho.\u003c/p\u003e\u003cp\u003eAllen expects the kicking competition to ramp up this week as Radicic returns to action.\u003c/p\u003e\u003cp\u003e\"[Radicic has] been slowly brought back this week, so he should be fully kicking tomorrow,\" Allen said Wednesday. \"So it will be a chance to get a better evaluation, and I expect him to step up and compete ... I'm excited to get Nico back in that competition and see how he responds.\"\u003c/p\u003e\u003ch2\u003eRelated stories on Indiana football\u003c/h2\u003e\u003cul\u003e\u003cli\u003e\u003cstrong\u003eHOOSIERS SEEING O-LINE IMPROVEMENTS:\u003c/strong\u003e After an embarrassing performance in the 2022 season, Tom Allen hired Bob Bostad to fix the Indiana offensive line, and everyone from the running backs to other position coaches are already seeing the change they wanted. \u003cstrong\u003e\u003ca href=\"https://www.si.com/college/indiana/football/indiana-football-running-backs-coaches-seeing-offensive-line-improvements-in-fall-camp\"\u003eCLICK HERE\u003c/a\u003e\u003c/strong\u003e\u003c/li\u003e\u003cli\u003e\u003cstrong\u003eWHAT CHRISTIAN TURNER BRINGS TO IU: \u003c/strong\u003eThere's almost no one on the Hoosiers' entire roster with as much experience as Wake Forest transfer Christian Turner, and he's ready to round out a versatile Indiana running back trio in 2023.\u003cstrong\u003e\u003ca href=\"https://www.si.com/college/indiana/football/christian-turner-dynamic-indiana-running-back-trio-jaylin-lucas-josh-henderson\"\u003eCLICK HERE\u003c/a\u003e\u003c/strong\u003e\u003c/li\u003e\u003cli\u003e\u003cstrong\u003eJAYLIN LUCAS ON 'FREAKS' LIST: \u003c/strong\u003eIndiana running back Jaylin Lucas had a breakout freshman season in 2022, and for his efforts, he's received national recognition. On Tuesday, he was listed by The Athletic's Bruce Feldman as one of the 101 \"College Football Freaks\" for the 2023 season. \u003ca href=\"https://www.si.com/college/indiana/football/jaylin-lucas-bruce-feldman-college-football-freaks-list-2023-indiana-football\"\u003e\u003cstrong\u003eCLICK HERE\u003c/strong\u003e\u003c/a\u003e\u003c/li\u003e\u003cli\u003e\u003cstrong\u003eMEMORIAL STADIUM MODERNIZATION:\u003c/strong\u003e Indiana University has partnered with Nations Group to evaluate opportunities for renovating Memorial Stadium. Per release, IU stakeholders will receive a secure, online survey soliciting feedback on a wide array of topics related to modernizing the facility and the game day experience. \u003ca href=\"https://www.si.com/college/indiana/football/indiana-university-examining-options-to-modernize-memorial-stadium\"\u003e\u003cstrong\u003eCLICK HERE\u003c/strong\u003e\u003c/a\u003e\u003c/li\u003e\u003c/ul\u003e\u003cp\u003e\u003ci\u003eCopyright ABG-SI LLC. SPORTS ILLUSTRATED is a registered trademark of ABG-SI LLC. All Rights Reserved.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278317208",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Jack Ankony\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eSports Illustrated Indiana Hoosiers News, Analysis and More\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Tom Allen was disappointed in the showing from Indiana kickers Chris Freeman and Alejandro Quintero during Saturday’s scrimmage, and he expects freshman Nico Radicic to compete for the starting job after missing recent practices due to injury.",
+      "lead_media": {
+        "id": "278316913",
+        "url": "https://www.mcclatchy-wires.com/incoming/ckfgdo/picture278316913",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "a41966b3-9f00-47d6-9327-8c2eb864d24b",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692220405,
+        "expires": 1693428182,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692218582,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/ckfgdo/picture278316913/alternates/FREE_1140/a41966b3-9f00-47d6-9327-8c2eb864d24b",
+        "href": "/web/v1/content/278316913",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "SI Indiana Hoosiers",
+      "copyright": "SI Indiana Hoosiers",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278317178",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278317178.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Oklahoma WR gaining more confidence with each big play",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692220385,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.si.com/college/oklahoma/football/oklahoma-wr-gaining-more-confidence-with-each-big-play",
+      "meta_description": "Michigan transfer Anthony will help stretch opposing defenses for Sooners",
+      "published_date": 1692219600,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/e5opvg/picture278289823/alternates/FREE_1140/d7230aa3-e05f-4cda-af17-53cdbaa91490",
+      "authors": [
+        {
+          "name": "Tim Willert",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "88903"
+      ],
+      "credit": "Sports Illustrated Oklahoma Sooners News, Analysis and More",
+      "dateline": "",
+      "summary": "Michigan transfer Anthony will help stretch opposing defenses for Sooners",
+      "content": "\u003cp\u003eIn a room full of talented pass catchers, Oklahoma junior \u003cstrong\u003eAndrel Anthony\u003c/strong\u003e is creating separation.\u003c/p\u003e\u003cp\u003eAnthony, a speedy transfer from Michigan who enrolled at OU in January, turned heads in the Sooners' first scrimmage with two long touchdowns.\u003c/p\u003e\u003cp\u003e“He’s done well. Had some big plays in the scrimmage,\" head coach \u003cstrong\u003eBrent Venables\u003c/strong\u003e said Monday after practice. \"Another big play out here today (at practice). He’s gaining more and more confidence every day that he practices.\"\u003c/p\u003e\u003cp\u003eAnthony made some big plays during his time at Michigan, where he played in 26 of 28 games over two seasons and caught  19 passes for 328 yards and three touchdowns. \u003c/p\u003e\u003cp\u003eHis first career reception went for 93 yards and a touchdown against Michigan State in 2021, the second-longest passing play from scrimmage in school history.\u003c/p\u003e\u003cp\u003eThat season he also recovered a fumble in the end zone for a TD against Nebraska and caught a 35-yard touchdown pass against Georgia in the CFP Semifinal at the Capital One Orange Bowl.\u003c/p\u003e\u003cp\u003eAnthony said competing for a national championship \"really set the standard of where I want to be at every year.\"\u003c/p\u003e\u003cp\u003e\"The coaches and the players, they really emphasize that,\" he said. \"Yeah, we want to win the Big 12 and we want to go to the playoffs, and me knowing how good that feels to be in Miami, to be in that situation, it's amazing.\u003c/p\u003e\u003cp\u003e\"To be able to compete for, to go to the national championship, I want to do that every year, so that's why I'm here.\"\u003c/p\u003e\u003cp\u003eAnthony said he's grown more comfortable with the offense and quarterback \u003cstrong\u003eDillon Gabriel \u003c/strong\u003eduring fall camp. \u003c/p\u003e\u003cp\u003e\"It's definitely progressed a lot over the summer,\" he said of his relationship with Gabriel, \"just those player-led (practices), those workouts. \"We'll do stuff on the weekends, after practice. It's just the timing and all that is really coming together right now.\"\u003c/p\u003e\u003cp\u003eAsked about his big showing at Saturday's scrimmage, Anthony gave Gabriel all the credit.\u003c/p\u003e\u003cp\u003e\"Well, I'd just say that the quarterback play really played a big factor into it, just because the balls were like ... you couldn't ask for a better pass,\" he said. \"That's going to be huge moving forward. I'd say I give credit mostly to the quarterback, because I might have a step, but he'll put it to where only I can get it. I can't ask for anything else.\"\u003c/p\u003e\u003cp\u003eAnthony is also becoming better acquainted with receivers \u003cstrong\u003eJaquaize Pettaway\u003c/strong\u003e, a freshman, and \u003cstrong\u003eBrenen Thompson\u003c/strong\u003e, a sophomore transfer from Texas. The trio of newcomers is looking to play significant minutes this season in offensive coordinator \u003cstrong\u003eJeff Lebby's\u003c/strong\u003e fast-paced system.\u003c/p\u003e\u003cp\u003e\"I hang out with Brenen all the time and Jaquaize, he's funny. We all get along pretty well,\" Anthony said. \"It's funny because they were both stressing over the playbook, as I was, too, when I got here in the spring. I was telling them 'just view it bit by bit every day and soon you'll tie in that this goes with this, (that) this is the same play but the slot (receiver) is different. It's just being ... not stressing out about it and just knowing that in time it will come.\"\u003c/p\u003e\u003cp\u003eAnthony said OU's receiving corps -- a mix of size and speed and experience -- is going to be special.\u003c/p\u003e\u003cp\u003e\"I'm excited about everybody in the room because since I've been here, I've seen the growth that everybody's had, and it's like ... wow! I know we're going to be special.\"\u003c/p\u003e\u003chr/\u003e\u003cul\u003e\u003cli\u003e\u003cem\u003e\u003ca href=\"https://www.si.com/signup/fannation2?sitekeyword=oklahoma\"\u003e\u003cstrong\u003eSign up\u003c/strong\u003e\u003c/a\u003e for your premium membership to \u003ca href=\"http://allsooners.com/\"\u003e\u003cstrong\u003eAllSooners.com\u003c/strong\u003e\u003c/a\u003e today, and get access to the entire Fan Nation premium network\u003c/em\u003e\u003cem\u003e!\u003c/em\u003e\u003c/li\u003e\u003cli\u003e\u003cem\u003e\u003ca href=\"https://twitter.com/All_Sooners\"\u003e\u003cstrong\u003eFollow AllSooners on Twitter\u003c/strong\u003e\u003c/a\u003e to stay up to date on all the latest OU news!\u003c/em\u003e\u003c/li\u003e\u003cli\u003e\u003cstrong\u003e\u003cem\u003eWant even more Sooners news? \u003c/em\u003e\u003c/strong\u003e\u003cstrong\u003e\u003cem\u003e\u003ca href=\"https://www.si.com/college/college-football/team/oklahoma-sooners\"\u003eCheck out the SI.com OU team page here\u003c/a\u003e!\u003c/em\u003e\u003c/strong\u003e\u003c/li\u003e\u003cli\u003e\u003cem\u003e\u003ca href=\"https://podcasts.apple.com/us/podcast/the-allsooners-podcast/id1523115354\"\u003e\u003cstrong\u003eListen and subscribe\u003c/strong\u003e\u003c/a\u003eto the AllSooners Podcast!\u003c/em\u003e\u003c/li\u003e\u003cli\u003e\u003cem\u003e\u003ca href=\"https://www.youtube.com/channel/UCwXnvq499WdjNAANFeduX_A\"\u003e\u003cstrong\u003eWatch more Sooners videos and subscribe\u003c/strong\u003e\u003c/a\u003eon YouTube!\u003c/em\u003e\u003c/li\u003e\u003c/ul\u003e\u003cp\u003e\u003ci\u003eCopyright ABG-SI LLC. SPORTS ILLUSTRATED is a registered trademark of ABG-SI LLC. All Rights Reserved.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278317178",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Tim Willert\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eSports Illustrated Oklahoma Sooners News, Analysis and More\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Michigan transfer Anthony will help stretch opposing defenses for Sooners",
+      "lead_media": {
+        "id": "278289823",
+        "url": "https://www.mcclatchy-wires.com/incoming/e5opvg/picture278289823",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "d7230aa3-e05f-4cda-af17-53cdbaa91490",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692220371,
+        "expires": 1693429200,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692150409,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/e5opvg/picture278289823/alternates/FREE_1140/d7230aa3-e05f-4cda-af17-53cdbaa91490",
+        "href": "/web/v1/content/278289823",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "SI Oklahoma Sooners",
+      "copyright": "SI Oklahoma Sooners",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278317168",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278317168.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "WATCH: This Is The Strangest Michigan vs. Ohio State Preview You’ll Ever See",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692220384,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.si.com/college/michigan/football/michigan-wolverines-ohio-state-buckeyes-big-ten-football-jim-harbaugh-urban-meyer-the-game",
+      "meta_description": "While there's typically no shortage of pregame hype videos that surface prior to a rivalry game between Michigan and Ohio State, this particular previewing 'The Game' is likely one of the weirdest videos you'll ever see.",
+      "published_date": 1692219260,
+      "thumbnail": "",
+      "authors": [
+        {
+          "name": "Christopher Breiler",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "88948"
+      ],
+      "credit": "Sports Illustrated Michigan Wolverines News, Analysis and More",
+      "dateline": "",
+      "summary": "While there's typically no shortage of pregame hype videos that surface prior to a rivalry game between Michigan and Ohio State, this particular previewing 'The Game' is likely one of the weirdest videos you'll ever see.",
+      "content": "\u003cp\u003eIt's no secret that the internet is home to some of the weirdest things out there. From TikTok to YouTube influencers, folks can easily find themselves tumbling down a strange rabbit hole when mindlessly browsing through content. That is particularly true when it comes to a video that recently surfaced highlighting what looks like the 2016 matchup between Michigan and Ohio State. \u003c/p\u003e\u003cp\u003eAs for the game itself, the 2016 matchup was one of the most closely contested games between No. 3 Michigan and No. 2 Ohio State. The Wolverines held a 10-7 lead at halftime, but the Buckeyes returned the favor in the second half by outscoring Michigan 10-7 - forcing what would be an epic (\u003ca href=\"https://www.youtube.com/watch?v=LM_OPM3QRu0\"\u003eand controversial\u003c/a\u003e) overtime battle between the two rivals. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:262461372; alt=\"michigan-ohio-state-6227.jpg\"% --\u003e\u003c/p\u003e\u003cp\u003eIt would take two overtime periods to settle things between Michigan and Ohio State, and the Buckeyes would ultimately escape with a 30-27 victory. \u003c/p\u003e\u003cp\u003eWhile there's typically no shortage of pregame hype videos that surface prior to a rivalry game between Michigan and Ohio State, the video previewing 'The Game' below is likely one of the weirdest videos you'll ever see. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278317138% --\u003e\u003c/p\u003e\u003cp\u003eThe animated video begins with a Michigan and Ohio State player repeatedly kicking each other in the groin, and then quickly transitions into what appears to be ESPN Gameday commentator Lee Corso gasping for air with an oxygen mask while a panda dances in the background...and it only gets more bizarre from there. \u003c/p\u003e\u003cp\u003eI'm not sure where the video came from or who created it, but now that I've seen it, you have to see it too. \u003c/p\u003e\u003cp\u003eEnjoy. \u003c/p\u003e\u003cp\u003e\u003ci\u003eCopyright ABG-SI LLC. SPORTS ILLUSTRATED is a registered trademark of ABG-SI LLC. All Rights Reserved.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278317168",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Christopher Breiler\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eSports Illustrated Michigan Wolverines News, Analysis and More\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "While there’s typically no shortage of pregame hype videos that surface prior to a rivalry game between Michigan and Ohio State, this particular previewing ‘The Game’ is likely one of the weirdest videos you’ll ever see.",
+      "owner": "SI Michigan Wolverines",
+      "copyright": "SI Michigan Wolverines",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278317088",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278317088.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Ian Machado Garry promises UFC 292 finish of Neil Magny in ‘beautiful, spectacular fashion’",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692220262,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://mmajunkie.usatoday.com/2023/08/ufc-292-ian-machado-garry-promises-spectacular-finish-neil-magny",
+      "meta_description": "Whether it was Geoff Neal or now Neil Magny, Ian Machado Garry expects to put on a show at UFC 292.",
+      "published_date": 1692219640,
+      "thumbnail": "",
+      "authors": [
+        {
+          "name": "Simon Samano and Danny Segura",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87713"
+      ],
+      "credit": "MMA Junkie",
+      "dateline": "",
+      "summary": "Whether it was Geoff Neal or now Neil Magny, Ian Machado Garry expects to put on a show at UFC 292.",
+      "content": "\u003cp\u003eBOSTON – Pardon Ian Machado Garry, but he’s a little pissed off heading into \u003ca href=\"https://mmajunkie.usatoday.com/events/ufc-292-sterling-vs-omalley\"\u003eUFC 292\u003c/a\u003e.\u003c/p\u003e\u003cp\u003eGarry was supposed to fight Geoff Neal, who’s No. 8 in the official UFC welterweight rankings, on Saturday at TD Garden, but \u003ca href=\"https://mmajunkie.usatoday.com/2023/08/ufc-292-geoff-neal-out-of-ufc-292-fight-vs-ian-machado-garry-boston-health-issues\"\u003eNeal withdrew last week\u003c/a\u003e, so instead he’s facing another Neil (different spelling) in No. 11 Neil Magny.\u003c/p\u003e\u003cp\u003eIt’s funny how things work out – because \u003ca href=\"https://mmajunkie.usatoday.com/2023/05/ufc-on-abc-4-ian-machado-garry-calls-out-neil-magny-perfect-opponent-after-daniel-rodriguez-tko\"\u003eMagny (28-10 MMA, 21-9 UFC) is who No. 13 Garry originally wanted\u003c/a\u003e. But undefeated Garry (12-0 MMA, 5-0 UFC) was hyped about the chance to make an even bigger splash against a higher ranked opponent in Neal.\u003c/p\u003e\u003cp\u003eGarry’s anger and frustration heading into UFC 292, he said, is really for the fans more than himself.\u003c/p\u003e\u003cp\u003e“This is the thing with the fight game: It’s infuriating at times,” Garry told MMA Junkie and other reporters of Neal’s pullout. “… It’s part of the fight game. It’s infuriating, it’s upsetting for the fans, because the fans buy into something, and then it doesn’t happen.\u003c/p\u003e\u003cp\u003e“Look, I’m upset with the change of opponent, because I wanted to finish Geoff Neal the way I knew I was gonna finish him. I feel like the fans deserve that finish. Now I’ve got another guy, No. 11 in the world. I’m still gonna go out there and finish him and still do it in a beautiful, spectacular fashion. But I feel like the fans are being robbed of something that they were excited about.”\u003c/p\u003e\u003cp\u003eThose are the words you’d expect from a fighter who’s declared that he’s carrying the UFC 292 pay-per-view card on his back.\u003c/p\u003e\u003cp\u003eSo whether it was Neal or Neil, it doesn’t matter to him.\u003c/p\u003e\u003cp\u003e“They’re both irrelevant at the end of the day,” Garry said. “The fact that I’m in that octagon is what’s exciting.”\u003c/p\u003e\u003cp\u003eThat proclamation checks out, for the most part, with Garry off to a 5-0 start in his UFC tenure. He most recently earned a Performance of the Night bonus for his \u003ca href=\"https://mmajunkie.usatoday.com/2023/05/ufc-on-abc-4-results-ian-machado-garry-first-round-head-kick-tko-daniel-rodriguez\"\u003efirst-round TKO win over Daniel Rodriguez\u003c/a\u003e this past May at UFC on ABC 4.\u003c/p\u003e\u003cp\u003eGarry’s attitude heading into UFC 292 is simple: He’s unbeatable if he fights his fight.\u003c/p\u003e\u003cp\u003e“You’ve just got to operate in full faith, do you, and let the world work itself around you,” Garry said. “At the end of the day, all I have to do is show up. It doesn’t matter who is in that octagon against me or where it is. As long as I show up and do what I do best, there’s no one that can beat me.”\u003c/p\u003e\u003cp\u003e\u003cem\u003eFor more on the card, visit MMA Junkie’s event hub for \u003ca href=\"https://mmajunkie.usatoday.com/events/ufc-292\" target=\"blank\" rel=\"noopener\"\u003eUFC 292\u003c/a\u003e.\u003c/em\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eCopyright 2023 MMA Junkie. All rights reserved.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278317088",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Simon Samano and Danny Segura\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eMMA Junkie\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Whether it was Geoff Neal or now Neil Magny, Ian Machado Garry expects to put on a show at UFC 292.",
+      "owner": "MMA Junkie",
+      "copyright": "MMA Junkie",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278317038",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278317038.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "76ers Player Reacts to James Harden Blasting Daryl Morey",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692220203,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.si.com/nba/clippers/news/76ers-player-reacts-to-james-harden-blasting-daryl-morey",
+      "meta_description": "Philadelphia 76ers guard Patrick Beverley sees both sides of James Harden vs. Daryl Morey",
+      "published_date": 1692218932,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/2avu1v/picture278316948/alternates/FREE_1140/8fb6faf8-01cc-4ff7-9b2e-0b04d8352d24",
+      "authors": [
+        {
+          "name": "Joey Linn",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "88878"
+      ],
+      "credit": "Sports Illustrated LA Clippers News, Analysis and More",
+      "dateline": "",
+      "summary": "Philadelphia 76ers guard Patrick Beverley sees both sides of James Harden vs. Daryl Morey",
+      "content": "\u003cp\u003eHaving recently signed with the Philadelphia 76ers, veteran guard Patrick Beverley now finds himself in a unique position. Getting his start in the NBA with the Houston Rockets, Beverley has a strong relationship with both James Harden and Daryl Morey. With the two now going through a messy public breakup while Harden pushes for a trade to the LA Clippers, Beverley addressed the situation on the latest episode of his podcast.\u003c/p\u003e\u003cp\u003e\"I obviously understand both sides,\" Beverley said. \"I understand James's side, obviously the window of making a ton off money in this league for a long period of time, that window is very small.\"\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278316943% --\u003e\u003c/p\u003e\u003cp\u003eBeverley continued by saying that Harden is entitled to feel any way he wants if he's been promised certain things, and added that he is one of the most talented players ever, and has adapted his game to become Philadelphia's point guard. \u003c/p\u003e\u003cp\u003eAs for Morey's side of this situation, Beverley said, \"His job is to get the best product for as cheap as possible. So you know, that's his job... That's the name of the game. You're a GM, you're a president, you're trying to get a bunch of great product for as least as possible.\"\u003c/p\u003e\u003cp\u003eBeverley didn't take a side in this situation, but acknowledged the unfortunate nature of what has occurred, especially for somebody like himself who has a strong relationship with Harden and Morey.\u003c/p\u003e\u003ch2\u003eRelated Articles\u003c/h2\u003e\u003cp\u003e\u003ca href=\"https://www.si.com/nba/clippers/news/kevin-durant-gets-honest-about-russell-westbrooks-impact\"\u003eKevin Durant Gets Honest About Russell Westbrook's Impact\u003c/a\u003e\u003c/p\u003e\u003cp\u003e\u003ca href=\"https://www.si.com/nba/clippers/news/paul-george-reveals-conversation-with-kawhi-leonard-after-devastating-injury\"\u003ePaul George Reveals Conversation With Kawhi Leonard After Devastating Injury\u003c/a\u003e\u003c/p\u003e\u003cp\u003e\u003ca href=\"https://www.si.com/nba/clippers/news/massive-paul-george-damian-lillard-knicks-three-team-trade-idea\"\u003eMassive Paul George, Damian Lillard, Knicks Trade Idea\u003c/a\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eCopyright ABG-SI LLC. SPORTS ILLUSTRATED is a registered trademark of ABG-SI LLC. All Rights Reserved.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278317038",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Joey Linn\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eSports Illustrated LA Clippers News, Analysis and More\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Philadelphia 76ers guard Patrick Beverley sees both sides of James Harden vs. Daryl Morey",
+      "lead_media": {
+        "id": "278316948",
+        "url": "https://www.mcclatchy-wires.com/incoming/2avu1v/picture278316948",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "8fb6faf8-01cc-4ff7-9b2e-0b04d8352d24",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692220134,
+        "expires": 1693428532,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692218932,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/2avu1v/picture278316948/alternates/FREE_1140/8fb6faf8-01cc-4ff7-9b2e-0b04d8352d24",
+        "href": "/web/v1/content/278316948",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "SI Los Angeles Clippers",
+      "copyright": "SI Los Angeles Clippers",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278316728",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278316728.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "UFC 292 ‘Embedded,’ No. 3: The Serra-Longo band is back together",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692219842,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://mmajunkie.usatoday.com/2023/08/ufc-292-embedded-no-3-the-serra-longo-band-is-back-together",
+      "meta_description": "In the latest UFC 292 \"Embedded,\" Chris Weidman touches down in Boston for his first fight week since that gruesome broken leg.",
+      "published_date": 1692219017,
+      "thumbnail": "",
+      "authors": [
+        {
+          "name": "MMA Junkie Staff",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87713"
+      ],
+      "credit": "MMA Junkie",
+      "dateline": "",
+      "summary": "In the latest UFC 292 \"Embedded,\" Chris Weidman touches down in Boston for his first fight week since that gruesome broken leg.",
+      "content": "\u003cp\u003eThe UFC is back with its 10th pay-per-view of the year, which means the popular “Embedded” fight-week video series is here to document what’s happening behind the scenes.\u003c/p\u003e\u003cp\u003e\u003ca href=\"https://mmajunkie.usatoday.com/events/ufc-fight-night-august-12\"\u003eUFC 292\u003c/a\u003e takes place Saturday at TD Garden in Boston. The main card airs on pay-per-view following prelims on ESPN and early prelims on ESPN+.\u003c/p\u003e\u003cp\u003eIn the main event, bantamweight champion Aljamain Sterling (23-3 MMA, 15-3 UFC) takes on challenger Sean O’Malley (16-1 MMA, 8-1 UFC). Sterling holds the UFC record for most consecutive title defenses at 135 pounds. In the co-feature, women’s strawweight champ Zhang Weili (23-3 MMA, 7-2 UFC) meets challenger Amanda Lemos (13-2-1 MMA, 7-2 UFC) in the first test of her second reign as titleholder.\u003c/p\u003e\u003cp\u003eIn addition, former middleweight champ Chris Weidman (15-6 MMA, 11-6 UFC) returns from more than two years out after a severe broken leg in 2021. He takes on Brad Tavares (19-9 MMA, 14-8 UFC) in a featured bout on the prelims.\u003c/p\u003e\u003cp\u003eThe third episode of “Embedded” follows the featured fighters while they get ready for fight week. Here is the UFC’s description of the episode from YouTube:\u003c/p\u003e\u003cblockquote\u003e\u003cp\u003eChito Vera, Chris Weidman and Ian Garry Machado arrive in Boston. Sean O’Malley and Amanda Lemos sharpen their mental games. Champs Zhang Weili and Aljamain Sterling dive into fight week.\u003c/p\u003e\u003c/blockquote\u003e\u003cp\u003eAlso see:\u003c/p\u003e\u003cul\u003e\u003cli\u003e\u003ca href=\"https://mmajunkie.usatoday.com/2023/08/ufc-292-embedded-preview-video-boston-sean-omalley-lamborghini-channing-tatum-aljamain-sterling\" target=\"blank\" rel=\"noopener\"\u003eUFC 292 ‘Embedded,’ No. 1: Like Channing Tatum in ’22 Jump Street,’ Sean O’Malley livin’ that Lambo life\u003c/a\u003e\u003c/li\u003e\u003cli\u003e\u003ca href=\"https://mmajunkie.usatoday.com/2023/08/ufc-292-embedded-no-2-marlon-vera-boston-celtics-green-jersey-shoes-packing\"\u003eUFC 292 ‘Embedded,’ No. 2: Overpacker Marlon Vera breaks out the Celtic green\u003c/a\u003e\u003c/li\u003e\u003c/ul\u003e\u003cp\u003e\u003cem\u003eFor more on the card, visit MMA Junkie’s event hub for \u003ca href=\"https://mmajunkie.usatoday.com/tag/ufc-292\" target=\"blank\" rel=\"noopener\"\u003eUFC 292\u003c/a\u003e.\u003c/em\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eCopyright 2023 MMA Junkie. All rights reserved.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278316728",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy MMA Junkie Staff\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eMMA Junkie\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "In the latest UFC 292 “Embedded,” Chris Weidman touches down in Boston for his first fight week since that gruesome broken leg.",
+      "owner": "MMA Junkie",
+      "copyright": "MMA Junkie",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278316558",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278316558.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Saints-Chargers: One Thing to Watch From Each Team",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692219601,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.si.com/nfl/saints/editorial-opinion/saints-chargers-one-thing-to-watch",
+      "meta_description": "There is plenty to watch when the Saints take on the Chargers this week, but here's one thing for each team that caught the attention of an NFL.com writer.",
+      "published_date": 1692217546,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/dgmo5h/picture278316433/alternates/FREE_1140/d10455d5-6cd8-4bee-8a5b-53d897b45d92",
+      "authors": [
+        {
+          "name": "Bob Rose",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87452"
+      ],
+      "credit": "Sports Illustrated New Orleans Saints News, Analysis and More",
+      "dateline": "",
+      "summary": "There is plenty to watch when the Saints take on the Chargers this week, but here's one thing for each team that caught the attention of an NFL.com writer.",
+      "content": "\u003cp\u003eThe New Orleans Saints play their second preseason game this Sunday when they play at the Los Angeles Chargers. Before that kicks off, the Saints and Chargers will engage of two days of scrimmages against each other Thursday and Friday. \u003c/p\u003e\u003cp\u003eThere will be plenty to watch during those three days of action for the Saints, who defeated the Chiefs in their opener last week. NFL.com writer Eric Edholm highlights one area from each team that he'll be watching in this weekend's games. This is what he had to say about the Saints-Chargers matchup. \u003c/p\u003e\u003ch2\u003eSAINTS\u003c/h2\u003e\u003cp\u003eThe Saints already know they’ll be without \u003ca href=\"https://www.nfl.com/players/alvin-kamara/\"\u003eAlvin Kamara\u003c/a\u003e for the first three regular-season games, so the news that rookie RB \u003ca href=\"https://www.nfl.com/players/kendre-miller/\"\u003eKendre Miller\u003c/a\u003e suffered a knee injury against the Chiefs didn’t come at the best time. Miller’s injury isn’t believed to be major, so that’s the silver lining. But it likely will leave New Orleans a bit shorthanded for the final two preseason games, starting Sunday against the Chargers. \u003ca href=\"https://www.nfl.com/players/jamaal-williams/\"\u003eJamaal Williams\u003c/a\u003e is the starter, but ideally, they wouldn’t use him much before the regular season behind. Converted WR \u003ca href=\"https://www.nfl.com/players/kirk-merritt/\"\u003eKirk Merritt\u003c/a\u003e is also banged up, so he’s a question mark, leaving undrafted rookie \u003ca href=\"https://www.nfl.com/players/ellis-merriweather/stats/situational/1958/\"\u003eEllis Merriweather\u003c/a\u003e and recently signed \u003ca href=\"https://www.nfl.com/players/darrel-williams/\"\u003eDarrel Williams\u003c/a\u003e as the slack picker-uppers. Merriweather looked good against the Chiefs and might be closer to making the opening roster than many might realize.\u003c/p\u003e\u003ch2\u003eCHARGERS\u003c/h2\u003e\u003cp\u003eWhat do we make of first-rounder \u003ca href=\"https://www.nfl.com/players/quentin-johnston/\"\u003eQuentin Johnston\u003c/a\u003e’s drops? He had two passes slip through his hands against the Rams last weekend, atoning with a pretty TD grab that could have foreshadowed some red-zone work in the regular season. But he also hasn’t consistently caught the ball in camp practices, according to media reports. If Johnston’s drops continue, would he earn the trust of QB \u003ca href=\"https://www.nfl.com/players/justin-herbert/\"\u003eJustin Herbert\u003c/a\u003e and offensive coordinator Kellen Moore? After all, Johnston was credited with eight drops on 97 targets last season with TCU, and he had a few big ones at his pro day, suggesting an issue that has yet to be rectified. All eyes will be on Johnston -- and his hands -- Sunday against the Saints to see if that worry continues. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278316423; alt=\"c5f01a51-2980-4a90-b9c3-3d9e7edf0cb6\"% --\u003e\u003c/p\u003e\u003cp\u003eWe probably won't see much of Kamara, Williams, or the other projected starters from the Saints against the Chargers. Much of what the coaches will want to accomplish will likely get done during the two days of scrimmages. \u003c/p\u003e\u003cp\u003eMerriweather exhibited power as a runner and solid receiving skills as a receiver last week against the Chiefs. He'll have an opportunity to solidify a backup role with another good performance. Merritt has shown little, some because of his hamstring injury, and needs to put something out there for a chance at a job. \u003c/p\u003e\u003cp\u003eDarrel Williams will see his first action as a Saint after being signed just days ago. The sixth-year veteran and former LSU standout is a terrific receiver and good in space. He'll have an opportunity to solidify depth, crucial with Miller banged up and Kamara missing the first three contests.\u003c/p\u003e\u003cp\u003eWilliams, Merriweather, and possibly Merritt should see the majority of the backfield reps. Just as critical will be the performance of the line in front of them. The starting five did a nice job in their brief appearance against Kansas City. However, the backups were atrocious as run blockers and pass protectors. Rookie Nick Saldiveri and veterans Max Garcia, Calvin Throckmorton, Storm Norton, and Lewis Kidd need to do a better job for their backs and quarterbacks to have any chance to get things done. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278316428; alt=\"10e80c24-ace8-4c22-85b6-23539138f3d1\"% --\u003e\u003c/p\u003e\u003cp\u003eLike the Saints, it'll be a little surprising if the Chargers starters play at all. With one of the league's better passing attacks, QB Justin Herbert, RB Austin Ekeler, and WRs Johnston, Mike Williams, Joshua Palmer, and Keenan Allen present an excellent challenge for an outstanding New Orleans secondary. \u003c/p\u003e\u003cp\u003eMost of this marquee matchup will be seen during the scrimmage sessions. However, the physical L.A. receivers will test an equally physical and athletic set of Saints corners led by Marshon Lattimore. Second-year CB Alontae Taylor, in particular, looks to bounce back after giving up two big plays against the Chiefs. He's in a battle for the Number 2 corner job with Paulson Adebo and both players have had impressive camps.\u003c/p\u003e\u003cp\u003eAdditionally, the Chargers also use their backs as receivers a lot.  This will be a big test for the New Orleans linebackers. Demario Davis may not play. However, newly signed LB Jaylon Smith will see his first action. It's also a great opportunity for D'Marco Jackson, Nephi Sewell, and the other inexperienced linebackers on the roster to make coaches and fans feel better about the depth at this position. \u003c/p\u003e\u003cp\u003e\u003ci\u003eCopyright ABG-SI LLC. SPORTS ILLUSTRATED is a registered trademark of ABG-SI LLC. All Rights Reserved.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278316558",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Bob Rose\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eSports Illustrated New Orleans Saints News, Analysis and More\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "There is plenty to watch when the Saints take on the Chargers this week, but here’s one thing for each team that caught the attention of an NFL.com writer. ",
+      "lead_media": {
+        "id": "278316433",
+        "url": "https://www.mcclatchy-wires.com/incoming/dgmo5h/picture278316433",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "d10455d5-6cd8-4bee-8a5b-53d897b45d92",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692219567,
+        "expires": 1693427146,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692217546,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/dgmo5h/picture278316433/alternates/FREE_1140/d10455d5-6cd8-4bee-8a5b-53d897b45d92",
+        "href": "/web/v1/content/278316433",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "SI New Orleans Saints",
+      "copyright": "SI New Orleans Saints",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278316498",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278316498.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Giles Jackson Could Redshirt the 2023 Season",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692219481,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.si.com/college/washington/football/giles-jackson-could-redshirt-the-2023-season",
+      "meta_description": "Ryan Grubb gave an injury update on the senior receiver.",
+      "published_date": 1692218645,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/8tyms8/picture278316323/alternates/FREE_1140/bb4d467a-4498-4220-84c7-db81bc961ac6",
+      "authors": [
+        {
+          "name": "Roman Tomashoff",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87382"
+      ],
+      "credit": "Sports Illustrated Washington Huskies News, Analysis and More",
+      "dateline": "",
+      "summary": "Ryan Grubb gave an injury update on the senior receiver.",
+      "content": "\u003cp\u003eIt appears the injury bug has claimed its first victim of Washington's fall camp. Following Wednesday's practice, offensive coordinator Ryan Grubb informed the media that wide receiver Giles Jackson injured his thumb and could end up missing the entire 2023 season.\u003c/p\u003e\u003cp\u003eWhen asked about utilizing a medical redshirt for the senior receiver, Grubb said, \"We've got to be totally open to all options.\"\u003c/p\u003e\u003cp\u003eDuring the spring, Kalen DeBoer praised the senior receiver as one of the team's most consistent performers in practice and, if the injury is serious, it could impact Washington's depth at receiver during the season. However, the Huskies are in a better position than most teams to deal with this injury.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278316318% --\u003e\u003c/p\u003e\u003cp\u003eWhile the starting group of Rome Odunze, Jalen McMillan, and Ja'Lynn Polk seems to be solidified, Jackson was playing very well during fall camp and had become a reliable target for freshman quarterback Austin Mack during his time with the second team. In his stead, true freshman Taeshaun Lyons has been taking snaps with the second-team offense.\u003c/p\u003e\u003cp\u003eLyons, a former four-star recruit, struggled with drops during the early portion of fall camp but has made enough progress to earn the trust of the coaching staff. When running with the second team, Lyons has been lining up next to two of fall camp's biggest standouts.\u003c/p\u003e\u003cp\u003eDenzel Boston and Germie Bernard have had as good of a camp as any player on the team and have earned a lot of praise from their teammates. \u003c/p\u003e\u003cp\u003eOdunze called Boston a \"ball hawk\" following Wednesday's practice, and said that the redshirt freshman is \"able to do everything on the field from underneath to over the top, and he's consistently made those plays during fall camp.\"\u003c/p\u003e\u003chr/\u003e\u003cp\u003e\u003cstrong\u003e\u003cem\u003eGo to \u003c/em\u003e\u003c/strong\u003e\u003ca href=\"https://www.si.com/college/washington/\"\u003e\u003cstrong\u003e\u003cem\u003esi.com/college/washington\u003c/em\u003e\u003c/strong\u003e\u003c/a\u003e\u003cstrong\u003e\u003cem\u003e to read the latest Inside the Huskies stories \u003c/em\u003e— as\u003cem\u003e soon as they’re published.\u003c/em\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003cstrong\u003e\u003cem\u003eNot all stories are posted on the fan sites.\u003c/em\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003cstrong\u003e\u003cem\u003eFind Inside the Huskies on Facebook by searching:\u003c/em\u003e\u003c/strong\u003e\u003ca href=\"https://www.facebook.com/UWFanNation/\"\u003e\u003cstrong\u003e\u003cem\u003eInside Huskies/FanNation at SI.com\u003c/em\u003e\u003c/strong\u003e\u003c/a\u003e\u003cstrong\u003e\u003cem\u003e or \u003c/em\u003e\u003c/strong\u003e\u003ca href=\"https://www.facebook.com/dan.raley.12\"\u003e\u003cstrong\u003e\u003cem\u003ehttps://www.facebook.com/dan.raley.12\u003c/em\u003e\u003c/strong\u003e\u003c/a\u003e\u003c/p\u003e\u003cp\u003e\u003cstrong\u003e\u003cem\u003eFollow Roman Tomashoff of Inside the Huskies on Twitter: \u003c/em\u003e\u003c/strong\u003e\u003ca href=\"https://twitter.com/rtomashoff34\"\u003e\u003cstrong\u003e\u003cem\u003e@rtomashoff34\u003c/em\u003e\u003c/strong\u003e\u003c/a\u003e\u003cstrong\u003e\u003cem\u003e or \u003c/em\u003e\u003c/strong\u003e\u003ca href=\"https://twitter.com/UWFanNation\"\u003e\u003cstrong\u003e\u003cem\u003e@UWFanNation\u003c/em\u003e\u003c/strong\u003e\u003c/a\u003e\u003c/p\u003e\u003cp\u003e\u003cstrong\u003e\u003cem\u003eSubscribe to the Locked On Huskies Podcast \u003c/em\u003e\u003c/strong\u003e\u003ca href=\"https://www.youtube.com/@LockedonHuskies\"\u003e\u003cstrong\u003e\u003cem\u003eon Youtube\u003c/em\u003e\u003c/strong\u003e\u003c/a\u003e\u003cstrong\u003e\u003cem\u003e and wherever you get your podcasts.\u003c/em\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003cstrong\u003e\u003cem\u003eHave a question? Message me on Twitter!\u003c/em\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eCopyright ABG-SI LLC. SPORTS ILLUSTRATED is a registered trademark of ABG-SI LLC. All Rights Reserved.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278316498",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Roman Tomashoff\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eSports Illustrated Washington Huskies News, Analysis and More\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Ryan Grubb gave an injury update on the senior receiver.",
+      "lead_media": {
+        "id": "278316323",
+        "url": "https://www.mcclatchy-wires.com/incoming/8tyms8/picture278316323",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "bb4d467a-4498-4220-84c7-db81bc961ac6",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692219422,
+        "expires": 1693428245,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692218645,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/8tyms8/picture278316323/alternates/FREE_1140/bb4d467a-4498-4220-84c7-db81bc961ac6",
+        "href": "/web/v1/content/278316323",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "SI Washington Huskies",
+      "copyright": "SI Washington Huskies",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278316468",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278316468.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Scarce Crimson Tide Presence on Sports Illustrated Preseason All-American Teams",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692219422,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.si.com/college/alabama/football/scarce-crimson-tide-presence-on-sports-illustrated-preseason-all-american-teams-gaither",
+      "meta_description": "Alabama only places three members on Sports Illustrated's Preseason All-American Team.",
+      "published_date": 1692218413,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/hri35g/picture278316148/alternates/FREE_1140/b20c7c9d-ef74-4236-a94b-f5f6dd641112",
+      "authors": [
+        {
+          "name": "Joe Gaither",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "88953"
+      ],
+      "credit": "Sports Illustrated Alabama Crimson Tide News, Analysis and More",
+      "dateline": "",
+      "summary": "Alabama only places three members on Sports Illustrated's Preseason All-American Team.",
+      "content": "\u003cp\u003eNick Saban can play the disrespect card with his \u003ca href=\"https://www.si.com/college/college-football/team/alabama-crimson-tide\"\u003eAlabama Crimson Tide\u003c/a\u003e program for the first time in several years. \u003c/p\u003e\u003cp\u003eThe program received its lowest preseason ranking in the \u003ca href=\"https://www.si.com/college/alabama/football/where-is-alabama-preseason-ap-top-25\"\u003eAssociated Press preseason poll\u003c/a\u003e this past week since 2009 and despite a roster loaded with talent the Tide only placed three players on the Sports Illustrated Preseason All-American Team. \u003c/p\u003e\u003cp\u003eThe Crimson Tide saw two defenders, Dallas Turner and Kool-Aid McKinstry both named to \u003ca href=\"https://www.si.com/college/2023/08/16/sports-illustrated-2023-preseason-college-football-all-americans\"\u003eSports Illustrated's Preseason All-American First Team\u003c/a\u003e while specialist Will Reichard landed on the Second Team. \u003c/p\u003e\u003cp\u003eThe honor just adds to preseason expectations for the trio as Turner was named to the Phil Steele Preview Second-Team, Athlon Sports Fourth-Team as well as preseason Bednarik and Bronko Nagurski Award watch-list.\u003c/p\u003e\u003cp\u003eMckinstry was named to the Phil Steele Preview First-Team and Athlon Sports First-Team and earned recognition on the Badnarik, Bronko Nagurski, Jim Thorpe, Walter Camp and Lott Impact Award watch list.\u003c/p\u003e\u003cp\u003eReichard is recognized o the Phil Steele Preview and Athlon Sports Fourth-Team, while also earning a place on the Lou Groza Award watch list.\u003c/p\u003e\u003cp\u003eThe Southeastern Conference as a whole saw 13 representatives across the two Sports Illustrated Preseason teams with Georgia tying Alabama with three selections for the most in the conference. LSU, Arkansas each placed two players on the list while Mississippi State, South Carolina and Ole Miss each had one representative.\u003c/p\u003e\u003ch2\u003eSee Also: \u003c/h2\u003e\u003cp\u003e\u003ca href=\"https://www.si.com/college/alabama/football/should-alabama-move-jc-latham-to-left-tackle-on-the-joe-gaither-show-episode-61-aug-16-2023-gaither\"\u003eShould Alabama Move JC Latham to Left Tackle? on The Joe Gaither Show | Episode 61: Aug. 16, 2023\u003c/a\u003e\u003c/p\u003e\u003cp\u003e\u003ca href=\"https://www.si.com/college/alabama/football/nick-saban-emphasizes-desire-for-a-self-motivated-roster-gaither\"\u003eNick Saban Emphasizes Desire For a Self-Motivated Roster\u003c/a\u003e\u003c/p\u003e\u003cp\u003e\u003ca href=\"https://www.si.com/college/alabama/football/what-nick-saban-said-after-alabama-footballs-tuesday-practice-hannon\"\u003eWhat Nick Saban Said After Alabama Football's Tuesday Practice\u003c/a\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eCopyright ABG-SI LLC. SPORTS ILLUSTRATED is a registered trademark of ABG-SI LLC. All Rights Reserved.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278316468",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Joe Gaither\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eSports Illustrated Alabama Crimson Tide News, Analysis and More\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Alabama only places three members on Sports Illustrated’s Preseason All-American Team.",
+      "lead_media": {
+        "id": "278316148",
+        "url": "https://www.mcclatchy-wires.com/incoming/hri35g/picture278316148",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "b20c7c9d-ef74-4236-a94b-f5f6dd641112",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692219357,
+        "expires": 1693428013,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692218413,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/hri35g/picture278316148/alternates/FREE_1140/b20c7c9d-ef74-4236-a94b-f5f6dd641112",
+        "href": "/web/v1/content/278316148",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "SI Alabama Crimson Tide",
+      "copyright": "SI Alabama Crimson Tide",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278316388",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278316388.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Analyzing Day 15 of the 2023 49ers QB Competition",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692219302,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.si.com/nfl/49ers/news/analyzing-day-15-of-the-2023-49ers-qb-competition",
+      "meta_description": "Guess how many interceptions Brock Purdy threw today.",
+      "published_date": 1692217998,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/ov4asx/picture277830658/alternates/FREE_1140/10093686-1868-4bef-a361-16c2ac492b62",
+      "authors": [
+        {
+          "name": "Grant Cohn",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87472"
+      ],
+      "credit": "Sports Illustrated San Francisco 49ers News, Analysis and More",
+      "dateline": "",
+      "summary": "Guess how many interceptions Brock Purdy threw today.",
+      "content": "\u003cp\u003eSANTA CLARA -- Here's what Brock Purdy, Trey Lance and Sam Darnold did on Day 15 of 49ers training camp.\u003c/p\u003e\u003ch3\u003eBROCK PURDY\u003c/h3\u003e\u003cp\u003eCompleted just 11 of 20 pass attempts and threw two interceptions plus a third that was dropped. To be fair, he also threw two beautiful touchdown passes from the 10-yard line -- one to Brandon Aiyuk in the back-left corner of the end zone, and one to Deebo Samuel in the back-right corner of the end zone. But the story for Purdy is the interceptions. He is becoming a walking turnover. Through 12 practices (he took three days off), he has thrown 10 interceptions, 4 pick-6s and 7 dropped picks. Which means he has thrown 17 interceptable passes in 12 days. Not good. Today, he threw a pass directly to backup linebacker Curtis Robinson, who dropped the pass, because he's a backup. Had he caught it, he had nothing but grass in front of him. Later, Purdy threw another pass directly to Robinson, but this time he caught it, because if you give him two chances, he'll catch one. And then in the red zone, Purdy forced a pass to Brandon Aiyuk, who wasn't open. Deommodore Lenoir reached out and tipped the pass to Tashaun Gipson, who recorded his fourth pick of training camp. Earlier this week, Kyle Shanahan said Purdy would have to melt down in practice to lose his job. Every day Purdy throws multiple interceptable passes feels like a meltdown. He does not appear ready to start Week 1 in a few weeks.\u003c/p\u003e\u003ch3\u003eTREY LANCE\u003c/h3\u003e\u003cp\u003eCompleted 4 of 6 pass attempts, fumbled once and did not score in the red zone. But hey, at least he didn't throw an interception. The 49ers better hope Purdy is ready to start Week 1, because Lance hasn't gotten enough reps in camp to be ready. He clearly is better than he was the last two years, but he still seems like a rookie at times.\u003c/p\u003e\u003ch3\u003eSAM DARNOLD\u003c/h3\u003e\u003cp\u003eCompleted 5 of 9 throws and completed a touchdown pass to Brayden Willis from 10 yards out. Darnold isn't great, but he might be the best quarterback on the team -- he arguably has had the best training camp of these three. But the 49ers haven't given him a rep with the first-string offense in more than a week. They're giving both Darnold and Lance crumbs. Which means none of their quarterbacks currently are ready to play. What a waste of time.\u003c/p\u003e\u003cp\u003e\u003ci\u003eCopyright ABG-SI LLC. SPORTS ILLUSTRATED is a registered trademark of ABG-SI LLC. All Rights Reserved.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278316388",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Grant Cohn\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eSports Illustrated San Francisco 49ers News, Analysis and More\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Guess how many interceptions Brock Purdy threw today.",
+      "lead_media": {
+        "id": "277830658",
+        "url": "https://www.mcclatchy-wires.com/incoming/ov4asx/picture277830658",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "10093686-1868-4bef-a361-16c2ac492b62",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692219263,
+        "expires": 1693427598,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1690838406,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/ov4asx/picture277830658/alternates/FREE_1140/10093686-1868-4bef-a361-16c2ac492b62",
+        "href": "/web/v1/content/277830658",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "SI San Francisco 49ers",
+      "copyright": "SI San Francisco 49ers",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278316383",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278316383.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Building Camraderie, Communication Goal for Secondary",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692219301,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.si.com/college/arkansas/hogs-football/hogs-building-togetherness-communication-in-secondary",
+      "meta_description": "New coaches trying to get all the new faces working together in fall camp",
+      "published_date": 1692218423,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/wug8cv/picture278316178/alternates/FREE_1140/11eaf9cb-f71f-4f5a-b8bd-824848b4a525",
+      "authors": [
+        {
+          "name": "Andy Hodges",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "88983"
+      ],
+      "credit": "Sports Illustrated All Hogs News, Analysis and More",
+      "dateline": "",
+      "summary": "New coaches trying to get all the new faces working together in fall camp",
+      "content": "\u003cp\u003eFAYETTEVILLE, Ark. — Yeah, last year was bad in the defensive secondary so now that we've covered that about as completely as needed, this year has new faces and new coaches. The hope is that translates to the bottom line.\u003c/p\u003e\u003cp\u003e\"I never look back to last year,\" co-defensive coordinator and secondary coach Marcus Woodson said Wednesday morning. \"At the end of the day, it’s about today and moving forward, not yesterday. What I do is go back and look at what are the things we did good, or fairly good, and what’s the biggest areas of improvement. Whatever those areas of improvement are, that’s what we’re going to emphasize\u003ca href=\"https://arkansasrazorbacks.com\" rel=\"nofollow\"\u003e.\u003c/a\u003e\u003c/p\u003e\u003cp\u003e\"Coming here to Arkansas, I felt watching film and just getting some history of what went on last year, the first thing was just coming together as a group. It was the same way at Florida State. I tell the guys all the time, if you want to go far, go together. If you want to get there fast, go by yourself. But it’s a long journey and we want to go far, so we’re going to go together. It’s a brotherhood, and it’s amazing how much you can accomplish just by bringing guys together. I’m excited about the chemistry in the room and where we’re going. They know it’s going to be a collective deal for us to be successful. It’s a 'we' and 'us' mindset and not an I and me\u003ca href=\"https://cbssports.com\" rel=\"nofollow\"\u003e.\u003c/a\u003e\"\u003c/p\u003e\u003cp\u003eThey are doing it with communications, which fellow secondary coach Deron Wilson said earlier in the week. When they do that off the field, it helps what they do on the field. Everyone hopes combining that with some pressure from the defensive front translates to wins\u003ca href=\"https://sports.yahoo.com\" rel=\"nofollow\"\u003e.\u003c/a\u003e\u003c/p\u003e\u003cp\u003e\"One issue that you see around the country, not specifically last year here but around the country, is if you have issues within the pass game, busted coverages, it’s because of communication. That’s the reason we do the things that we do, myself andcCoach Woodson, having guys together, and they’re hearing both voices. Now, communication is not an issue\u003ca href=\"https://espn.com\" rel=\"nofollow\"\u003e.\u003c/a\u003e\"\u003c/p\u003e\u003cp\u003eWe probably won't find out for a couple of weeks into the season. The Razorbacks open the season Sept. 2 at War Memorial Stadium in Little Rock against Western Carolina at 3 p\u003ca href=\"https://www.espn.com/college-football/team/_/id/8/arkansas-razorbacks\"\u003e.\u003c/a\u003em. There is no network broadcast available of the game that is only available on ESPN+\u003ca href=\"https://yahoo.com\" rel=\"nofollow\"\u003e.\u003c/a\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:265590111; alt=\"f49e7fdc-f4c2-4100-bdaf-627049db8119\"% --\u003e\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eHOGS FEED\u003c/strong\u003e\u003cstrong\u003e\u003ca href=\"https://google.com/\"\u003e:\u003c/a\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eWATCH: HOGS' CO-DEFENSIVE COORDINATOR AND SECONDARY COACH MARCUS WOODSON WITH THE MEDIA WEDNESDAY\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003cstrong\u003e\u003ca href=\"https://www.si.com/college/arkansas/hogs-football/watch-razorback-defensive-backs-press-conference\"\u003eWATCH: RAZORBACKS' DEFENSIVE BACKS JAYDEN JOHNSON AND LORANDO \"SNAXX\" JOHNSON AFTER PRACTICE\u003c/a\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003cstrong\u003e\u003ca href=\"https://www.si.com/college/arkansas/hogs-football/new-razorbacks-receiver-considered-freak-athlete-by-columnist-jd\"\u003eHOGS' TRANSFER WIDE RECEIVER ISAAC TESLAA DRAWING NATIONAL ATTENTION FOR ATHLETICISM\u003c/a\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:265590111; alt=\"f49e7fdc-f4c2-4100-bdaf-627049db8119\"% --\u003e\u003c/p\u003e\u003cp\u003e• \u003cstrong\u003e\u003ca href=\"https://www.si.com/college/arkansas/\"\u003eReturn to allHogs home page\u003c/a\u003e\u003cbr/\u003e\u003cbr/\u003e\u003c/strong\u003e• \u003cstrong\u003eSubscribe and follow us on \u003c/strong\u003e\u003cstrong\u003e\u003ca href=\"https://www.youtube.com/channel/UCIkJdx0aLaHal8GprqTeXOQ\"\u003eYouTube\u003c/a\u003e.\u003cbr/\u003e\u003cbr/\u003e\u003c/strong\u003e• \u003cstrong\u003eFollow allHOGS on \u003ca href=\"https://twitter.com/SI_AllHogs\"\u003eTwitter\u003c/a\u003e\u003ca href=\"https://twitter.com/LonghornsSI\"\u003e\u003c/a\u003eand \u003ca href=\"https://www.facebook.com/allhogs\"\u003eFacebook.\u003c/a\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eCopyright ABG-SI LLC. SPORTS ILLUSTRATED is a registered trademark of ABG-SI LLC. All Rights Reserved.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278316383",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Andy Hodges\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eSports Illustrated All Hogs News, Analysis and More\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "New coaches trying to get all the new faces working together in fall camp",
+      "lead_media": {
+        "id": "278316178",
+        "url": "https://www.mcclatchy-wires.com/incoming/wug8cv/picture278316178",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "11eaf9cb-f71f-4f5a-b8bd-824848b4a525",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692219259,
+        "expires": 1693428023,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692218423,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/wug8cv/picture278316178/alternates/FREE_1140/11eaf9cb-f71f-4f5a-b8bd-824848b4a525",
+        "href": "/web/v1/content/278316178",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "SI Arkansas Razorbacks",
+      "copyright": "SI Arkansas Razorbacks",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278315958",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278315958.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Dolphins Stars, Coach Tackle Wilkins Situation",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692218886,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.si.com/nfl/dolphins/news/miami-dolphins-stars-head-coach-mike-mcdaniel-tackle-christian-wilkins-situation",
+      "meta_description": "Defensive tackle Christian Wilkins has the support of his teammates and head coach as he looks for a new contract",
+      "published_date": 1692217035,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/xukwzr/picture278315733/alternates/FREE_1140/e754099c-4635-489f-ae99-9f42826658b8",
+      "authors": [
+        {
+          "name": "Alain Poupart",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87442"
+      ],
+      "credit": "Sports Illustrated Miami Dolphins News, Analysis and More",
+      "dateline": "",
+      "summary": "Defensive tackle Christian Wilkins has the support of his teammates and head coach as he looks for a new contract",
+      "content": "\u003cp\u003eHOUSTON — Xavien Howard couldn't help but laugh when he was asked about Christian Wilkins' hold-in as his Miami Dolphins teammate looks for a new contract.\u003c/p\u003e\u003cp\u003eAfter all, it wasn't that long ago that Howard was in the same situation.\u003c/p\u003e\u003cp\u003e“I knew you were going to ask me this,\" Howard said with a smile.\u003c/p\u003e\u003cp\u003eThen asked for his advice, Howard simply said: “Get your money. Get your money. I can’t say anything else, man.”\u003c/p\u003e\u003cp\u003eHoward eventually did get his money after a turbulent 2021 summer, one that reached the point where he requested a trade via Instagram before getting his contract adjusted with a promise to revisit it the next offseason, at which time the Dolphins gave him a new deal.\u003c/p\u003e\u003cp\u003eHoward was asked about the importance of taking care of the business side of things.\u003c/p\u003e\u003cp\u003e“At the end of the day, you’ve got to make sure you’re ready to play football also, though — no matter what you’re going through — because there’s like, some guys just focus on getting paid and stuff like that,\" Howard said. \"Then they forget that you’ve still got to play football if you get paid or if you don’t. You’ve still got to perform. So it’s like, you’ve just got to take care of it and just be a pro. And I’m sure he’s going to do that because he’s a pro.”\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278315728% --\u003e\u003c/p\u003e\u003ch3\u003eARMSTEAD CONFIDENT\u003c/h3\u003e\u003cp\u003ePro Bowl tackle Terron Armstead also was asked about Wilkins' hold-in after the joint practice with the Houston Texans on Wednesday.\u003c/p\u003e\u003cp\u003e“Christian is a dawg,\" Armstead said. \"We need him. We need him to win. There’s no question. So he knows what he needs to be ready, to be prepared. He practices and plays harder than anybody I’ve ever seen. You never worry about a guy like him.\u003c/p\u003e\u003cp\u003e\"We need him. The organization knows we need him. I’m pretty sure they’ll figure out something whether it’s stock options or whatever to get the job done.”\u003c/p\u003e\u003ch3\u003eMIKE McDANIEL COMFORTABLE\u003c/h3\u003e\u003cp\u003eWilkins hasn't taken part in team periods since he took the first snap of the first joint practice with the Atlanta Falcons last week after getting off to a tremendous start in training camp.\u003c/p\u003e\u003cp\u003eHe also didn't miss any of the offseason program despite his clear desire to land the kind of contract so many other high-end defensive tackles around the NFL have gotten in 2023.\u003c/p\u003e\u003cp\u003eAs it stands now, Wilkins is scheduled to earn $10.7 million on the fifth-year option of the rookie contract he signed as a first-round pick in the 2019 NFL draft.\u003c/p\u003e\u003cp\u003eMcDaniel has sung Wilkins' praises as a player and a leader on numerous occasions and it's pretty clear he views Wilkins as a foundational piece for the Dolphins defense.\u003c/p\u003e\u003cp\u003e“Christian is such a good player, such an important person in the locker room, who has made it clear that he feels that his play is deserving of a contract,\" McDaniel said before practice Wednesday. \"We would agree, as the Miami Dolphins organization, henceforth we are in negotiations. As a result, he’s hasn’t been participating in team (drills). When he next participates, that will be up to him.”\u003c/p\u003e\u003cp\u003eMcDaniel then was asked whether he was comfortable with where things stand.\u003c/p\u003e\u003cp\u003e“Every player is like a snowflake, I would say, unique to itself,\" he replied. \"So I’m comfortable with the situation as it stands. Christian and I are in constant communication, and this is part of the business that a lot of teams are dealing with.”\u003c/p\u003e\u003cp\u003e\u003cem\u003e---------------------------------------------------------------------------\u003c/em\u003e\u003c/p\u003e\u003cp\u003e\u003cem\u003eThanks for reading. Make sure to bookmark this site and check back daily for the latest Dolphins news and analysis year-round. Check out our daily podcast (All Dolphins Podcast) on YouTube and also available wherever you get your audio podcasts under Miami Dolphins Insider on the Fans First Sports Network. Also,\u003cstrong\u003e\u003c/strong\u003eyou can follow me on Twitter at @PoupartNFL, and that's where you can ask questions for the regular All Dolphins mailbags. You also can ask questions via email at fnalldolphins@yahoo.com.\u003c/em\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eCopyright ABG-SI LLC. SPORTS ILLUSTRATED is a registered trademark of ABG-SI LLC. All Rights Reserved.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278315958",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Alain Poupart\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eSports Illustrated Miami Dolphins News, Analysis and More\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Defensive tackle Christian Wilkins has the support of his teammates and head coach as he looks for a new contract",
+      "lead_media": {
+        "id": "278315733",
+        "url": "https://www.mcclatchy-wires.com/incoming/xukwzr/picture278315733",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "e754099c-4635-489f-ae99-9f42826658b8",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692218839,
+        "expires": 1693426635,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692217035,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/xukwzr/picture278315733/alternates/FREE_1140/e754099c-4635-489f-ae99-9f42826658b8",
+        "href": "/web/v1/content/278315733",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "SI Miami Dolphins",
+      "copyright": "SI Miami Dolphins",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278315953",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278315953.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "7 Broncos With the Most to Lose in Preseason Game 2 vs. Niners",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692218885,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.si.com/nfl/broncos/news/broncos-49ers-players-lose-garett-bolles",
+      "meta_description": "Which Denver Broncos are under the gun entering the preseason game vs. the San Francisco 49ers?",
+      "published_date": 1692216977,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/yca1k1/picture278315718/alternates/FREE_1140/bd9c3628-57f0-48e7-8341-8e04e790d9d8",
+      "authors": [
+        {
+          "name": "Erick Trickel",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "89915"
+      ],
+      "credit": "Sports Illustrated Mile High Huddle: Denver Broncos News, Analysis and More",
+      "dateline": "",
+      "summary": "Which Denver Broncos are under the gun entering the preseason game vs. the San Francisco 49ers?",
+      "content": "\u003cp\u003eThe \u003ca href=\"https://www.si.com/nfl/team/denver-broncos\"\u003eDenver Broncos\u003c/a\u003e lost their preseason opener, but the team's overall outlook remains positive. There were issues with the starting unit, but the Broncos still managed to move the ball and lead a touchdown drive, with two more ending in missed field goals. \u003c/p\u003e\u003cp\u003eObviously, the Broncos need those field goals to connect, along with better results from the run game and better blocking from the offensive line. But it wasn't all bad. With the second preseason game coming up, the hope is to see the Broncos improve those areas, or else it'll be time to raise serious concerns. \u003c/p\u003e\u003cp\u003eWhen it comes to individual performances, multiple players have a lot on the line against the \u003ca href=\"https://www.si.com/nfl/team/san-francisco-49ers\"\u003eSan Francisco 49ers\u003c/a\u003e. The following seven players didn't have the best game to open the preseason or were unable to see the field. \u003c/p\u003e\u003cp\u003eWith how others looked at the same position, some could be in jeopardy of being cut, while others could be in danger of losing their spot on the depth chart. \u003c/p\u003e\u003csection\u003e\u003cdiv\u003e\u003cp\u003eAs Denver's No. 2 quarterback, Stidham completed a third of his passing attempts, going 5-of-15, with only 50 yards to show. The 10-yard average isn't terrible, but you want more consistency from the backup QB. \u003c/p\u003e\u003cp\u003eStidham led four drives, with one field goal, which came on a four-play, eight-yard drive. He led another 10-play drive that went 19 yards for a missed field goal. \u003c/p\u003e\u003cp\u003eWith Stidham under center, the Broncos ran 27 plays for 90 yards. While Denver scored once, Stidham also threw an interception. It's safe to say the offense stalled under him, and it was a time when the offensive line was doing somewhat decent. \u003c/p\u003e\u003cp\u003eOf Stidham's 50 yards, 26 of them came on one play. It highlights how inconsistent he was, but his issues were how those inconsistencies looked. \u003c/p\u003e\u003cp\u003eStidham was all over the place with his ball placement on throws, and his reads weren't great. The best thing he showed was his athleticism and ability to use his legs to pick up yards. If he isn't more consistent with his throws, he could be at risk of losing the backup job.\u003c/p\u003e\u003cp\u003e\u003ca href=\"https://sibforms.com/serve/MUIEACu35tDCvWTU8nrZq3tu-omjLixgehvQuqnYGbQ5JZ8iO1opdYklsdU2qJSc8MsKh-kFeniiedKufe5dsVn4SVS3PQ9kiWBxRrGpeqLnT2jnUHWsKpAnbwxykIv8W6xdyqeJAtpssR8Kq5TptID_USaXtVUx2WmFzTPI1xF92kwWDCs3wqBJpwb4E2CKvf4lLtMun7UipsWP\"\u003eWhat happens next on the Broncos? Don't miss out on any news and analysis!\u003cstrong\u003e Take a second, sign up for our free newsletter, and get breaking Broncos news delivered to your inbox daily!\u003c/strong\u003e\u003c/a\u003e\u003c/p\u003e\u003cp\u003eWhen Callaway was signed, he was presumed to make the roster due to his special teams play and familiarity with Sean Payton and his offense. However, Payton called out Callaway after practice last week, and the receiver didn't respond in the game.\u003c/p\u003e\u003cp\u003eThe wide receiver is such a dependent position. They can get open, but they aren't getting a chance if the quarterback doesn't look their way. \u003c/p\u003e\u003cp\u003eCallaway was targeted twice in preseason Game 1, with only one catch for seven yards. Unlike other receivers, what stood out was that he wasn't getting separation consistently enough. Callaway played 19 total snaps, 16 of them as a receiver, and the three snaps as a run blocker left you wanting more. \u003c/p\u003e\u003cp\u003eThe Broncos' wide receiver room is tight, and the coaches are looking for someone to stand out. This was an excellent opportunity for Callaway with Marvin Mims, Jr. and Brandon Johnson not playing, but he didn't take advantage of it. \u003c/p\u003e\u003cp\u003eIf Callaway doesn't step up during the week of practice as Payton called for and fails to stand out against the Niners, his roster prospects could be in jeopardy. \u003c/p\u003e\u003cp\u003eThere were not many expecting Okwuegbunam to make the roster. He entered the game late against the Cardinals and was the fourth tight end to enter the game. \u003c/p\u003e\u003cp\u003eChris Manhertz didn't play, and if you look at the depth chart, Manhertz is the third tight end. With all that in mind, it cements the probability that Okquegbunam and the Broncos are poised to part ways.\u003c/p\u003e\u003cp\u003eOkweugbunam still has issues as a blocker and was never targeted in the game. When he entered the game, the Cardinals were fielding mostly fourth-unit defenders. \u003c/p\u003e\u003cp\u003eThat should have been an opportunity for Okwuegbunam, but he didn't make his presence felt. He's always been at risk of getting cut or traded if the Broncos can somehow manage to get something, but if he doesn't step up against the Niners, his chances of making it will be zero. \u003c/p\u003e\u003cp\u003eIt was a rough night for the Broncos' starting left tackle. Plenty of excuses are available for Bolles, from changing offenses, changing his position coach once again, to even the leg injury that ended his season last October, but his play was that of a college freshman going against NFL All-Pros. And yet, Bolles' lapses came against Dennis Gardeck.\u003c/p\u003e\u003cp\u003eGardeck has been in the NFL since 2018 and has played 480 snaps on defense during the regular season, not in 2018, but over his whole career. He has eight career sacks, seven of which came as a situational pass rusher in 2020. That's who beat Bolles like a drum on Friday night. \u003c/p\u003e\u003cp\u003eWhile Bolles isn't at risk of losing the starting job, it is only because Cameron Fleming wasn't any better. Fleming also has much to lose, as the third and fourth-team tackles looked better than he or Bolles. \u003c/p\u003e\u003cp\u003eThe Broncos need Bolles to step up, and he wants to keep his job. If he doesn't answer the bell vs. the Niners, it increases the chances of him being benched or potentially released. \u003c/p\u003e\u003cp\u003eCutting Bolles would create nearly $12 million in cap savings with $6 million in dead cap. It would be even better if the Broncos could find a trade partner, but they would need him to look decent to find a potential buyer. \u003c/p\u003e\u003cp\u003eWhatever happens, the Broncos can't go forward with Bolles looking like he did against a weak Cardinals defensive front. \u003c/p\u003e\u003cp\u003eIt sucks that Purcell is hurt and unable to get out on the field. Even at his age, he can still contribute to the defensive line. However, the Broncos could consider parting ways if he can't get healthy in time. \u003c/p\u003e\u003cp\u003eDespite the issues the Broncos had against the Cardinals, the defensive line did well. It would be hard for Purcell to stick if the Broncos get similar results against the Niners. He has to get healthy and cleared to return to practice as soon as possible.\u003c/p\u003e\u003cp\u003eBrowning is in a similar boat as Purcell, but Browning's timetable to return is known. While he won't be cut, Browning is at risk of losing his spot as the third rusher in the rotation. \u003c/p\u003e\u003cp\u003eJonathon Cooper and Nik Bonitto are doing well in camp and translated it to the first preseason game. If those two keep it up, it significantly boosts the Broncos' pass rush and can change the plans with Browning going forward. \u003c/p\u003e\u003c/div\u003e\u003c/section\u003e\u003cp\u003eYes, Essang Bassey had an interception, but it came off a receiver slipping on the field. He also had that weird onside kick recovery, so hats off to him. \u003c/p\u003e\u003cp\u003eHowever, outside of that, it was a rough showing from Bassey. The backup nickel spot is his to lose, as he started the game there, but Ja'Quan McMillian may have something to say about it. \u003c/p\u003e\u003cp\u003eMcMillian showed versatility to play inside and on the boundary against the Cardinals, and Bassey doesn't have that. Bassey has to offer more against the Niners if he wants to fend off McMillian and secure the backup job. \u003c/p\u003e\u003cp\u003eFaion Hicks is also there pushing for the job. Bassey is at risk of not making the roster due to the numbers game, losing out to the versatile McMillian, or losing his job outright. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278314688% --\u003e\u003c/p\u003e\u003chr/\u003e\u003cp\u003e\u003cem\u003eFollow Mile High Huddle on \u003c/em\u003e\u003cstrong\u003e\u003ca href=\"https://twitter.com/MileHighHuddle\"\u003e\u003cem\u003eTwitter\u003c/em\u003e\u003c/a\u003e\u003cem\u003e\u003c/em\u003e\u003c/strong\u003e\u003cem\u003eand \u003c/em\u003e\u003ca href=\"https://www.facebook.com/MileHighHuddle/\"\u003e\u003cem\u003e\u003cstrong\u003eFacebook\u003c/strong\u003e\u003c/em\u003e\u003c/a\u003e\u003cem\u003e.\u003c/em\u003e\u003c/p\u003e\u003cp\u003e\u003cem\u003eSubscribe to Mile High Huddle \u003c/em\u003e\u003ca href=\"https://www.youtube.com/c/MileHighHuddle\"\u003e\u003cem\u003e\u003cstrong\u003eon YouTube\u003c/strong\u003e\u003c/em\u003e\u003c/a\u003e\u003cem\u003e\u003c/em\u003e\u003cem\u003efor daily Broncos live-stream podcasts!\u003c/em\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eCopyright ABG-SI LLC. SPORTS ILLUSTRATED is a registered trademark of ABG-SI LLC. All Rights Reserved.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278315953",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Erick Trickel\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eSports Illustrated Mile High Huddle: Denver Broncos News, Analysis and More\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Which Denver Broncos are under the gun entering the preseason game vs. the San Francisco 49ers?",
+      "lead_media": {
+        "id": "278315718",
+        "url": "https://www.mcclatchy-wires.com/incoming/yca1k1/picture278315718",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "bd9c3628-57f0-48e7-8341-8e04e790d9d8",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692218826,
+        "expires": 1693426577,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692216977,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/yca1k1/picture278315718/alternates/FREE_1140/bd9c3628-57f0-48e7-8341-8e04e790d9d8",
+        "href": "/web/v1/content/278315718",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "SI Mile High Huddle",
+      "copyright": "SI Mile High Huddle",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278315798",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278315798.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Why Eagles’ Blankenship is ‘Milk That Doesn’t Spoil!’",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692218762,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.si.com/nfl/eagles/news/philadelphia-eagles-reed-blankenship-training-camp-sydney-brown-darius-slay-roster-depth-chart",
+      "meta_description": "Philadelphia Eagles safety Reed Blankenship is opening his teammates' eyes with his strong play at safety in just his second season as an undrafted free agent",
+      "published_date": 1692216768,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/fd4qfk/picture278315523/alternates/FREE_1140/5f9c34f8-ed50-4d65-a90c-f788e49e4ca7",
+      "authors": [
+        {
+          "name": "Ed Kracz",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "89875"
+      ],
+      "credit": "Sports Illustrated Philadelphia Eagles News, Analysis and More",
+      "dateline": "",
+      "summary": "Philadelphia Eagles safety Reed Blankenship is opening his teammates' eyes with his strong play at safety in just his second season as an undrafted free agent",
+      "content": "\u003cp\u003ePHILADELPHIA – Deshaun Watson threw three interceptions in two practice days against the \u003ca href=\"https://www.si.com/nfl/eagles/news/philadelphia-eagles-cleveland-browns-joint-practice-intensity-jason-kelce-sydney-brown-kvon-wallace\"\u003ePhiladelphia Eagles\u003c/a\u003e.\u003c/p\u003e\u003cp\u003eAll three of the picks from the Cleveland Browns’ quarterback were to safety \u003ca href=\"https://www.si.com/nfl/eagles/news/philadelphia-eagles-training-camp-cleveland-browns-joint-practice-reed-blankenship-wwe-deshaun-watson\"\u003eReed Blankenship.\u003c/a\u003e Eagles fans on social media have taken to calling him Ed Reed Blankenship in deference to Hall of Fame safety and Baltimore Ravens legend Ed Reed.\u003c/p\u003e\u003cp\u003eThat’s a little much at this stage, but it’s hard not to be encouraged about what Blankenship has done this summer. He always seems to be around the football, and when you intercept the great Aaron Rodgers in your first meaningful defensive action in the NFL, the way Blankenship did last November, that only heightens the excitement.\u003c/p\u003e\u003cp\u003e“Right now, he got the most picks during camp right now, and I’m kind of jealous because I’m trying to win,” joked Eagles veteran cornerback Darius Slay. “But I don’t really get too much action like that, but dang, I’m jealous because I want to win, but happy for him.\u003c/p\u003e\u003cp\u003e“…He makes a lot of plays. He’s been smart. As you can see, he was growing into it last year, playing at a high level, filling in for Chauncey (Gardner-Johnson), and still rotating a little bit. And learning from (Marcus) Epps last year and all that and carrying it over into this year. He’s been doing a great job, communicating, leading the way.”\u003c/p\u003e\u003cp\u003eSlay went on to talk about how Buffalo Bills quarterback Josh Allen refers to white players as 'Milk Check.'\u003c/p\u003e\u003cp\u003eThe cornerback said Blankenship, \"Ain't no Milk Check. He's good milk. He doesn't spoil.\"\u003c/p\u003e\u003cp\u003eBlankenship was an undrafted free agent last year after being the rare five-year, college starter, playing at Middle Tennessee State.\u003c/p\u003e\u003cp\u003e“What makes Reed special is his passion for the game,” said rookie Sydney Brown. “I think that’s what makes him so special. He puts in time on and off the field to better his craft. That’s why he’s a special player.\u003c/p\u003e\u003cp\u003e“Then again, his intensity every single day. He brings it. He wants to practice. He wants to play hard. Looking at what he’s done in such a short period of time is encouraging for sure. Reed is who he is because of what he does. He’s a product of the work he puts in.”\u003c/p\u003e\u003cp\u003eWith K’Von Wallace in the final year of his rookie contract, and Terrell Edmunds and Justin Evans signed to only one-year, free-agent contracts, Brown and Blankenship could be a mainstay as the Eagles’ starting safeties for years to come.\u003c/p\u003e\u003cp\u003e“Reed has done a tremendous job,” said Wallace. “He’s done nothing but prove that he belongs. I’m definitely excited to see what he does this season. We all are.” \u003c/p\u003e\u003cp\u003eBlankenship is entrenched as the starter, Brown still has work to do, but he seems to be developing quickly. Wallace has also had a solid camp and could be playing his way into another contract in Philly.\u003c/p\u003e\u003cp\u003e“Obviously, they're battling there at safety,” said head coach Nick Sirianni. “...We lost a couple of really good players. Obviously wish them the best, but lost a couple really good players and replaced them with some really good players.\u003c/p\u003e\u003cp\u003e\"So that's just competition. I'm looking forward to how that continues to play out at that position, at safety.”\u003c/p\u003e\u003cp\u003e\u003cstrong\u003e\u003cem\u003eEd Kracz covers the Philadelphia Eagles for SI's EaglesToday.\u003c/em\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003cstrong\u003e\u003cem\u003ePlease \u003c/em\u003e\u003c/strong\u003e\u003ca href=\"https://twitter.com/kracze\"\u003e\u003cstrong\u003e\u003cem\u003efollow him and our Eagles coverage on Twitter at @kracze.\u003c/em\u003e\u003c/strong\u003e\u003c/a\u003e\u003c/p\u003e\u003cp\u003e\u003cem\u003e\u003cstrong\u003eWant the latest in breaking news and insider information on the \u003c/strong\u003e\u003c/em\u003e\u003ca href=\"https://www.si.com/nfl/team/eagles\"\u003e\u003cstrong\u003ePhiladelphia Eagles\u003c/strong\u003e\u003c/a\u003e\u003cem\u003e\u003cstrong\u003e? \u003c/strong\u003e\u003c/em\u003e\u003ca href=\"https://www.si.com/nfl/eagles/\"\u003e\u003cstrong\u003eClick Here\u003c/strong\u003e\u003c/a\u003e\u003cstrong\u003e\u003cem\u003e.\u003c/em\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003cem\u003e\u003cstrong\u003eWant even more Philadelphia Eagles news? \u003c/strong\u003e\u003c/em\u003e\u003ca href=\"https://www.si.com/nfl/team/eagles\"\u003e\u003cstrong\u003eCheck out the SI.com team page here\u003c/strong\u003e\u003c/a\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eCopyright ABG-SI LLC. SPORTS ILLUSTRATED is a registered trademark of ABG-SI LLC. All Rights Reserved.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278315798",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Ed Kracz\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eSports Illustrated Philadelphia Eagles News, Analysis and More\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Philadelphia Eagles safety Reed Blankenship is opening his teammates’ eyes with his strong play at safety in just his second season as an undrafted free agent",
+      "lead_media": {
+        "id": "278315523",
+        "url": "https://www.mcclatchy-wires.com/incoming/fd4qfk/picture278315523",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "5f9c34f8-ed50-4d65-a90c-f788e49e4ca7",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692218730,
+        "expires": 1693426368,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692216768,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/fd4qfk/picture278315523/alternates/FREE_1140/5f9c34f8-ed50-4d65-a90c-f788e49e4ca7",
+        "href": "/web/v1/content/278315523",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "SI Eagle Maven",
+      "copyright": "SI Eagle Maven",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278315778",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278315778.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Penix Pronounces His Throwing Arm at 100 Percent",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692218702,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.si.com/college/washington/football/penix-pronounces-his-throwing-arm-at-100-percent",
+      "meta_description": "The Husky quarterback reiterates that his passing shutdown was precautionary.",
+      "published_date": 1692217353,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/9z8697/picture278315638/alternates/FREE_1140/fc59e600-7d91-4765-a238-d99250d8563f",
+      "authors": [
+        {
+          "name": "Dan Raley",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87382"
+      ],
+      "credit": "Sports Illustrated Washington Huskies News, Analysis and More",
+      "dateline": "",
+      "summary": "The Husky quarterback reiterates that his passing shutdown was precautionary.",
+      "content": "\u003cp\u003eWith all of the nonstop hearty handshakes received from well-meaning fans, charity events used for lobbing passes to people running here and there, and even throwing out a Mariners' first pitch, it's a wonder Michael Penix Jr. didn't experience a little arm weariness well before fall camp opened.\u003c/p\u003e\u003cp\u003eOn Wednesday, the left-handed University of Washington quarterback, serious Heisman Trophy candidate and potential NFL first-rounder pronounced himself fully recovered from his earlier week off because of arm discomfort.\u003c/p\u003e\u003cp\u003e\"I'm 100 percent,\" Penix said, standing in brilliant sunshine following practice. \"Nothing wrong. You see me now doing everything I was doing before.\"\u003c/p\u003e\u003cp\u003eThe sixth-year senior from Tampa, Florida, and former Indiana transfer admitted he felt soreness in his left arm while doing a lot of weight-lifting combined with excessive throwing once fall football practice began.\u003c/p\u003e\u003cp\u003ePenix ended up not firing passes in practice scrimmage plays for the good part of a week, turning over the first-team snaps to junior Dylan Morris, the Huskies' starting quarterback in 2020 and 2021.\u003c/p\u003e\u003cp\u003e\"Just a little bit of soreness,\" he reiterated. \"Nothing that's hurting nobody.\"\u003c/p\u003e\u003cp\u003ePenix, if you didn't know by now, is a fairly resilient college football player, bouncing back from four consecutive season-ending injuries while with his Big Ten team. \u003c/p\u003e\u003cp\u003eAt the UW for 13 games and 20 months now, he's been the picture of good health, though he had to leave last season's Arizona State game for a play after having trouble getting a breath after being sandwiched by a pair of overzealous pass rushers. \u003c/p\u003e\u003cp\u003eOne of his Husky quarterback predecessors, Jake Browning, reportedly had a similar issue when he played in 2015-18, coming into fall camp after throwing hundreds of passes that summer and momentarily suffering from a dead arm. \u003c/p\u003e\u003cp\u003ePenix seemed to shrug at that story and indicated his situation was just precautionary.\u003c/p\u003e\u003cp\u003e\"I'm just making sure my arm stayed fresh for whenever the season comes,\" he said.\u003c/p\u003e\u003chr/\u003e\u003cp\u003e\u003cstrong\u003e\u003cem\u003eGo to \u003ca href=\"https://www.si.com/college/washington/\"\u003esi.com/college/washington\u003c/a\u003e to read the latest Inside the Huskies stories \u003c/em\u003e\u003c/strong\u003e\u003cstrong\u003e— as\u003c/strong\u003e\u003cstrong\u003e\u003cem\u003e soon as they’re published.\u003c/em\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003cstrong\u003e\u003cem\u003eNot all stories are posted on the fan sites.\u003c/em\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003cstrong\u003e\u003cem\u003eFind Inside the Huskies on Facebook by searching:\u003c/em\u003e\u003c/strong\u003e\u003cstrong\u003e\u003cem\u003e\u003ca href=\"https://www.facebook.com/UWFanNation/\"\u003eInside Huskies/FanNation at SI.com\u003c/a\u003e or \u003ca href=\"https://www.facebook.com/dan.raley.12\"\u003ehttps://www.facebook.com/dan.raley.12\u003c/a\u003e\u003c/em\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003cstrong\u003e\u003cem\u003eFollow Dan Raley of Inside the Huskies on Twitter: \u003ca href=\"https://twitter.com/DanRaley1\"\u003e@DanRaley1\u003c/a\u003e or \u003ca href=\"https://twitter.com/UWFanNation\"\u003e@UWFanNation\u003c/a\u003e or \u003ca href=\"https://twitter.com/DanRaley3\"\u003e@DanRaley3\u003c/a\u003e\u003c/em\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003cstrong\u003e\u003cem\u003eHave a question, direct message me on Facebook or Twitter.\u003c/em\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eCopyright ABG-SI LLC. SPORTS ILLUSTRATED is a registered trademark of ABG-SI LLC. All Rights Reserved.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278315778",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Dan Raley\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eSports Illustrated Washington Huskies News, Analysis and More\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "The Husky quarterback reiterates that his passing shutdown was precautionary.",
+      "lead_media": {
+        "id": "278315638",
+        "url": "https://www.mcclatchy-wires.com/incoming/9z8697/picture278315638",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "fc59e600-7d91-4765-a238-d99250d8563f",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692218687,
+        "expires": 1693426953,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692217353,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/9z8697/picture278315638/alternates/FREE_1140/fc59e600-7d91-4765-a238-d99250d8563f",
+        "href": "/web/v1/content/278315638",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "SI Washington Huskies",
+      "copyright": "SI Washington Huskies",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278307708",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278307708.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "ESPN Expert Says George Pickens “Much More Talented” Than Justin Jefferson",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692219038,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.si.com/college/georgia/news/pittsburgh-steelers-george-pickens-more-talented-than-minnesota-vikings-wr-justin-jefferson",
+      "meta_description": "Georgia has a history of producing high-caliber NFL football players at a litany of positions. In recent years they’ve seen all-pros at multiple positions — Roquan Smith at Linebacker, Nick Chubb at running back, and offensive tackle Andrew Thomas.  Though one position they haven’t seen ...",
+      "published_date": 1692207537,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/y6qpwg/picture278307463/alternates/FREE_1140/81f36409-1cd2-4eec-8b0d-a7fe256068f2",
+      "authors": [
+        {
+          "name": "Brooks Austin",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87392"
+      ],
+      "credit": "Sports Illustrated Georgia Bulldogs News, Analysis and More",
+      "dateline": "",
+      "summary": "Georgia has a history of producing high-caliber NFL football players at a litany of positions. In recent years they’ve seen all-pros at multiple positions — Roquan Smith at Linebacker, Nick Chubb at running back, and offensive tackle Andrew Thomas.  Though one position they haven’t seen ...",
+      "content": "\u003cp\u003eGeorgia has a history of producing high-caliber NFL football players at a litany of positions. In recent years they’ve seen all-pros at multiple positions — Roquan Smith at Linebacker, Nick Chubb at running back, and offensive tackle Andrew Thomas. \u003c/p\u003e\u003cp\u003eThough one position they haven’t seen “pro-bowl caliber” play at is the wide receiver position. That could be changing, however, with George Pickens. \u003c/p\u003e\u003cp\u003eFootball fans who have been following \u003ca href=\"https://georgiadogs.com/sports/football/roster/george-pickens/5457\"\u003ePickens since his days at The University of Georgia\u003c/a\u003e are already very familiar with the multitude of acrobatic catches that the receiver is capable of. During his rookie season with the Steelers, \u003ca href=\"https://www.espn.com/nfl/player/_/id/4426354/george-pickens\"\u003ePickens hauled in 52 catches for 801 yards and four touchdowns\u003c/a\u003e while “wowing” numerous NFL fans with his catching abilities. His successes in 2022 have led to many anticipating that the Steelers’ receiver will have a massive 2023 season.\u003c/p\u003e\u003cp\u003eNow, he’s turning heads in NFL training camp and preseason. ESPN’s Ryan Clark went as far as to say he’s “Much more talented than Justin Jefferson. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278307453% --\u003e\u003c/p\u003e\u003ch4\u003eOther Georgia News:\u003c/h4\u003e\u003cul\u003e\u003cli\u003e\u003ca href=\"https://www.si.com/college/georgia/news/georgia-football-commit-nate-frazier-highlights\"\u003eEVAL: What The Film Says About Nate Frazier\u003c/a\u003e\u003c/li\u003e\u003cli\u003e\u003ca href=\"https://www.si.com/college/georgia/football/george-pickens-can-be-a-top-guy-in-the-league-according-to-steelers-qb\"\u003eGeorge Pickens Can Be a “Top Guy in the League,” According to Steelers QB\u003c/a\u003e\u003c/li\u003e\u003cli\u003e\u003ca href=\"https://www.si.com/college/georgia/news/georgia-football-players-dominate-preseason-all-sec-team-selections\"\u003ePreseason All-SEC Teams Released\u003c/a\u003e\u003c/li\u003e\u003c/ul\u003e\u003ch4\u003eJoin the Community:\u003c/h4\u003e\u003cp\u003eFollow Brooks Austin on Twitter: \u003ca href=\"https://twitter.com/BrooksAustinBA\"\u003e@BrooksAustinBA\u003c/a\u003e\u003c/p\u003e\u003cp\u003eSubscribe\u003ca href=\"https://www.youtube.com/channel/UCqipe2JOIQZke4AN3-K9DJA\"\u003e to our YouTube Page HERE\u003c/a\u003e.\u003c/p\u003e\u003cp\u003eY\u003cem\u003eou can follow us for future coverage by clicking “Follow” on the top right-hand corner of the page. Also, \u003c/em\u003e\u003ca href=\"https://www.facebook.com/BulldogMaven\"\u003e\u003cem\u003ebe sure to like us on Facebook @BulldogMaven\u003c/em\u003e\u003c/a\u003e\u003cem\u003e \u0026 follow us on Twitter at\u003c/em\u003e\u003ca href=\"https://twitter.com/DawgsDailyFN\"\u003e\u003cem\u003e @DawgsDailyFN\u003c/em\u003e\u003c/a\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eCopyright ABG-SI LLC. SPORTS ILLUSTRATED is a registered trademark of ABG-SI LLC. All Rights Reserved.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278307708",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Brooks Austin\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eSports Illustrated Georgia Bulldogs News, Analysis and More\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Georgia has a history of producing high-caliber NFL football players at a litany of positions. In recent years they’ve seen all-pros at multiple positions — Roquan Smith at Linebacker, Nick Chubb at running back, and offensive tackle Andrew Thomas.  Though one position they haven’t seen ...",
+      "lead_media": {
+        "id": "278307463",
+        "url": "https://www.mcclatchy-wires.com/incoming/y6qpwg/picture278307463",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "81f36409-1cd2-4eec-8b0d-a7fe256068f2",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692208405,
+        "expires": 1693417137,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692207537,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/y6qpwg/picture278307463/alternates/FREE_1140/81f36409-1cd2-4eec-8b0d-a7fe256068f2",
+        "href": "/web/v1/content/278307463",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "SI Georgia Bulldogs",
+      "copyright": "SI Georgia Bulldogs",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278315753",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278315753.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Lucas Glover Beat His Putting Demons and Now He’s Beating Everyone",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692218645,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.si.com/golf/news/lucas-glover-beat-his-putting-demons-now-beating-everyone-fedexcup",
+      "meta_description": "Two weeks ago the 2009 U.S. Open champion was doubtful to even make the FedEx Cup playoffs, now he has a shot to win the title.",
+      "published_date": 1692217677,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/lychus/picture278315648/alternates/FREE_1140/fb3183b7-076a-4c17-85fc-743f82c18415",
+      "authors": [
+        {
+          "name": "Bob Harig",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "85176"
+      ],
+      "credit": "Sports Illustrated Golf: News, Scores, Equipment, Instruction, Travel, Courses",
+      "dateline": "",
+      "summary": "Two weeks ago the 2009 U.S. Open champion was doubtful to even make the FedEx Cup playoffs, now he has a shot to win the title.",
+      "content": "\u003cp\u003eOLYMPIA FIELDS, Ill. — There is no nice way to say it: Lucas Glover had the yips.\u003cu\u003e\u003c/u\u003e\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003e Among the harsher words you can hear in golf—\"shank\" ranks up there as well—the yips are no laughing matter. It is often described as a neurological disorder, one that can lead to spasms in the arms and wrists during putting.\u003cu\u003e\u003c/u\u003e\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003e For much of the past decade, Glover faced those kind of demons on the greens and saw his game suffer through it.\u003cu\u003e\u003c/u\u003e\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003e\"I had no control over my faculties sometimes,\" Glover said. “I could just lose all feelings over a 10-inch putt. It was frustrating. I fought it for a long time.\"\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003e It is a tribute to Glover’s other skills in hitting a golf ball that he managed to survive in the game going through so much grief just trying to get it in the hole.\u003cu\u003e\u003c/u\u003e\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003e A two-week run of success that has seen Glover, 43, \u003ca href=\"https://www.si.com/golf/news/from-112-to-playoffs-lucas-glover-captures-stunning-win-wyndham-championship\"\u003ewin the Wyndham Championship\u003c/a\u003e and then \u003ca href=\"https://www.si.com/golf/news/lucas-glover-fedex-st-jude-championship-winner-back-to-back-victories-pga-tour-playoffs\"\u003ethe FedEx St. Jude Championship\u003c/a\u003e to come from out of nowhere to fourth in the FedEx Cup standings has led to him telling the story a few times.\u003cu\u003e\u003c/u\u003e\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003e But earlier this year, Glover ordered a long putter and started practicing with it. At the Rocket Mortgage Classic last month, he switched to a broomstick-style putter that Adam Scott uses. Even the same make and model. Then he went to work and saw almost immediate success.\u003cu\u003e\u003c/u\u003e\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003e\"Making all your tap-ins is nice,\" he said.\u003cu\u003e\u003c/u\u003e\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003e And Glover wasn’t kidding.\u003cu\u003e\u003c/u\u003e\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003e The easiest way to quantify it is this: Glover missed 24 putts from 3 feet and in (out of 887) in 2020-21. A year later, he missed 27 from that distance. This year, prior to his win in Greensboro, N.C., he had missed 26 and was ranked 180th on the PGA Tour in strokes-gained putting.\u003cu\u003e\u003c/u\u003e\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003e With the new putter, he taught himself a split-handed grip in which his left hand is away from his chest holding the top of the club while his right hand is farther down the shaft. (In 2016, anchored putting strokes were banned as part of the Rules of Golf by the USGA and R\u0026A.)\u003cu\u003e\u003c/u\u003e\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003e\"I’d always been a streaky putter,\" Glover said Wednesday at Olympia Fields Country Club, where he begins play in the 50-player BMW Championship on Thursday. “When I putted well, I played well. When I putted poorly, I played OK.\u003cu\u003e\u003c/u\u003e\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003e “But the nervy, yippy stuff didn’t start for three or four years until after the U.S. Open (that he won in 2009). Did I make them all? No. But it wasn’t because of the yips. It was always probably the weakest part of my game but not to the extent that it has been the last 10 years and had been the last 10 years.\"\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003e Glover’s turnaround began the week after the Memorial Tournament when he tied for 20th at the RBC Canadian Open. Earlier that week, he missed out a playoff spot in a U.S. Open qualifier when \u003ca href=\"https://www.si.com/golf/news/lucas-glover-us-open-qualifier-missed-putt\"\u003ehe missed a short putt on the final green\u003c/a\u003e—although he said it was not due to his previous woes.\u003cu\u003e\u003c/u\u003e\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003e He missed the cut at the Travelers Championship, but Glover then tied for fourth at the Rocket Mortgage and tied for sixth at the John Deere. He missed the cut at the 3M Open by a shot but said \"I putted well, I just didn’t make any.\"\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003e Then came the victory at the Wyndham followed by his playoff win Sunday over Patrick Cantlay.\u003cu\u003e\u003c/u\u003e\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003e Prior to the Wyndham, Glover was 112th in FedEx Cup points and need no worse than a two-way tie for second in order to advance to the 70-player playoffs that began last week in Memphis. His win moved him to 49th. Then with another win—and points quadrupled during the playoffs—Glover jumped all the way to fourth.\u003c/p\u003e\u003cp\u003e\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003e He’s now a lock for next week’s Tour Championship in Atlanta and is in position to win the FedEx Cup.\u003cu\u003e\u003c/u\u003e\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003e Glover’s story is one of perseverance. As frustrating as his putting problems were, he said he was a good kind of stubborn. He kept working at it.\u003cu\u003e\u003c/u\u003e\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003e\"A lot of experimentation for sure with a lot of things,\" he said. \"Before this, the most success I had was with the up-the-arm kind of arm lock that (Matt) Kuchar kind of brought out. I'd pretty much tried everything. If you could come up with it in your head, I probably did, two times, legitimately.\u003c/p\u003e\u003cp\u003e“Then if something didn't work, I'd just go back and grab a short one and I'd (say) I'll just out-practice this thing, and I just couldn't do it.\"\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003eGlover said the new stroke with the split-hand grip is \"a completely different motor skill. When you struggle as long as I have, it just happened to be the answer.\"\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003eNow Glover is in the mix to win the FedEx Cup and his name is being mentioned as a possible pick for the U.S. Ryder Cup Team.\u003cu\u003e\u003c/u\u003e\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003e\"I can honestly say I never thought I wouldn't win again,\" Glover said. “I didn't think it would be two in a row. I didn't know if it would be a FedEx event. But I never thought I wouldn't win again.\u003cu\u003e\u003c/u\u003e\u003cu\u003e\u003c/u\u003e\u003c/p\u003e\u003cp\u003e“I've always said, if it gets to that point, it is probably time to hang them up. But I just knew if I could figure this putting thing out that I'd be right back where I wanted to be.\"\u003c/p\u003e\u003cp\u003e\u003ci\u003eABG-SI LLC. SPORTS ILLUSTRATED is a registered trademark of ABG-SI LLC. All Rights Reserved. Use of this site constitutes acceptance of our Terms of Use and Privacy Policy\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278315753",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Bob Harig\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eSports Illustrated Golf: News, Scores, Equipment, Instruction, Travel, Courses\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Two weeks ago the 2009 U.S. Open champion was doubtful to even make the FedEx Cup playoffs, now he has a shot to win the title.",
+      "lead_media": {
+        "id": "278315648",
+        "url": "https://www.mcclatchy-wires.com/incoming/lychus/picture278315648",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "fb3183b7-076a-4c17-85fc-743f82c18415",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692218620,
+        "expires": 1693427277,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692217677,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/lychus/picture278315648/alternates/FREE_1140/fb3183b7-076a-4c17-85fc-743f82c18415",
+        "href": "/web/v1/content/278315648",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "SI Golf",
+      "copyright": "SI Golf",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278315748",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278315748.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "How Matt Guerreri Wants to Build on the Defense Tom Allen has Built",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692218643,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.si.com/college/indiana/football/matt-guerreri-wants-to-build-on-indiana-defense-tom-allen-built-football-hoosiers",
+      "meta_description": "Matt Guerreri was hired away from Ohio State by Indiana coach Tom Allen in the 2023 offseason to call plays for the Hoosier defense. On Wednesday, both coaches spoke to the media, and described how they want Guerreri to bring the defense along and improve upon it from where it was in 2022.",
+      "published_date": 1692217522,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/f92ihp/picture278315588/alternates/FREE_1140/c05a7a79-d329-4e7e-903a-d96952e6040d",
+      "authors": [
+        {
+          "name": "Daniel Olinger",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "88918"
+      ],
+      "credit": "Sports Illustrated Indiana Hoosiers News, Analysis and More",
+      "dateline": "",
+      "summary": "Matt Guerreri was hired away from Ohio State by Indiana coach Tom Allen in the 2023 offseason to call plays for the Hoosier defense. On Wednesday, both coaches spoke to the media, and described how they want Guerreri to bring the defense along and improve upon it from where it was in 2022.",
+      "content": "\u003cp\u003eBLOOMINGTON, Ind. — Tom Allen is a defensive coach by trade. \u003c/p\u003e\u003cp\u003eThat was the first thing the Indiana football coach said at 2023 Big Ten Media Days in July when asked not about his defense but about his quarterbacks. Allen obviously has some influence over the offense, but he's far more comfortable drawing up the X's and O's for a defense.\u003c/p\u003e\u003cp\u003eThat's why he took over defensive play calling duties in 2022, and on the surface it was a perfectly reasonable plan. Allen was originally hired in 2016 by former coach Kevin Wilson to call the defense for Indiana, and the solid IU defenses in 2019 and 2020 were molded by Allen's defensive system and recruiting acumen. Then-defensive play caller Kane Wommack also played a big part in that success before being hired as the head coach at South Alabama. \u003c/p\u003e\u003cp\u003eBut Indiana's defense was pretty bad in 2022, and one of Allen's solutions was to hire Matt Guerreri as a coordinator, a safeties position coach and, most importantly, a defensive play caller. \u003c/p\u003e\u003cp\u003e\"I chose to call it a year ago because I felt that was best for our program at that time,\" Allen said Wednesday in Indianapolis at Media Days. \"But I've not called it obviously [in the past] with all the different things that are going on, and with the portal and the NIL and just the complexities you now deal with ...in order for us to get better and move forward, I wanted to bring somebody in to be able to call that.\"\u003c/p\u003e\u003cp\u003eGuerreri spent 10 seasons as an assistant coach at Duke from 2012-21, and he served as the co-defensive coordinator during his final four seasons with the Blue Devils. In 2022, he worked at Ohio State for coach Ryan Day as a senior advisor and analyst. \u003c/p\u003e\u003cp\u003eAllen hired him away from the Big Ten East powerhouse not because Indiana needed a dramatic shift in the way it approaches defense, but because calling plays for the defense limited his ability to oversee the entire program. \u003c/p\u003e\u003cp\u003e\"But I feel like it's important for me to become the best head coach I can be,\" Allen said at Media Days. \"The best game-day manager of the entire game, both sides of the football and special teams, for me not to be focused on calling the defense.\"\u003c/p\u003e\u003cp\u003eWhen Guerreri spoke with the media on Wednesday, he reiterated Allen's points. He spoke of his role in calling the defense as adding to what has been in the past under Allen, rather than making a 180 degree shift. \u003c/p\u003e\u003cp\u003e\"Coach Allen has a system. There's fundamentals of how we play defense, how we stop the run, how we pressure the quarterback and how we stop the throw game,\" Guerreri said. \"The tweaks are week-to-week in a game plan. What does the opponent do best, and how do we limit that? And what do we do best?\"\u003cbr/\u003e\u003cbr/\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278315583% --\u003e\u003c/p\u003e\u003cp\u003eHaving a new voice in charge of the defensive side of the ball is fitting for the 2023 Hoosiers. The roster is filled with new faces on both sides of the ball, but particularly on defense, where Allen and Co. hit the transfer portal hard. \u003c/p\u003e\u003cp\u003e\u003ca href=\"https://www.si.com/college/indiana/football/indiana-football-transfer-portal-tracker\"\u003eIndiana brought in 17 defensive transfers during the 2023 offseason\u003c/a\u003e, many of whom are expected to start and/or contribute. Guerreri is new to Bloomington just like they are, and he is working in fall camp to bring the diverse, well-traveled group together as one cohesive unit. \u003c/p\u003e\u003cp\u003eHis role as an analyst rather than as a play caller or coach at Ohio State in 2022 might seem like a step back, but Guerreri said the experience will make him a better play caller. While he was not entrenched in the stressful, everyday minutiae that play callers and coaches deal with, he observed the OSU defense from a calmer perspective and got a better understanding of what he wants from his own defenses. \u003c/p\u003e\u003cp\u003e\"Sometimes when you're in the fire, you don't see the bigger picture,\" Guerreri said, describing his role as a defensive analyst. \"It gives you a chance to reassess, and then apply going forward.\" \u003c/p\u003e\u003cp\u003eReassess and apply going forward is a good way to look at everything Allen did as Indiana's head coach this offseason.\u003c/p\u003e\u003cp\u003eAfter Indiana finished a combined 6-18 over the past two seasons, it was clear big changes were needed. \u003c/p\u003e\u003cp\u003eOut went several position coaches and players (either via graduation or transfer portal). In came college football veterans from other schools and new coaches such as Guerreri. They don't intend to tear down what Allen was previously able to build in Bloomington just a few seasons ago. They aim to revamp it and deliver a new and improved product. \u003c/p\u003e\u003cp\u003eGuerreri gets his first chance to show Hoosier nation how he's upgraded the Indiana defense when his old friends at Ohio State come to Bloomington on Sept. 2 for the 2023 season opener. \u003c/p\u003e\u003ch3\u003eRelated Stories on Indiana Football\u003c/h3\u003e\u003cul\u003e\u003cli\u003e\u003cstrong\u003eIU OPPONENT PREVIEW SERIES — OHIO STATE:\u003c/strong\u003e We're previewing all 12 teams that Indiana will face on the football field in 2023, and up first is the one, the only, The Ohio State Buckeyes. \u003cstrong\u003e\u003ca href=\"https://www.si.com/college/indiana/football/ohio-state-big-ten-2023-indiana-football-opponent-preview-series-quarterback-secondary\"\u003eCLICK HERE\u003c/a\u003e\u003c/strong\u003e\u003c/li\u003e\u003cli\u003e\u003cstrong\u003eWHAT CHRISTIAN TURNER BRINGS TO IU: \u003c/strong\u003eThere's almost no one on the Hoosiers' entire roster with as much experience as Wake Forest transfer Christian Turner, and he's ready to round out a versatile Indiana running back trio in 2023.\u003cstrong\u003e\u003ca href=\"https://www.si.com/college/indiana/football/christian-turner-dynamic-indiana-running-back-trio-jaylin-lucas-josh-henderson\"\u003eCLICK HERE\u003c/a\u003e\u003c/strong\u003e\u003c/li\u003e\u003cli\u003e\u003cstrong\u003eRUNNING BACKS, COACHES SEEING IMPROVEMENTS ON O-LINE:\u003c/strong\u003e After an embarrassing performance in the 2022 season, Tom Allen hired Bob Bostad to fix the Indiana offensive line, and everyone from the running backs to other position coaches are already seeing the change they wanted. \u003cstrong\u003e\u003ca href=\"https://www.si.com/college/indiana/football/indiana-football-running-backs-coaches-seeing-offensive-line-improvements-in-fall-camp\"\u003eCLICK HERE\u003c/a\u003e\u003c/strong\u003e\u003c/li\u003e\u003c/ul\u003e\u003cp\u003e\u003ci\u003eCopyright ABG-SI LLC. SPORTS ILLUSTRATED is a registered trademark of ABG-SI LLC. All Rights Reserved.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278315748",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Daniel Olinger\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eSports Illustrated Indiana Hoosiers News, Analysis and More\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Matt Guerreri was hired away from Ohio State by Indiana coach Tom Allen in the 2023 offseason to call plays for the Hoosier defense. On Wednesday, both coaches spoke to the media, and described how they want Guerreri to bring the defense along and improve upon it from where it was in 2022. ",
+      "lead_media": {
+        "id": "278315588",
+        "url": "https://www.mcclatchy-wires.com/incoming/f92ihp/picture278315588",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "c05a7a79-d329-4e7e-903a-d96952e6040d",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692218632,
+        "expires": 1693427122,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692217522,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/f92ihp/picture278315588/alternates/FREE_1140/c05a7a79-d329-4e7e-903a-d96952e6040d",
+        "href": "/web/v1/content/278315588",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "SI Indiana Hoosiers",
+      "copyright": "SI Indiana Hoosiers",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    }
+  ]
+}

--- a/data/news.json
+++ b/data/news.json
@@ -1,0 +1,1751 @@
+{
+  "items": [
+    {
+      "id": "278281728",
+      "url": "https://www.kansascity.com/news/nation-world/national/article278281728.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Husband shows wife a winning lottery ticket after work. ‘Her mouth dropped wide open’",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2629",
+      "home_section": {
+        "name": "National",
+        "url": "https://www.kansascity.com/news/nation-world/national/"
+      },
+      "modified_date": 1692137041,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Husband wins big Iowa lottery prize \u0026 wife’s ‘mouth dropped’",
+      "originating_url": "https://www.kansascity.com/news/nation-world/national/article278281728.html",
+      "meta_description": "Iowa Lottery says man used two small prizes to buy another ticket after work and he won $100,000 prize. He and wife shocked by his winnings.",
+      "published_date": 1692137041,
+      "thumbnail": "https://www.kansascity.com/latest-news/tloi8r/picture278282118/alternates/FREE_1140/PR081023JamesHolston.jpg",
+      "authors": [
+        {
+          "name": "Kaitlyn  Alanis",
+          "email": "kalanis@mcclatchy.com"
+        }
+      ],
+      "keywords": "iowa, lottery, ticket, prize, win",
+      "access_tags": [
+        "matbasic",
+        "matopend"
+      ],
+      "additional_sections": [
+        "2629"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Iowa Lottery says man used two small prizes to buy another ticket after work and he won $100,000 prize. He and wife shocked by his winnings.",
+      "content": "\u003cp\u003eA 61-year-old man stopped at a gas station on his way to work and decided to buy two \u003ca href=\"https://www.ialottery.com/Pages/Pressroom/PressReleaseDetail.aspx?winnerID=1565\" target=\"_blank\" rel=\"Follow\"\u003eIowa lottery tickets\u003c/a\u003e. \u003c/p\u003e\u003cp\u003eOn his lunch break, James Holston scratched the “White Ice” game tickets and realized each one was worth a small prize, according to a news release from the \u003ca href=\"https://www.ialottery.com/Default.aspx\" target=\"_blank\" rel=\"Follow\"\u003eIowa Lottery\u003c/a\u003e. \u003c/p\u003e\u003cp\u003eBut his winning streak wasn’t over yet. \u003c/p\u003e\u003cp\u003eHolston, who works for the University of Dubuque’s security department, stopped at a Kwik Stop on his way home from work to buy a third $10 \u003ca href=\"https://ialottery.com/Pages/Games-Scratch/ScratchGamesDetail.aspx?g=614\" target=\"_blank\" rel=\"Follow\"\u003e“White Ice” ticket\u003c/a\u003e. \u003c/p\u003e\u003cp\u003eAnd that one was a winner, too. \u003c/p\u003e\u003cp\u003e“I thought, ‘Oh, well, it’s going to be another one of those small winners. We never get any big winners here in Dubuque,’” he recalled to lottery officials. “When I saw it, I thought, ‘You’ve got to be kidding me!’”\u003c/p\u003e\u003cp\u003eHe used the Iowa Lottery mobile app to scan his ticket — and it confirmed this was no small prize, according to the release. \u003c/p\u003e\u003cp\u003e“Man, to my surprise, that thing said $100,000,” Holston said when claiming his prize on Aug. 10. “I was like, ‘Oh, my goodness!’”\u003c/p\u003e\u003cp\u003eHe went home to his wife, but he didn’t tell her about his big win right away. Instead, he showed her one of his tickets with a smaller prize. \u003c/p\u003e\u003cp\u003e“She scanned it and said, ‘Hey! $20! You doubled your money,’” Holston told lottery officials. “I said, ‘I have another one over there. Scan that.’ She scanned it and when it came up on her phone, her mouth dropped wide open. I thought, ‘Yep! That’s what I thought!’”\u003c/p\u003e\u003cp\u003eThe couple plans to use their winnings on new vinyl siding, a new home air-conditioning system and other home improvements, officials said. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:256658952% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278278183% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278269548% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278237123% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278281728",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Kaitlyn  Alanis\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:kalanis@mcclatchy.com\"\u003ekalanis@mcclatchy.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "The Iowa man bought the ticket after winning two smaller prizes. ",
+      "lead_media": {
+        "id": "278282118",
+        "url": "https://www.kansascity.com/latest-news/tloi8r/picture278282118",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "PR081023JamesHolston.jpg",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1692134554,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692134554,
+        "thumbnail": "https://www.kansascity.com/latest-news/tloi8r/picture278282118/alternates/FREE_1140/PR081023JamesHolston.jpg",
+        "href": "/web/v1/content/278282118",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "Iowa Lottery",
+        "dateline": "",
+        "caption": "James Holston, 61, with his oversized check.",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": [
+        {
+          "name": "mcc-realtime-ta"
+        }
+      ]
+    },
+    {
+      "id": "278282133",
+      "url": "https://www.miamiherald.com/news/coronavirus/article278282133.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Man’s legs turn purple when he stands up. It’s a rare long COVID symptom, doctors say",
+      "publication": "miamiherald",
+      "layout_option": "none",
+      "home": "/web/v1/sections/82736",
+      "home_section": {
+        "name": "Coronavirus",
+        "url": "https://www.miamiherald.com/news/coronavirus/"
+      },
+      "modified_date": 1692136791,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Blood pooling in legs was caused by long COVID: doctors",
+      "originating_url": "https://www.miamiherald.com/news/coronavirus/article278282133.html",
+      "meta_description": "A 33-year-old man’s blood started pooling in his legs when he stood. Doctors learned it was caused by a rare long COVID symptom.",
+      "published_date": 1692136791,
+      "thumbnail": "https://www.miamiherald.com/latest-news/thlrbp/picture278282068/alternates/FREE_1140/martin-sanchez-Tzoe6VCvQYg-unsplash.jpg",
+      "authors": [
+        {
+          "name": "Irene Wright",
+          "email": "iwright@mcclatchy.com"
+        }
+      ],
+      "keywords": "long COVID, infection, COVID-19, rare, doctor",
+      "access_tags": [
+        "matbasic",
+        "matopend"
+      ],
+      "additional_sections": [
+        "82736",
+        "5092"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "A 33-year-old man’s blood started pooling in his legs when he stood. Doctors learned it was caused by a rare long COVID symptom.",
+      "content": "\u003cp\u003eThe development of a rare heart condition may actually be a symptom of long COVID, researchers say. \u003c/p\u003e\u003cp\u003eA man was referred to a specialist clinic with doctors from the University of Leeds in the United Kingdom after months of odd leg discoloration.\u003c/p\u003e\u003cp\u003eThe 33-year-old’s legs would\u003ca href=\"https://www.thelancet.com/article/S0140-6736(23)01461-7/fulltext\" target=\"_blank\" rel=\"Follow\"\u003e rapidly turn purple\u003c/a\u003e when he would stand, according to a case report published in The Lancet on Aug. 12.\u003c/p\u003e\u003cp\u003e“He reported that his legs would progressively feel heavy, tingly, itchy, and become dusky in color,” the doctors said in the report. \u003c/p\u003e\u003cp\u003eIn \u003ca href=\"https://www.eurekalert.org/news-releases/998264\" target=\"_blank\" rel=\"Follow\"\u003ejust 10 minutes\u003c/a\u003e of standing, the man’s legs would go from completely normal to incredibly uncomfortable, the doctors said in an EurekAlert release. \u003c/p\u003e\u003cp\u003eHis legs would once again go back to normal after a few minutes of sitting or lying down, they said. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278281888; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003eThe condition, a pooling of blood in the veins of the legs, is called acrocyanosis and is a common symptom of a rare heart condition. \u003c/p\u003e\u003cp\u003e“He was diagnosed with postural orthostatic tachycardia syndrome (POTS), a condition that causes an abnormal increase in heart rate on standing,” according to the release. \u003c/p\u003e\u003cp\u003eOnly 0.2% of the population have been diagnosed with POTS, a relatively \u003ca href=\"https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7046364/#:~:text=The%20prevalence%20of%20POTS%20is,United%20States%20have%20the%20disorder.\" target=\"_blank\" rel=\"Follow\"\u003erare disorder\u003c/a\u003e, according to a study shared by the National Institutes of Health.\u003c/p\u003e\u003cp\u003eThe symptoms of POTS — which include lightheadedness, heart palpitations, weakness, blurred vision, exercise intolerance and fatigue — are often misdiagnosed as other conditions due to their similarities, the NIH says.\u003c/p\u003e\u003cp\u003eFor the 33-year-old man, he started to notice the color changes in his legs after he had a COVID-19 infection, according to the release.\u003c/p\u003e\u003cp\u003e“This was a striking case of acrocyanosis in a patient who had not experienced it before his COVID-19 infection,” case report author Manoj Sivan said in the release. “Patients experiencing this may not be aware that it can be a symptom of Long Covid and dysautonomia and may feel concerned about what they are seeing. Similarly, clinicians may not be aware of the link between acrocyanosis and Long Covid.”\u003c/p\u003e\u003cp\u003eA study in 2021 found some people experiencing long COVID symptoms were \u003ca href=\"https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8009458/\" target=\"_blank\" rel=\"Follow\"\u003ealso diagnosed with POTS\u003c/a\u003e, as shared by the NIH.\u003c/p\u003e\u003cp\u003e“POTS can be triggered by infection, surgery, pregnancy or concussion,” the study said, “with the post-infectious being the most common mode of onset.”\u003c/p\u003e\u003cp\u003eSivan’s team says there may be people who have developed POTS after having COVID-19 who may think they are only experiencing long COVID and are therefore not being treated for their condition.\u003c/p\u003e\u003cp\u003eLong COVID \u003ca href=\"https://www.yalemedicine.org/news/long-covid-symptoms#:~:text=The%20symptoms%2C%20such%20as%20chronic,the%20origins%20of%20those%20symptoms.\" target=\"_blank\" rel=\"Follow\"\u003esymptoms\u003c/a\u003e, like brain fog, chest pain and intense fatigue, are similar to POTS and may be misinterpreted.\u003c/p\u003e\u003cp\u003e“We need to ensure that there is more awareness of dysautonomia in Long Covid so that clinicians have the tools they need to manage patients appropriately,” Sivan said in the release.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:277603978% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:276582451% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:276450941% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:275260531% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278282133",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Irene Wright\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:iwright@mcclatchy.com\"\u003eiwright@mcclatchy.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "The rare condition only impacts 0.2% of the population, according to the National Institutes of Health.",
+      "lead_media": {
+        "id": "278282068",
+        "url": "https://www.miamiherald.com/latest-news/thlrbp/picture278282068",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "martin-sanchez-Tzoe6VCvQYg-unsplash.jpg",
+        "publication": "miamiherald",
+        "layout_option": "",
+        "home": "/web/v1/sections/3180",
+        "modified_date": 1692134500,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692134500,
+        "thumbnail": "https://www.miamiherald.com/latest-news/thlrbp/picture278282068/alternates/FREE_1140/martin-sanchez-Tzoe6VCvQYg-unsplash.jpg",
+        "href": "/web/v1/content/278282068",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3180"
+        ],
+        "credit": "Martin Sanchez via Unsplash",
+        "dateline": "",
+        "caption": "The rare heart condition was a symptom of long COVID, a condition that occurs after an infection and persists for months.",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Miami",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278280618",
+      "url": "https://www.charlotteobserver.com/news/state/north-carolina/article278280618.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Remains found two years after man vanished, cops say. Now SC man charged with murder",
+      "publication": "charlotteobserver",
+      "layout_option": "none",
+      "home": "/web/v1/sections/8378",
+      "home_section": {
+        "name": "North Carolina",
+        "url": "https://www.charlotteobserver.com/news/state/north-carolina/"
+      },
+      "modified_date": 1692136165,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Missing North Carolina man’s remains found in South Carolina",
+      "originating_url": "https://www.charlotteobserver.com/news/state/north-carolina/article278280618.html",
+      "meta_description": "A resident of SC was charged with murder after the remains of a missing NC man were found. He had been missing for two years, deputies say",
+      "published_date": 1692136165,
+      "thumbnail": "https://www.charlotteobserver.com/news/nation-world/national/2atc9j/picture272773855/alternates/FREE_1140/RTT-policeHandcuffs.jpg",
+      "authors": [
+        {
+          "name": "Olivia Lloyd",
+          "email": "olloyd@mcclatchy.com"
+        }
+      ],
+      "keywords": "Phillip Cullen Burr, Jacob Dewayne Hall, Rutherford County",
+      "access_tags": [
+        "matbasic",
+        "matopend"
+      ],
+      "additional_sections": [
+        "8378",
+        "7039",
+        "8085"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "A resident of SC was charged with murder after the remains of a missing NC man were found. He had been missing for two years, deputies say",
+      "content": "\u003cp\u003eA South Carolina man has been \u003ca href=\"https://www.facebook.com/RutherfordCountySheriffsOfficeNC/posts/pfbid022gcmnYQ2qgG8Bjnx8FJ5BsXwSv4aCFTHKHMYCZvHxK7vG5dLczD1g5hYe1MPf6Mhl\" target=\"_blank\" rel=\"Follow\"\u003echarged with the murder \u003c/a\u003eof a North Carolina resident who deputies say went missing two years ago.\u003c/p\u003e\u003cp\u003eThe Rutherford County Sheriff’s office asked the public in March 2023 for help locating Phillip Cullen Burr. A family member said Burr, of Ellenboro, North Carolina, had \u003ca href=\"https://local.nixle.com/alert/9988749/?fbclid=IwAR3COdmXSAZziic0d-yUMo1pbm-uqEzuzzhahgRnD5ChpR_2O6fuWy1BSU4\" target=\"_blank\" rel=\"Follow\"\u003enot been seen since \u003c/a\u003eNovember 2021.\u003c/p\u003e\u003cp\u003eMcClatchy News reached out to Rutherford County officials for more details but did not immediately hear back.\u003c/p\u003e\u003cp\u003eAs the investigation got underway, authorities said, the missing person case became a homicide investigation. They identified 30-year-old Jacob Dewayne Hall, of Clover, South Carolina, as a suspect, according to the news release.\u003c/p\u003e\u003cp\u003eYork County jail records show Hall was booked at the \u003ca href=\"https://inmatesinjail.yorkcountygov.com/detentioncenter/inmatesinjail.aspx\" target=\"_blank\" rel=\"Follow\"\u003eSouth Carolina detention center\u003c/a\u003e April 20, 2022 on unrelated charges and is currently being held there. \u003c/p\u003e\u003cp\u003eClover, South Carolina is about 50 miles southeast of Ellenboro, North Carolina.\u003c/p\u003e\u003cp\u003eIn May 2023, investigators with the York County Sheriff’s Office, the York County Coroner’s Office, Foothills Search and Rescue, and the University of South Carolina Anthropology Department executed a warrant on a property in South Carolina, according to the news release. \u003c/p\u003e\u003cp\u003eThere, they say they found Burr’s remains.\u003c/p\u003e\u003cp\u003eA grand jury in Rutherford indicted Hall with first degree murder on Aug. 10, according to the release.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278248363% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278243803% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278261363% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278226738% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278212727% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278280618",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Olivia Lloyd\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:olloyd@mcclatchy.com\"\u003eolloyd@mcclatchy.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "Investigators found the remains of Phillip Cullen Burr of North Carolina",
+      "lead_media": {
+        "id": "272773855",
+        "url": "https://www.charlotteobserver.com/news/nation-world/national/2atc9j/picture272773855",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "RTT-policeHandcuffs.jpg",
+        "publication": "charlotteobserver",
+        "layout_option": "",
+        "home": "/web/v1/sections/8085",
+        "modified_date": 1689690973,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1678037647,
+        "thumbnail": "https://www.charlotteobserver.com/news/nation-world/national/2atc9j/picture272773855/alternates/FREE_1140/RTT-policeHandcuffs.jpg",
+        "href": "/web/v1/content/272773855",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "8085"
+        ],
+        "credit": "Getty Images/iStock photo",
+        "dateline": "",
+        "caption": "Handcuffs, thumb prints",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Charlotte",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278280268",
+      "url": "https://www.kansascity.com/news/politics-government/article278280268.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Missouri Supreme Court upholds law allowing jailing of parents over kids’ missed school",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2595",
+      "home_section": {
+        "name": "Government \u0026 Politics",
+        "url": "https://www.kansascity.com/news/politics-government/"
+      },
+      "modified_date": 1692135128,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Missouri Supreme Court upholds mandatory school attendance law",
+      "originating_url": "https://www.kansascity.com/news/politics-government/article278280268.html",
+      "meta_description": "The Missouri Supreme Court ruled against parents who had challenged a state law requiring them to ensure their children attend school regularly.",
+      "published_date": 1692135128,
+      "thumbnail": "https://www.kansascity.com/news/local/community/lsjournal/jors7i/picture278281628/alternates/FREE_1140/bus",
+      "authors": [
+        {
+          "name": "Jonathan Shorman",
+          "email": "jshorman@kcstar.com"
+        }
+      ],
+      "keywords": "school, attendance, missouri, supreme court, jail",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "2595",
+        "83765",
+        "2415",
+        "2732"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "The Missouri Supreme Court ruled against parents who had challenged a state law requiring them to ensure their children attend school regularly.",
+      "content": "\u003cp\u003eThe Missouri Supreme Court on Tuesday unanimously upheld a state law requiring school attendance, after two parents were sentenced to jail following numerous absences by their children.\u003c/p\u003e\u003cp\u003eIn a 6-0 decision, \u003ca href=\"https://www.courts.mo.gov/file.jsp?id=198519\" target=\"_self\" rel=\"Follow\"\u003ethe court ruled\u003c/a\u003e the law is not unconstitutionally vague, as the parents argued. The court also found enough evidence existed to support finding that the parents knowingly failed to make their children attend school on a regular basis. Judge George Draper didn’t participate in the case.\u003c/p\u003e\u003cp\u003eMissouri law requires parents and guardians of children in enrolled public schools to ensure their children attend “on a regular basis,” but doesn’t define the term. \u003c/p\u003e\u003cp\u003eCaitlyn Williams and Tamarae LaRue, both single parents, had children enrolled in Lebanon public schools who both missed 15 days of school, according to prosecutors. They were charged with class C misdemeanors and a judge found both guilty after a bench trial.\u003c/p\u003e\u003cp\u003eWilliams was sentenced to seven days in jail and LaRue was sentenced to 15 days in jail, with the sentence suspended.\u003c/p\u003e\u003cp\u003e“When measured by common understanding and practices, no Missouri parent would conclude attendance ‘on a regular basis’ means anything less than having their child go to school on those days the school is in session,” Judge Robin Ransom wrote for the court.\u003c/p\u003e\u003cp\u003eRansom wrote that the law “of course” contains exceptions to the mandatory attendance requirements, but that those exceptions weren’t present in the record in the case. The parents didn’t remove their children from the schools’ rolls or demonstrate that their children were mentally or physically incapacitated.\u003c/p\u003e\u003cp\u003e“This nonattendance was not excused by any circumstance provided for in the statute,” Ransom wrote. “Given the notice provided to each parent and that each parent was in control of their young child, evidence existed to support the inference that each parent knowingly failed to cause their child to attend school on a regular basis.”\u003c/p\u003e\u003cp\u003eA public defender representing the parents declined to comment in response to the ruling.\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278280268",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Jonathan Shorman\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:jshorman@kcstar.com\"\u003ejshorman@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "The Missouri Supreme Court ruled that the absences of the children at the center of the case “was not excused by any circumstance provided for” in state law.",
+      "lead_media": {
+        "id": "278281628",
+        "url": "https://www.kansascity.com/news/local/community/lsjournal/jors7i/picture278281628",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "bus",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/73889",
+        "modified_date": 1692133984,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692133984,
+        "thumbnail": "https://www.kansascity.com/news/local/community/lsjournal/jors7i/picture278281628/alternates/FREE_1140/bus",
+        "href": "/web/v1/content/278281628",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "73889"
+        ],
+        "credit": "File photo",
+        "dateline": "",
+        "caption": "The Missouri Supreme Court upheld the state’s anti-truancy school attendance law.",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278235373",
+      "url": "https://www.kansascity.com/news/politics-government/article278235373.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Dolly comes to Kansas. Parton promotes reading program as it expands to JoCo, WyCo",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2595",
+      "home_section": {
+        "name": "Government \u0026 Politics",
+        "url": "https://www.kansascity.com/news/politics-government/"
+      },
+      "modified_date": 1692134928,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Dolly Parton touts Imagination Library expansion in Kansas",
+      "originating_url": "https://www.kansascity.com/news/politics-government/article278235373.html",
+      "meta_description": "The program is now available in Johnson and Wyandotte Counties as every young child in Kansas can access a free book a month. Will it improve reading test scores?",
+      "published_date": 1692054788,
+      "thumbnail": "https://www.kansascity.com/latest-news/rre5yk/picture278250818/alternates/FREE_1140/KCM_DollyPartonKansas_08142%20(5)",
+      "authors": [
+        {
+          "name": "Katie Bernard",
+          "email": "cbernard@kcstar.com"
+        }
+      ],
+      "keywords": "Kansas, Dolly Parton, reading, literacy",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "2595",
+        "97091",
+        "2639",
+        "2415",
+        "2579"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "The program is now available in Johnson and Wyandotte Counties as every young child in Kansas can access a free book a month. Will it improve reading test scores?",
+      "content": "\u003cp\u003eDolly Parton said she started a foundation to give free books to children because her father, though he was very smart, couldn’t read. \u003c/p\u003e\u003cp\u003e“That seemed to trouble him a lot so it troubled me that my daddy was troubled,” Parton, an internationally famous country music star, said. “I thought, ‘I’m gonna start a program and I’m gonna get my dad involved in this.”\u003c/p\u003e\u003cp\u003eSpeaking to a crowd in Overland Park Monday, Parton said she told her father that millions of people didn’t know how to read. Prior to his death, Parton said, her father worked with her to get the program off the ground. \u003c/p\u003e\u003cp\u003e“I made him feel better about himself and he made me feel better because Daddy was smart and he could guide me and direct me in certain ways,” she said.\u003c/p\u003e\u003cp\u003eParton visited Overland Park Monday to celebrate the full implementation of the program, the Imagination Library, in Kansas. Starting this summer every child in the state up to the age of five can receive a free book every month by mail. \u003c/p\u003e\u003cp\u003eDuring an on-stage interview with Kansas Gov. Laura Kelly, a Democrat, Parton shared personal stories and discussed life as a celebrity and her other philanthropic and business efforts. She explained that her father couldn’t read because he didn’t have a chance to go to school. He married her mother when he was 17 and had 12 children by the time he was 37. \u003c/p\u003e\u003cp\u003eKelly, who is Irish Catholic, quipped that with that many siblings\u003cb\u003e \u003c/b\u003eParton could be Irish. \u003c/p\u003e\u003cp\u003e“People always ask, they say ‘while you have 12 kids, your parents have 12 kids, you must be Catholic,’” responded Parton, who grew up in the Great Smoky Mountains of Tennessee. \u003c/p\u003e\u003cp\u003e“I said, ‘No, we’re just horny\u003cb\u003e \u003c/b\u003ehillbillies.’”\u003c/p\u003e\u003cp\u003eParton ended the conversation asking Kelly how someone “so-soft spoken” had gotten into politics and performed two songs, “Try” and “Coat of Many Colors,” for the crowd at the Jewish Community Center’s White Theatre.\u003c/p\u003e\u003ch3\u003eImagination Library\u003c/h3\u003e\u003cp\u003e\u003ca href=\"https://imaginationlibrary.com/\" target=\"_self\" rel=\"Follow\"\u003eParton’s program\u003c/a\u003e started in Tennessee in 1995. In 2005, Pratt, Kansas, was the first community outside Tennessee to begin a local Imagination Library program. \u003c/p\u003e\u003cp\u003eEarlier this year,\u003cb\u003e \u003c/b\u003eKansas lawmakers approved $1.5 million in funds for Kelly’s Children’s Cabinet, which administers early childhood programs, to expand the Imagination Library. Prior to the expansion in July, Johnson and Wyandotte Counties were among 12 counties in the state that did not have universal access to the program. Last year, the Shawnee Mission Education Foundation began offering the program to Johnson County children within Shawnee Mission School District boundaries. \u003c/p\u003e\u003cp\u003eState Senate Minority Leader Dinah Sykes, a Lenexa Democrat, said she was excited to see the program expand to Johnson County families and believed they would benefit from the tips offered to parents in each book. \u003c/p\u003e\u003cp\u003e“There’s something about getting something in the mail and the excitement and wanting to share that with your child,” she said. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278250898; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003eThe program has grown by about 12,000 students in the past year, said Melissa Rooker, executive director of the Kansas Children’s Cabinet. Much of that has come through promotion over the summer as the program expands. State and local partners cover the cost of postage and books for Kansas children while Parton’s foundation manages all administrative and overhead costs. \u003c/p\u003e\u003cp\u003eLawmakers and advocates hope the program will play a role in improving reading outcomes for Kansas students, which have been declining for more than a decade.\u003c/p\u003e\u003cp\u003eAccording to data from the \u003ca href=\"https://datacenter.aecf.org/data/line/1272-reading-proficiency?loc=18\u0026loct=2#2/any/false/2048,1729,37,871,870,573,869,36,868,867/asc/any/2751\"\u003eAnnie E Casey Foundation\u003c/a\u003e, Kansas’ reading proficiency rates have been consistently declining since 2011. \u003c/p\u003e\u003cp\u003eFrom 2011 to 2013, the\u003cb\u003e \u003c/b\u003epercentage of fifth graders in the top three performance levels on reading assessments from 87.29% to 84.91%. In 2015 the state began calculating instead the reading proficiency among students between 3rd and 8th grade. In 2015, 79.62% of those students met the basic assessment level or above. In 2021 that number had dropped to 70%. \u003c/p\u003e\u003cp\u003eThe drops in proficiency came on a backdrop of lawsuits alleging insufficient funding for Kansas’ K-12 schools immediately followed by COVID-19, which wreaked havoc on student achievement nationwide. \u003c/p\u003e\u003cp\u003eLeah Fliter, a lobbyist for the Kansas Association of School Boards, said districts are expecting to see scores improve when they are reported later this year. \u003c/p\u003e\u003cp\u003e“School funding has been phased back in and with COVID now hopefully out of the way,” Fliter said. “We’re going to start seeing some improvement.”\u003c/p\u003e\u003cp\u003eSimilar challenges have been seen nationwide as questions have been raised about the efficacy of \u003ca href=\"https://www.nytimes.com/2023/04/16/us/science-of-reading-literacy-parents.html#:~:text=About%20one%20in%20three%20children,below%20basic%E2%80%9D%20by%20eighth%20grade.\"\u003ecommon methods used to teach reading.\u003c/a\u003e\u003c/p\u003e\u003cp\u003eParton’s foundation hits on an area many see as a pathway toward improved outcomes for students, strong early childhood opportunities. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278253508; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003e“You’ve got to start young to avoid problems later,” Kelly told reporters before the event. “This really levels that playing field so that every child everywhere, every family, will have access to books and with the emphasis on actually reading the book.”\u003c/p\u003e\u003cp\u003eState Sen. Renee Erickson, a Wichita Republican, said she was concerned about the state’s declining test scores despite increased funding for K-12 schools in recent years. She said she hoped expansion of Parton’s program would help with early intervention, but that it would only work if parents signed up. \u003c/p\u003e\u003cp\u003e“Hopefully with Dolly, herself, coming to the state, and getting some publicity around that, that will help families become aware of this opportunity,” Erickson said. \u003c/p\u003e\u003cp\u003eIn addition to holding the celebration Monday, billboards promoting the non-profit are up around the state. Rooker said the children’s cabinet has plans to increase promotional work in the coming months. \u003c/p\u003e\u003cp\u003eThough the Imagination Library has been shown to have success in improving literacy in the areas it’s been implemented, Kansas advocates say it is a step toward better outcomes and not the solution. \u003c/p\u003e\u003cp\u003eJohn Wilson, president of Kansas Action for Children, said Kansas needs to look next to more substantial investment in the early childhood education system. \u003c/p\u003e\u003cp\u003e“Programs like the Imagination Library are critical and can be powerful tools in and of themselves,” Wilson said. “We undercut our investment in the Imagination Library if we don’t invest in other areas.”\u003c/p\u003e\u003cp\u003e\u003ci\u003eThis story was updated to reflect the program has been available in the Shawnee Mission School District since last year. \u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278235373",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Katie Bernard\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:cbernard@kcstar.com\"\u003ecbernard@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "Officials hope the Imagination Library, now available in Johnson and Wyandotte County, will improve student’s reading scores. ",
+      "lead_media": {
+        "id": "278250818",
+        "url": "https://www.kansascity.com/latest-news/rre5yk/picture278250818",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "KCM_DollyPartonKansas_08142 (5)",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1692054036,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692054036,
+        "thumbnail": "https://www.kansascity.com/latest-news/rre5yk/picture278250818/alternates/FREE_1140/KCM_DollyPartonKansas_08142%20(5)",
+        "href": "/web/v1/content/278250818",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "ecuriel@kcstar.com",
+        "dateline": "",
+        "caption": "Dolly Parton speaks about the Imagination Library at White Theatre at the Jewish Community Center on Monday, Aug. 14, 2023, in Overland Park, Kan.",
+        "photographer": "Emily Curiel",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278278278",
+      "url": "https://www.miamiherald.com/news/nation-world/world/article278278278.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Richly decorated synagogue — one of the oldest — unearthed. See its marble treasures",
+      "publication": "miamiherald",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5093",
+      "home_section": {
+        "name": "World",
+        "url": "https://www.miamiherald.com/news/nation-world/world/"
+      },
+      "modified_date": 1692134625,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Ancient synagogue and marble treasures found in Russia ",
+      "originating_url": "https://www.miamiherald.com/news/nation-world/world/article278278278.html",
+      "meta_description": "Archaeologists discovered one of the oldest synagogues in the world in Russia. It was filled with marble artifacts including menorahs.",
+      "published_date": 1692134625,
+      "thumbnail": "https://www.miamiherald.com/latest-news/8sz2iu/picture278280128/alternates/FREE_1140/ruins%20of%20synagogu_fitted.jpeg",
+      "authors": [
+        {
+          "name": "Moira Ritter",
+          "email": "mritter@mcclatchy.com"
+        }
+      ],
+      "keywords": "russia, black sea, synagogue, ancient, discover",
+      "access_tags": [
+        "matbasic",
+        "matopend"
+      ],
+      "additional_sections": [
+        "5093",
+        "3180"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Archaeologists discovered one of the oldest synagogues in the world in Russia. It was filled with marble artifacts including menorahs.",
+      "content": "\u003cp\u003eArchaeologists in Russia recently unearthed the ruins of a sprawling ancient building — and discovered the oldest synagogue in the country and one of the oldest synagogues in the world.\u003c/p\u003e\u003cp\u003e\u003ca href=\"https://volnoe-delo.ru/events/news/na-kubani-obnaruzhili-odnu-iz-drevneyshikh-v-mire-sinagog/\" target=\"_blank\" rel=\"Follow\"\u003eThe Phanagoria Synagogue \u003c/a\u003ewas discovered during ongoing excavations in Kuban, according to an Aug. 15 news release from the Oleg Deripaska’s Volnoe Delo Foundation. The site was home to a flourishing ancient city with a robust Jewish community dating to about the first century.\u003c/p\u003e\u003cp\u003eResearchers said they discovered the building’s walls and foundation, along with a trove of ancient treasures.\u003c/p\u003e\u003cp\u003eThe nearly \u003ca href=\"https://www.archaeolog.ru/ru/press/articles/fanagoriyskaya-sinagoga\" target=\"_blank\" rel=\"Follow\"\u003e2,000-year-old synagogue was richly decorated\u003c/a\u003e, with a tiled roof, painted and marble-tiled walls and strong floors, the Institute of Archaeology of the Russian Academy of Sciences said in an Aug. 15 news release. Inside the synagogue were lavish marble columns and a fenced off section for Torah scrolls and scripture reading.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278280153; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278280143; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003eArchaeologists also found fragments of at least three luxuriously decorated marble menorahs and several marble tables that were used for religious purposes, the institute said. Several fragments of marble with Greek inscriptions — one translating to “synagogue” — were also uncovered.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278280138; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278281283; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003ePrevious excavations in the area revealed tombstones depicting menorahs, confirming the existence of a Jewish community in the city, according to the institute.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278280158; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003eThe rectangular building, measuring about 70 feet by 20 feet, was composed of two rooms, each about 650 square feet, the Oleg Deripaska’s Volnoe Delo Foundation said. It was destroyed in the middle of the sixth century when tribes attacked and burned down the city.\u003c/p\u003e\u003cp\u003eThe synagogue also offers experts insight into Judaism practice during the religion’s “Second Temple Period,” experts with the foundation said. From 516 B.C. until 70 A.D., most Jewish rituals took place at the second Jerusalem Temple, so it was rare for synagogues to be built elsewhere. \u003c/p\u003e\u003cp\u003eKuban is in southeast Russia, bordering the Black Sea.\u003c/p\u003e\u003cp\u003e\u003ci\u003eGoogle Translate was used to translate news releases from the Oleg Deripaska’s Volnoe Delo Foundation and the Institute of Archaeology of the Russian Academy of Sciences.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278091472% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278170222% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278246008% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278278278",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Moira Ritter\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:mritter@mcclatchy.com\"\u003emritter@mcclatchy.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "The synagogue, which was found in Russia, dates to the first century.",
+      "lead_media": {
+        "id": "278280128",
+        "url": "https://www.miamiherald.com/latest-news/8sz2iu/picture278280128",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "ruins of synagogu_fitted.jpeg",
+        "publication": "miamiherald",
+        "layout_option": "",
+        "home": "/web/v1/sections/3180",
+        "modified_date": 1692131980,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692131980,
+        "thumbnail": "https://www.miamiherald.com/latest-news/8sz2iu/picture278280128/alternates/FREE_1140/ruins%20of%20synagogu_fitted.jpeg",
+        "href": "/web/v1/content/278280128",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3180"
+        ],
+        "credit": "The Institute of Archaeology of the Russian Academy of Sciences",
+        "dateline": "",
+        "caption": "The ancient synagogue was discovered near the Black Sea in Russia, experts said.",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Miami",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": [
+        {
+          "name": "mcc-realtime-ta"
+        }
+      ]
+    },
+    {
+      "id": "278265328",
+      "url": "https://www.kansascity.com/news/politics-government/article278265328.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "After Trump indictment, Ashcroft dodges how he would handle interference in Missouri",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2595",
+      "home_section": {
+        "name": "Government \u0026 Politics",
+        "url": "https://www.kansascity.com/news/politics-government/"
+      },
+      "modified_date": 1692133931,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Missouri’s Ashcroft dodges how he would handle Trump interference",
+      "originating_url": "https://www.kansascity.com/news/politics-government/article278265328.html",
+      "meta_description": "After Donald Trump’s indictment for attempting to interfere in Georgia’s elections, Missouri Secretary of State Jay Ashcroft dodged whether he would resist the former president.",
+      "published_date": 1692122423,
+      "thumbnail": "https://www.kansascity.com/latest-news/y71jlh/picture256256667/alternates/FREE_1140/jay%20ashcroft.JPG",
+      "authors": [
+        {
+          "name": "Kacen Bayless",
+          "email": "kbayless@kcstar.com"
+        }
+      ],
+      "keywords": "missouri, ashcroft, trump, indictment, georgia, election",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "2595",
+        "97091",
+        "2415",
+        "2640"
+      ],
+      "credit": "",
+      "dateline": "Columbia",
+      "summary": "After Donald Trump’s indictment for attempting to interfere in Georgia’s elections, Missouri Secretary of State Jay Ashcroft dodged whether he would resist the former president.",
+      "content": "\u003cp\u003eAs former President Donald Trump faces an indictment for attempting to interfere in Georgia’s 2020 election, Missouri’s top election official dodged how he would have handled the situation in Missouri. \u003c/p\u003e\u003cp\u003eWhen asked specifically by The Star on Tuesday whether Missouri Secretary of State Jay Ashcroft would have resisted Trump’s attempts to overturn an election result in Missouri as Georgia officials did in their state, Ashcroft’s campaign side-stepped the question. \u003c/p\u003e\u003cp\u003e“As Secretary of State, Jay has prioritized election integrity, and demonstrated a commitment to running credible elections. As a result, Missouri now ranks third in the nation for election integrity and is a model for other states,” spokesperson Jason Cabel Roe said in an email, citing a report from the Heritage Foundation, a Washington-based conservative think tank.\u003c/p\u003e\u003cp\u003e“Jay has demonstrated a willingness to listen to all Missourians and will always take a fact-based approach to investigating election irregularities.”\u003c/p\u003e\u003cp\u003eAshcroft, a Republican, is running for governor in 2024.\u003c/p\u003e\u003cp\u003eMonday’s \u003ca href=\"https://www.kansascity.com/news/politics-government/article277842363.html\"\u003eindictment against the former president\u003c/a\u003e offers an interesting case study for Ashcroft, who is in charge of running Missouri’s elections. Ashcroft holds the same office as Georgia Secretary of State Brad Raffensperger, a Republican who Trump allegedly \u003ca href=\"https://www.kansascity.com/news/politics-government/article277842363.html\"\u003eattempted to pressure to overturn the election results in Georgia\u003c/a\u003e. \u003c/p\u003e\u003cp\u003eThe statement from Ashcroft’s team illustrates how the Republican is walking a fine line between not supporting the former president’s actions while also refusing to criticize Trump, who is now facing his fourth indictment as he mounts another campaign for the White House.\u003c/p\u003e\u003cp\u003eSpokespeople for Missouri Lt. Gov. Mike Kehoe, a Republican who is running for governor against Ashcroft, did not respond to questions asking whether Kehoe would have resisted Trump’s demands. \u003c/p\u003e\u003cp\u003eIn contrast to Ashcroft and Kehoe, Kansas Gov. Laura Kelly, a Democrat, strongly applauded the way Georgia officials handled Trump’s pressure campaign that followed the election. \u003c/p\u003e\u003cp\u003e“I do think they handled it appropriately, they were doing their job,” Kelly said. “So yeah, if something like this were to happen in Kansas I would hope that our election officials would do likewise.”\u003c/p\u003e\u003cp\u003eIn a separate statement from Ashcroft’s official office, spokesperson JoDonn Chaney touted Missouri’s “safe and accurate elections.”\u003c/p\u003e\u003cp\u003e“Secretary Ashcroft took an oath to follow the constitution, which he takes very seriously,” Chaney said. “He abides by Missouri statute and will continue to do so in all circumstances.”\u003c/p\u003e\u003cp\u003eHowever, Ashcroft has taken steps that critics argue have elevated debunked claims of election fraud. \u003c/p\u003e\u003cp\u003eIn January, The Star \u003ca href=\"https://www.kansascity.com/news/politics-government/article270827147.html\"\u003erevealed that Ashcroft met with right-wing conspiracy theorist and MyPillow founder Mike Lindell\u003c/a\u003e in Jefferson City. Lindell played a major role in promoting baseless lies about the 2020 election and has continued to elevate claims in the years that have followed. \u003c/p\u003e\u003cp\u003eIn the months following the November 2020 vote, Trump attempted to push officials in Georgia, including Raffensperger, to overturn their official vote counts. The Republican resisted the former president. \u003c/p\u003e\u003cp\u003eIn a 2021 \u003ca href=\"https://www.kansascity.com/news/politics-government/article277842363.html\"\u003etelephone conversation\u003c/a\u003e, Trump pushed Raffensperger to overturn the state’s election results by finding enough votes to declare him the victor. This act led Fani Willis, the district attorney in Fulton County, Georgia, to charge Trump with felony charges for soliciting a violation of oath by a public officer and making false statements and writings. \u003c/p\u003e\u003cp\u003e“What I want to do is this,” Trump said in the phone call. “I just want to find, uh, 11,780 votes.”\u003c/p\u003e\u003cp\u003eAshcroft’s stance on the indictment is on par with his decisions as secretary of state. Following Trump’s debunked theories after the 2020 presidential election, Ashcroft said he was confident that Missouri’s elections were secure. But, at the same time, the Republican has taken an approach that some say \u003ca href=\"https://www.kansascity.com/news/politics-government/article274207115.html\"\u003esupports unproven claims about the elections in which he runs\u003c/a\u003e. \u003c/p\u003e\u003cp\u003eIn April, The Guardian reported that Ashcroft was among 10 state election officials who \u003ca href=\"https://www.theguardian.com/us-news/2023/apr/05/heritage-foundation-election-voting-rights-republican-states\"\u003eattended a secret February conference\u003c/a\u003e held by three groups that spread election denial lies and advocate for stricter voting laws.\u003c/p\u003e\u003cp\u003eKehoe’s unwillingness to weigh in on the indictment comes as Georgia’s former lieutenant governor was a witness against the former president in the Georgia election case. \u003c/p\u003e\u003cp\u003eTrump on Monday went on his social media site Truth Social and said Former Georgia Lt. Gov. Geoff Duncan, a Republican who served from 2019 to January 2023, should not testify. \u003c/p\u003e\u003cp\u003e“Republicans should never let honesty be mistaken for weakness,” Duncan posted Saturday on the social media site X, formerly known as Twitter, confirming that he had been called to testify. Current Georgia Lt. Gov. Burt Jones, also a Republican, is listed as one of nearly three dozen unindicted co-conspirators in the indictment against Trump.\u003c/p\u003e\u003cp\u003eAfter Monday’s indictment, Missouri Republicans, who typically have been quick to defend the former president and have painted his previous charges as politically-motivated, were largely silent. \u003c/p\u003e\u003cp\u003eMissouri Attorney General Andrew Bailey, one of the few officials to weigh in on social media, attempted to paint the indictment as a First Amendment violation, using the charges to promote the \u003ca href=\"https://www.kansascity.com/news/politics-government/article277459998.html\"\u003estate’s lawsuit\u003c/a\u003e alleging that the White House violated the First Amendment by working with social media companies to suppress conservative speech.\u003c/p\u003e\u003cp\u003e“Leftists seriously just indicted President Trump for tweeting and Mark Meadows for texting. This is precisely why Missouri is taking Joe Biden to task over his censorship regime,” Bailey posted, referring to Trump’s former chief of staff who was also indicted. “If the First Amendment goes, it all goes.” \u003c/p\u003e\u003cp\u003eMissouri Republican Sens. Josh Hawley and Eric Schmitt, both ardent Trump supporters, did not respond to requests for comment on Tuesday and neither posted about the indictment on social media. \u003c/p\u003e\u003cp\u003eHowever, just hours before the indictment, Schmitt posted photographs on social media at the Iowa State Fair with Trump supporters and Matthew Whitaker, who was acting U.S. attorney general under Trump. \u003c/p\u003e\u003cp\u003e“In Iowa. For Trump. For America,” Schmitt posted. \u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Star’s Katie Bernard contributed to this report. \u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278265328",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Kacen Bayless\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:kbayless@kcstar.com\"\u003ekbayless@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "“Jay has demonstrated a willingness to listen to all Missourians and will always take a fact-based approach to investigating election irregularities,” an Ashcroft spokesperson told The Star. ",
+      "lead_media": {
+        "id": "256256667",
+        "url": "https://www.kansascity.com/latest-news/y71jlh/picture256256667",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "jay ashcroft.JPG",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1638384356,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1638384356,
+        "thumbnail": "https://www.kansascity.com/latest-news/y71jlh/picture256256667/alternates/FREE_1140/jay%20ashcroft.JPG",
+        "href": "/web/v1/content/256256667",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "Star file photo",
+        "dateline": "",
+        "caption": "Missouri Secretary of State Jay Ashcroft",
+        "photographer": "Tim Bommel",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278280503",
+      "url": "https://www.kansascity.com/news/local/crime/article278280503.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Judge sentences Olathe man who led pursuit on KC’s Charles B. Wheeler Airport runway",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2619",
+      "home_section": {
+        "name": "Crime",
+        "url": "https://www.kansascity.com/news/local/crime/"
+      },
+      "modified_date": 1692133318,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Man gets prison for pursuit on downtown KC airport runway",
+      "originating_url": "https://www.kansascity.com/news/local/crime/article278280503.html",
+      "meta_description": "Efren Torres-Rodriguez, 35, pleaded guilty in March in the Western District of Missouri to damaging and disrupting an international airport.",
+      "published_date": 1692133318,
+      "thumbnail": "https://www.kansascity.com/latest-news/hf3wxf/picture262029222/alternates/FREE_1140/wheeler%20downtown%20airport%20photo.JPG",
+      "authors": [
+        {
+          "name": "Bill Lukitsch",
+          "email": "blukitsch@kcstar.com"
+        }
+      ],
+      "keywords": "kansas city, airport, charles b wheeler, chase, police, efren torres-rodriguez, ",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "2619",
+        "2415",
+        "2598",
+        "2579"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Efren Torres-Rodriguez, 35, pleaded guilty in March in the Western District of Missouri to damaging and disrupting an international airport.",
+      "content": "\u003cp\u003eAn Olathe man who \u003ca href=\"https://www.kansascity.com/news/local/crime/article262026562.html\" target=\"_blank\" rel=\"Follow\"\u003eled police on a high-speed chase\u003c/a\u003e down a runway at Kansas City’s \u003ca href=\"https://flymkc.com/\" target=\"_blank\" rel=\"Follow\"\u003eCharles B. Wheeler Downtown Airport\u003c/a\u003e 18 months ago was sentenced to more than five years in prison.\u003c/p\u003e\u003cp\u003eEfren Torres-Rodriguez, 35, \u003ca href=\"https://www.kansascity.com/news/local/crime/article272900800.html\" target=\"_self\" rel=\"Follow\"\u003epleaded guilty in March\u003c/a\u003e in the Western District of Missouri to damaging and disrupting an international airport. He also admitted to illegally possessing a firearm. \u003c/p\u003e\u003cp\u003eDuring a hearing Tuesday, Judge Howard F. Sachs ordered Torres-Rodriguez to spend 78 months in federal prison without the possibility of parole. \u003c/p\u003e\u003cp\u003eOn Feb. 1, 2022, prosecutors say Torres-Rodriguez was asleep inside a Dodge Charger, with the engine running, that was parked near an airport gate. Kansas City police officers responded there to a report of a suspicious vehicle. He awoke when officers turned off the car and opened the door. \u003c/p\u003e\u003cp\u003eProsecutors said Torres-Rodriguez refused to exit the car and took off, crashing through the airport gate and driving down a runway at 100 mph as officers were on his tail. The sports car was rendered disabled after he tried to cross through the grass next to the airstrip. \u003c/p\u003e\u003cp\u003eTorres-Rodriguez had a little less than five grams of methamphetamine in his pants pocket, according to prosecutors. An unloaded handgun was underneath the driver’s seat. \u003c/p\u003e\u003cp\u003eThe commotion led to a 40-minute delay of operations at Charles B. Wheeler, which serves corporate, charter and recreational airplanes. Prosecutors say five flights were affected, including one plane that was forced to spend an extra hour in the air for lack of a place to land.\u003c/p\u003e\u003cp\u003eAn estimated $23,000 in damage was also calculated, which was paid for by the insurance company holding the policy for Torres-Rodriguez’s car. \u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278280503",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Bill Lukitsch\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:blukitsch@kcstar.com\"\u003eblukitsch@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "The 35-year-old drove at 100 miles an hour down an airport runway with Kansas City police officers on his tail, according to prosecutors.",
+      "lead_media": {
+        "id": "262029222",
+        "url": "https://www.kansascity.com/latest-news/hf3wxf/picture262029222",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "wheeler downtown airport photo.JPG",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1654104566,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1654104566,
+        "thumbnail": "https://www.kansascity.com/latest-news/hf3wxf/picture262029222/alternates/FREE_1140/wheeler%20downtown%20airport%20photo.JPG",
+        "href": "/web/v1/content/262029222",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "Google Maps",
+        "dateline": "",
+        "caption": "A federal grand jury in Kansas City has indicted a 34-year-old Efren Torres-Rodriguez of Olathe following a high-speed police chase down a runway at the Wheeler Downtown Airport in Kansas City. This Google Maps Street View image of the airport is from 2021.",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278269128",
+      "url": "https://www.kansascity.com/news/state/kansas/article278269128.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Latest on Kansas newspaper raid: KBI takes over case; what to know about privacy law",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2639",
+      "home_section": {
+        "name": "Kansas",
+        "url": "https://www.kansascity.com/news/state/kansas/"
+      },
+      "modified_date": 1692132656,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Latest news on Marion, Kansas, newspaper police raid",
+      "originating_url": "https://www.kansascity.com/news/state/kansas/article278269128.html",
+      "meta_description": "The Kansas Bureau of Investigation took over the case after cops raided the Marion County Record in a small KS town, sparking Frist Amendment concerns.",
+      "published_date": 1692118856,
+      "thumbnail": "https://www.kansascity.com/latest-news/8x7prb/picture278248523/alternates/FREE_1140/EricMeyer_outside_Luke.jpg",
+      "authors": [
+        {
+          "name": "Natalie Wallington",
+          "email": "nwallington@kcstar.com"
+        }
+      ],
+      "keywords": "marion, kansas, newspaper, raid, police, KBI",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "2639",
+        "97091",
+        "2415"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "The Kansas Bureau of Investigation took over the case after cops raided the Marion County Record in a small KS town, sparking Frist Amendment concerns.",
+      "content": "\u003cp\u003eNew developments are unfolding in the case of the \u003ca href=\"https://www.kansascity.com/news/state/kansas/article278235083.html\" target=\"_self\" rel=\"Follow\"\u003eMarion, Kansas, newspaper raided by police\u003c/a\u003e on Friday. The homes of a local city councilwoman and the paper’s editor and publisher were also searched.\u003c/p\u003e\u003cp\u003eNow, the\u003ca href=\"https://www.kansas.gov/kbi/\" target=\"_self\" rel=\"Follow\"\u003e Kansas Bureau of Investigation\u003c/a\u003e has taken over the case — and the governor has weighed in. \u003c/p\u003e\u003cp\u003eGet caught up on the latest developments with these five things to know.\u003c/p\u003e\u003ch3\u003eKBI has taken over the investigation\u003c/h3\u003e\u003cp\u003eThe Kansas Bureau of Investigation became the “lead law enforcement agency” in the investigation of the Marion County Record on Monday, The Star’s Jonathan Shorman reports.\u003c/p\u003e\u003cp\u003eKBI spokesperson Melissa Underwood told The Star that the agency will “review prior steps taken and work to determine how best to proceed with the case,” which involved a search warrant suggesting that the newspaper’s offices contained evidence of \u003ca href=\"https://www.kansascity.com/news/state/kansas/article278245883.html\"\u003eidentity theft and improper use of computers\u003c/a\u003e.\u003c/p\u003e\u003cp\u003eIt’s unclear why the \u003ca href=\"https://www.kansas.gov/kbi/\"\u003eKBI\u003c/a\u003e, a state agency based in Topeka which provides advanced law enforcement services like forensic lab testing and special operations, has taken over this case.\u003c/p\u003e\u003cp\u003e\u003cb\u003eRead more: \u003ca href=\"https://www.kansascity.com/news/politics-government/article278253028.html\" target=\"_self\" rel=\"Follow\"\u003eKBI takes lead in Marion investigation following police raid of local newspaper\u003c/a\u003e\u003c/b\u003e\u003c/p\u003e\u003ch3\u003eNewspaper’s lawyer demands police not search seized documents\u003c/h3\u003e\u003cp\u003eIn a \u003ca href=\"https://www.kansascity.com/news/politics-government/article278234378.html\"\u003estrongly worded letter\u003c/a\u003e Sunday, Marion County Record attorney Bernie Rhodes demanded that authorities not review the documents and materials they seized in Friday’s raid. Rhodes also represents The Star.\u003c/p\u003e\u003cp\u003e“The computers, cell phones and other items you illegally seized contain the identity of confidential sources, as well as information provided by those confidential sources,” Rhodes’ letter says. “This information is protected by both federal and state law.”\u003c/p\u003e\u003cp\u003eRhodes also pointed to a “\u003ca href=\"http://kslegislature.org/li/b2023_24/statute/060_000_0000_chapter/060_004_0000_article/060_004_0083_section/060_004_0083_k/\"\u003eshield law\u003c/a\u003e” that protects journalists in Kansas from seizure of their materials without a hearing. \u003c/p\u003e\u003cp\u003e\u003cb\u003eRead more: \u003ca href=\"https://www.kansascity.com/news/politics-government/article278234378.html\" target=\"_self\" rel=\"Follow\"\u003eRaided Kansas paper’s lawyer demands police chief not review info from ‘illegal searches’\u003c/a\u003e\u003c/b\u003e\u003c/p\u003e\u003ch3\u003eKansas Gov. Laura Kelly questions whether rights were violated\u003c/h3\u003e\u003cp\u003eIn a statement Monday night, Kansas Gov. Laura Kelly expressed her support for further inquiry into Friday’s raid, The Star’s Katie Bernard reports. .\u003c/p\u003e\u003cp\u003e“I want to make sure that in the state of Kansas, that we are not violating either individuals’ or press’s constitutional right to free speech,” Kelly said. “We look forward to getting all of the facts out so we know what kind of issue we have.”\u003c/p\u003e\u003cp\u003eKelly didn’t explicitly condemn the raid or share her opinion on whether she believes the paper’s rights were violated.\u003c/p\u003e\u003cp\u003e\u003cb\u003eRead more: \u003ca href=\"https://www.kansascity.com/news/politics-government/article278243408.html\" target=\"_self\" rel=\"Follow\"\u003eKansas Gov. Laura Kelly says questions should be asked about raid on Marion newspaper\u003c/a\u003e\u003c/b\u003e\u003c/p\u003e\u003ch3\u003ePolice had a search warrant — but is that enough to search a newsroom?\u003c/h3\u003e\u003cp\u003eIn order to get a search warrant in Kansas, officers or others must convince a judge that they have cause to believe a crime has been (or will be) committed. \u003c/p\u003e\u003cp\u003ePolice in Marion did that — but the \u003ca href=\"https://www.law.cornell.edu/uscode/text/42/2000aa\"\u003ePrivacy Protection Act\u003c/a\u003e of 1980 \u003ca href=\"https://www.kansascity.com/news/state/kansas/article278245883.html\"\u003eestablishes stricter guidelines\u003c/a\u003e for searching journalists’ materials than for most other documents. \u003c/p\u003e\u003cp\u003eUnder this federal law, materials can only be seized without a court subpoena if a reporter is suspected of a crime, the documents are needed to prevent a death or serious injury or if police believe the documents will be destroyed if they are not immediately seized.\u003c/p\u003e\u003cp\u003eThe warrant to search the Record’s offices indicated that police suspected “\u003ca href=\"https://ksrevisor.org/statutes/chapters/ch21/021_061_0007.html\"\u003eidentity theft\u003c/a\u003e” and “\u003ca href=\"https://www.ksrevisor.org/statutes/chapters/ch21/021_058_0039.html\"\u003eunlawful acts concerning computers\u003c/a\u003e” had occurred. \u003c/p\u003e\u003cp\u003eA state “\u003ca href=\"http://kslegislature.org/li/b2023_24/statute/060_000_0000_chapter/060_004_0000_article/060_004_0082_section/060_004_0082_k/\" target=\"_self\" rel=\"Follow\"\u003eshield law\u003c/a\u003e” that protects journalists from seizures of their materials indicates that a hearing is necessary before seizing documents from a news agency.\u003c/p\u003e\u003cp\u003eIn order to seize a journalist’s documents, law enforcement must prove in court that the information they want is relevant to a case, can’t be obtained through other means and is of a “compelling interest,” meaning it could prevent a crime or harm coming to a person.\u003c/p\u003e\u003cp\u003e“Interests that are not compelling include, but are not limited to, those of parties whose litigation lacks sufficient grounds, is abusive or is brought in bad faith,” the state statute reads.\u003c/p\u003e\u003cp\u003e\u003cb\u003eRead more: \u003ca href=\"https://www.kansascity.com/news/state/kansas/article278245883.html\" target=\"_self\" rel=\"Follow\"\u003eWhen can police raid a newspaper like the Marion County Record? Here’s what the law says\u003c/a\u003e\u003c/b\u003e\u003c/p\u003e\u003ch3\u003eThe newspaper had previously investigated Marion’s new police chief \u003c/h3\u003e\u003cp\u003eThe Record had previously investigated Marion’s new police chief, Gideon Cody, at the time of the raid. Cody had recently started the job after 24 years as a captain with the KCPD.\u003c/p\u003e\u003cp\u003eMeyer declined to comment on the exact nature of the investigation, but characterized “the charges as serious.” The paper informed city officials of allegations against Cody, but had not published anything about them at the time of the raid.\u003c/p\u003e\u003cp\u003eCody led the raid Friday based on a search warrant. \u003c/p\u003e\u003cp\u003e“I have already been vetted. They’ve (the newspaper) actually did a background on me. And that’s why they chose not to (publish a story),” Cody said in \u003ca href=\"https://www.kansascity.com/news/state/kansas/article278212472.html\"\u003ea Sunday interview\u003c/a\u003e with The Star. \u003c/p\u003e\u003cp\u003e“However, if they can muddy the water, make my credibility look bad, I totally get it. They’re gonna try to do everything they possibly can.”\u003c/p\u003e\u003cp\u003e\u003cb\u003eRead more: \u003ca href=\"https://www.kansascity.com/news/state/kansas/article278212472.html\" target=\"_self\" rel=\"Follow\"\u003eKansas newspaper raided, shut down by police had investigated chief who came from KCPD\u003c/a\u003e\u003c/b\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Star’s Jonathan Shorman, Katie Bernard, Glenn E. Rice, Judy Thomas and Luke Nozicka contributed. \u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eDo you have more questions about the police raid at a Kansas newspaper office? Ask the Service Journalism team at \u003c/i\u003e\u003ca href=\"mailto:kcq@kcstar.com\"\u003e\u003ci\u003ekcq@kcstar.com\u003c/i\u003e\u003c/a\u003e\u003ci\u003e. \u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278269128",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Natalie Wallington\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:nwallington@kcstar.com\"\u003enwallington@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "Get caught up on the most recent developments in the police raid of a small Kansas newspaper office last weekend.",
+      "lead_media": {
+        "id": "278248523",
+        "url": "https://www.kansascity.com/latest-news/8x7prb/picture278248523",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "EricMeyer_outside_Luke.jpg",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1692127170,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692049612,
+        "thumbnail": "https://www.kansascity.com/latest-news/8x7prb/picture278248523/alternates/FREE_1140/EricMeyer_outside_Luke.jpg",
+        "href": "/web/v1/content/278248523",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "",
+        "dateline": "",
+        "caption": "Eric Meyer, the editor and publisher of the Marion County Record, stands outside the newspaper’s office on Monday. The office and Meyer’s home were raided by police on Friday.",
+        "photographer": "Luke Nozicka",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278253028",
+      "url": "https://www.kansascity.com/news/politics-government/article278253028.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "KBI takes lead in Marion investigation following police raid of local newspaper",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2595",
+      "home_section": {
+        "name": "Government \u0026 Politics",
+        "url": "https://www.kansascity.com/news/politics-government/"
+      },
+      "modified_date": 1692132656,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "KBI now lead on investigation that led to search of newspaper",
+      "originating_url": "https://www.kansascity.com/news/politics-government/article278253028.html",
+      "meta_description": "The Kansas Bureau of Investigation said it had taken the lead on an investigation that led to Marion Police Chief Gideon Cody searching the Marion County Record.",
+      "published_date": 1692061992,
+      "thumbnail": "https://www.kansascity.com/latest-news/aqrp98/picture278253198/alternates/FREE_1140/Capture.JPG",
+      "authors": [
+        {
+          "name": "Jonathan Shorman",
+          "email": "jshorman@kcstar.com"
+        }
+      ],
+      "keywords": "marion, record, newspaper, search, KBI",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "2595",
+        "2414",
+        "2639",
+        "2415"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "The Kansas Bureau of Investigation said it had taken the lead on an investigation that led to Marion Police Chief Gideon Cody searching the Marion County Record.",
+      "content": "\u003cp\u003eThe \u003ca href=\"https://www.kansas.gov/kbi/\" target=\"_self\" rel=\"Follow\"\u003eKansas Bureau of Investigation\u003c/a\u003e is now leading the criminal investigation that led to \u003ca href=\"https://www.kansascity.com/news/state/kansas/article278235083.html\" target=\"_self\" rel=\"Follow\"\u003ea raid of a newspaper in Marion\u003c/a\u003e, after the local police chief came under intense criticism for conducting the search.\u003c/p\u003e\u003cp\u003eThe KBI, which confirmed the change to The Star, said it was the “lead law enforcement agency” as of Monday morning after Marion Police Chief Gideon Cody and his officers on Friday\u003ca href=\"https://www.kansascity.com/news/state/kansas/article278212472.html\" target=\"_self\" rel=\"Follow\"\u003e searched the Marion County Record, \u003c/a\u003ethe home of the publisher and owner, as well as the home of a city councilwoman.\u003c/p\u003e\u003cp\u003e“As we transition, we will review prior steps taken and work to determine how best to proceed with the case. Once our thorough investigation concludes, we will forward all investigative facts to the prosecutor for review,” KBI spokesperson Melissa Underwood said in a statement.\u003c/p\u003e\u003cp\u003eIt’s unclear what precipitated the KBI taking over leadership of the investigation. Underwood offered no additional details. Cody didn’t immediately respond to a request for comment.\u003c/p\u003e\u003cp\u003eBut the move comes as Cody, who left a 24-year career in the Kansas City Police Department to become Marion’s chief earlier this year, faces blowback from the Record and press freedom advocates. Underwood’s statement, taken at face value, appears to indicate the KBI’s review will include the decision to search the newspaper.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278233503; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003eBernie Rhodes, an attorney for the Record who also represents The Star, \u003ca href=\"https://www.kansascity.com/news/politics-government/article278234378.html\" target=\"_self\" rel=\"Follow\"\u003esent a letter\u003c/a\u003e to Cody on Sunday calling the searches illegal and demanding that Marion police not review any information seized before a hearing could be held under Kansas’ journalist shield law.\u003c/p\u003e\u003cp\u003eRhodes then forwarded the same letter to KBI Director Tony Mattivi on Monday afternoon. The KBI \u003ca href=\"https://www.kansascity.com/news/state/kansas/article278222757.html\" target=\"_self\" rel=\"Follow\"\u003esaid in a statement\u003c/a\u003e the day before that Mattivi believed the freedom of the press “is a vanguard of American democracy” and that members of the media are not “above the law.”\u003c/p\u003e\u003cp\u003eA search warrant shows police were\u003ca href=\"https://www.kansascity.com/news/state/kansas/article278212472.html\"\u003e looking for evidence\u003c/a\u003e that a reporter had run an improper computer search to confirm an report that a local business owner applying for a liquor license had lost her driver’s license over a DUI. \u003c/p\u003e\u003cp\u003e“The KBI is entrusted to investigate credible allegations of illegal activity without fear or favor,” the agency said. “In order to investigate and gather facts, the KBI commonly executes search warrants on police departments, sheriff’s offices, and at city, county and state offices. ... No one is above the law, whether a public official or a representative of the media.”\u003c/p\u003e\u003cp\u003eThe KBI said it was asked by Marion police and Marion County Attorney Joel Ensey to join an investigation into accusations of “illegal access and dissemination of confidential criminal justice information.” Ensey will decide whether to file criminal charges after the KBI forwards the findings of its investigation.\u003c/p\u003e\u003cp\u003eThe KBI had already been involved in the investigation in Marion prior to Monday, with the agency assigning an agent to the case earlier this month. The KBI statement noted that the agent did not apply for the search warrants and was not present when they were executed.\u003c/p\u003e\u003cp\u003eThe search came after the Record investigated Cody’s background, but decided against publishing a story, newspaper owner and publisher Eric Meyer has said.\u003c/p\u003e\u003cp\u003eVideo from inside the newspaper’s office showed officers taking photographs of the space and seizing computers Friday. Meyer has described the seizures, which also unfolded at his home, as “Gestapo tactics.”\u003c/p\u003e\u003cp\u003eThe next day, Meyer’s mother Joan Meyer, who was also the newspaper’s co-owner, died at age 98. The stress from the “illegal raids,” the Record reported, contributed to her death.\u003c/p\u003e\u003cp\u003e\u003ci\u003eStar reporter Luke Nozicka contributed reporting\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278253028",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Jonathan Shorman\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:jshorman@kcstar.com\"\u003ejshorman@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "“As we transition, we will review prior steps taken and work to determine how best to proceed with the case,” the Kansas Bureau of Investigation said.",
+      "lead_media": {
+        "id": "278253198",
+        "url": "https://www.kansascity.com/latest-news/aqrp98/picture278253198",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "Capture.JPG",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1692062039,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692061809,
+        "thumbnail": "https://www.kansascity.com/latest-news/aqrp98/picture278253198/alternates/FREE_1140/Capture.JPG",
+        "href": "/web/v1/content/278253198",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "Luke Nozicka - The Kansas City Star",
+        "dateline": "",
+        "caption": "Front pages hang on a wall at the Marion County Record, where police served a search warrant Friday.",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278278748",
+      "url": "https://www.kansascity.com/news/local/crime/article278278748.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Read the search warrant that police used to raid the Marion County Record’s offices",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2619",
+      "home_section": {
+        "name": "Crime",
+        "url": "https://www.kansascity.com/news/local/crime/"
+      },
+      "modified_date": 1692132655,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Read police’s search warrant for Marion newspaper’s office",
+      "originating_url": "https://www.kansascity.com/news/local/crime/article278278748.html",
+      "meta_description": "The police raid of a Kansas newspaper office this weekend sparked outcry around the nation. Here’s the document that set it off.",
+      "published_date": 1692130881,
+      "thumbnail": "https://www.kansascity.com/latest-news/41omoh/picture278279608/alternates/FREE_1140/download%20(1).png",
+      "authors": [
+        {
+          "name": "Natalie Wallington",
+          "email": "nwallington@kcstar.com"
+        }
+      ],
+      "keywords": "search warrant, Marion, police raid, newspaper, Kansas",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "2619",
+        "2414",
+        "2639",
+        "2415",
+        "2598"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "The police raid of a Kansas newspaper office this weekend sparked outcry around the nation. Here’s the document that set it off.",
+      "content": "\u003cp\u003eOn Friday, police in the small town of Marion, Kansas, \u003ca href=\"https://www.kansascity.com/news/state/kansas/article278235083.html\"\u003eraided a local newspaper’s office\u003c/a\u003e. \u003c/p\u003e\u003cp\u003eThey confiscated computers, cell phones and other documents from Marion County Record staff, \u003ca href=\"https://www.kansascity.com/news/politics-government/article278234378.html\"\u003esparking outcry\u003c/a\u003e from press freedom advocates around the country.\u003c/p\u003e\u003cp\u003ePolice say their permission to carry out the seizures was spelled out in a search warrant signed by a judge. You can read the warrant below. \u003c/p\u003e\u003cp\u003eNeed to get caught up on the story? Check out \u003ca href=\"https://www.kansascity.com/news/state/kansas/article278269128.html\" target=\"_self\" rel=\"Follow\"\u003eour latest coverage here. \u003c/a\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278271248% --\u003e\u003c/p\u003e\u003ch3\u003eThe alleged crimes\u003c/h3\u003e\u003cp\u003eA few details stand out in this two-page document, which was signed by Magistrate Judge Laura Viar around 9 a.m. on Friday. The first is the two crimes listed on the warrant: “identity theft” and “unlawful acts concerning computers.” \u003c/p\u003e\u003cp\u003e“Identity theft” is \u003ca href=\"https://ksrevisor.org/statutes/chapters/ch21/021_061_0007.html\"\u003ebroadly defined in Kansas law\u003c/a\u003e as obtaining, possessing or using personal identifying information about someone with the intent to defraud them or “misrepresent” them in order to bring them “economic or bodily harm.”\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278279758; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003eKari Newell, a local restaurant owner, had recently claimed at a city council meeting that the Marion County Record used “illegal methods” to learn of her past DUI conviction. The newspaper never published information about the DUI.\u003c/p\u003e\u003cp\u003eUnder Kansas law, “unlawful acts concerning computers” are defined \u003ca href=\"https://www.ksrevisor.org/statutes/chapters/ch21/021_058_0039.html\"\u003emostly as cybercrimes like hacking\u003c/a\u003e. However, one provision mentions using a computer “to defraud or to obtain money, property, services or any other thing of value by means of false or fraudulent pretense or representation.” \u003c/p\u003e\u003cp\u003eWe don’t know exactly what evidence led Judge Viar to believe that either of these crimes were committed in the Marion County Record newsroom. But the warrant also mentions Newell by name — several times.\u003c/p\u003e\u003ch3\u003eKari Newell\u003c/h3\u003e\u003cp\u003eKari Newell, a Marion restaurant owner, is at the center of Friday’s search warrant authorizing the police raid. Three of the 15 items the warrant authorizes police to seize mention her by name.\u003c/p\u003e\u003cp\u003eList items 4 and 12 refer generally to documents, records and correspondences related to Newell. \u003c/p\u003e\u003cp\u003eList item 13 is more specific, describing evidence that internet access was used in the office to “participate in the identity theft of Kari Newell.”\u003c/p\u003e\u003cp\u003eNewell’s disdain for the local newspaper was evident before the raid occurred. She reportedly had the newspaper’s editor and a reporter \u003ca href=\"https://www.nbcnews.com/news/us-news/police-questioned-legality-kansas-newspaper-raid-computers-phones-seiz-rcna99681\"\u003eremoved from her restaurant by police\u003c/a\u003e during an event with a local Congressman earlier this month.\u003c/p\u003e\u003cp\u003eAt an August 7 city council meeting just days before the raid, Newell accused the newspaper of “illegally obtaining” information about her past DUI conviction. And in a statement made afterwards, she described the paper as having a “reputation of contortion.”\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278247093; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003ch3\u003eOther notable details\u003c/h3\u003e\u003cp\u003eSeveral list items on the warrant refer to devices used to access the \u003ca href=\"https://www.ksrevenue.gov/prrecrequest.html\"\u003eKansas Department of Revenue records website\u003c/a\u003e. This is a public website through which anyone can make requests for publicly available records under the \u003ca href=\"https://generalcounsel.ku.edu/open-records#:~:text=The%20Kansas%20Open%20Records%20Act%20recognizes%20that%20certain%20records%20contain,Personnel%20records%20of%20public%20employees\"\u003eKansas Open Records Act\u003c/a\u003e.\u003c/p\u003e\u003cp\u003eAnother line item specifies which devices police were allowed to seize. The warrant instructs them to conduct a “preview search” of all the digital devices on the premises, and not to seize ones “which have not been involved in the identity theft.”\u003c/p\u003e\u003cp\u003eWe don’t know exactly how police were supposed to determine which devices were potentially used in identity theft, but we do know that at least one reporter’s personal cell phone was taken away.\u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Star’s Jonathan Shorman contributed to this report.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eDo you have more questions about why police raided a local newspaper in a small Kansas town? Ask the Service Journalism team at \u003c/i\u003e\u003ca href=\"mailto:kcq@kcstar.com\"\u003e\u003ci\u003ekcq@kcstar.com\u003c/i\u003e\u003c/a\u003e\u003ci\u003e. \u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278278748",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Natalie Wallington\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:nwallington@kcstar.com\"\u003enwallington@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "The police raid of a Kansas newspaper office Friday sparked outcry around the nation. Here’s the document spelling out why the search of the newsroom was carried out.",
+      "lead_media": {
+        "id": "278279608",
+        "url": "https://www.kansascity.com/latest-news/41omoh/picture278279608",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "download (1).png",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1692131249,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692131249,
+        "thumbnail": "https://www.kansascity.com/latest-news/41omoh/picture278279608/alternates/FREE_1140/download%20(1).png",
+        "href": "/web/v1/content/278279608",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "Marion County Record",
+        "dateline": "",
+        "caption": "An image from surveillance video from inside the Marion County Record newspaper in central Kansas shows police officers executing a search warrant on Friday, Aug. 11, 2023.",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278240263",
+      "url": "https://www.kansascity.com/news/state/kansas/article278240263.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Raided Kansas newspaper is known for aggressively covering small town’s many disputes",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2639",
+      "home_section": {
+        "name": "Kansas",
+        "url": "https://www.kansascity.com/news/state/kansas/"
+      },
+      "modified_date": 1692132654,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Marion County Record has reputation for aggressive coverage",
+      "originating_url": "https://www.kansascity.com/news/state/kansas/article278240263.html",
+      "meta_description": "In Marion, Kansas, residents are waiting to see what comes of the criminal investigation that led to police raid on Marion County Record.",
+      "published_date": 1692127547,
+      "thumbnail": "https://www.kansascity.com/latest-news/8x7prb/picture278248523/alternates/FREE_1140/EricMeyer_outside_Luke.jpg",
+      "authors": [
+        {
+          "name": "Luke Nozicka",
+          "email": "lnozicka@kcstar.com"
+        }
+      ],
+      "keywords": "Marion, Kansas, newspaper, Record, raid,",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "2639",
+        "85427",
+        "97091",
+        "2415"
+      ],
+      "credit": "",
+      "dateline": "Marion, Kansas",
+      "summary": "In Marion, Kansas, residents are waiting to see what comes of the criminal investigation that led to police raid on Marion County Record.",
+      "content": "\u003cp\u003eSharon Kelsey had come to the \u003ca href=\"https://www.kansascity.com/news/politics-government/article278234378.html\" target=\"_blank\" rel=\"Follow\"\u003eMarion County Record\u003c/a\u003e on Monday afternoon to place resurrection lilies next to a red newspaper box outside the weekly paper in the small central-Kansas town.\u003c/p\u003e\u003cp\u003eKelsey, a subscriber whose paper gets passed between her sons, was “very upset” about a Friday police search of the Record’s newsroom, which was quickly criticized as the story spread across the U.S.\u003c/p\u003e\u003cp\u003ePolice also searched the home of the paper’s co-owners, Eric Meyer and his 98-year-old mother, Joan Meyer. She died the next day.\u003c/p\u003e\u003cp\u003e“I feel like things in this country aren’t going right,” said Kelsey, a longtime Marion resident who considers the paper’s staff friends.\u003c/p\u003e\u003cp\u003eOthers in the town of fewer than 2,000 people have different opinions about the paper and its self-described aggressive coverage.\u003c/p\u003e\u003cp\u003eAbout a block away on Monday, lifelong resident Jared Smith, 39, applauded the police raid as he closed down his wife’s spa on Main Street — a decision he tied to the Record’s “negative” coverage of her business.\u003c/p\u003e\u003cp\u003e“It blows my mind how negative our paper is to our community,” Smith said as he stood in front of the shuttered Dawn’s Day Spa, where a homemade “Support Marion PD” sign was displayed on the window.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278233503; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003eSettled among the prairie of Kansas’ rolling hills, the city that calls itself “the town between two lakes” has become a focal point of a national controversy over First Amendment rights and what many see as frightening law enforcement overreach.\u003c/p\u003e\u003cp\u003ePolice Chief \u003ca href=\"https://www.kansascity.com/news/state/kansas/article278212472.html\" target=\"_blank\" rel=\"Follow\"\u003eGideon Cody\u003c/a\u003e, appointed in May to lead the town’s force after 24 years with Kansas City police, has defended sending his five officers to seize journalists’ cellphones, computers and materials. Officers appeared to be looking for evidence about how the paper obtained information that a local restaurateur, who applied for a liquor license, lost her driver’s license over a DUI in 2008.\u003c/p\u003e\u003cp\u003eThe family-owned newspaper, which prides itself on being a watchdog in the community about an hour north of Wichita, said it did nothing wrong. Comparing the raid to tactics carried out by the secret police in Nazi Germany, editor Eric Meyer said there is “ill will” between the town’s top cop and the paper, which previously looked into tips about Cody’s background but did not publish a story about them.\u003c/p\u003e\u003cp\u003eIn a town where rumors spread within 15 minutes, though only a fraction are true, as one former city official put it, residents are waiting to see what comes of the police investigation.\u003c/p\u003e\u003cp\u003eChris Hernandez, a financial adviser who works around the corner from the newsroom, said community members who love their town just want “what’s right,” though they don’t know for sure yet why the raid took place. \u003c/p\u003e\u003cp\u003eStanding next to him Monday within eyesight of the police department, Gene Winkler, who has lived in town since 1962, also hoped investigators “get it right,” whether that’s good or bad for the Record.\u003c/p\u003e\u003cp\u003eWinkler, 81, who once served on the City Council, has had his differences with the Record, like others in town. He said the paper’s “negative” coverage can be a sore spot with residents and businesses.\u003c/p\u003e\u003cp\u003eThat could be because the Record — which is led by Meyer, who worked for 16 years at the Milwaukee Journal Sentinel, and whose staff includes a former Wichita Eagle reporter — covers a small community that has had its share of controversy even before the raid.\u003c/p\u003e\u003cp\u003eLast year, for example, the town’s two top cops and a city clerk, who was married to the then-police chief, all resigned, apparently over the lack of discipline against a city administrator accused of misconduct.\u003c/p\u003e\u003cp\u003eThe administrator allegedly showed a “provocative” photograph of the owner of Dawn’s Day Spa — who had worked as a model — to the city treasurer, Meyer said. The official was also accused of using a racial slur, among other things.\u003c/p\u003e\u003cp\u003eAnother issue involving the\u003cb\u003e \u003c/b\u003espa was also covered in the Record. The owner was “embroiled in a dispute” with officials over its sign, which was in violation of city code because it stuck out of its building. Meyer said he did not know how that coverage\u003cb\u003e \u003c/b\u003ewould drive her out of business.\u003c/p\u003e\u003cp\u003eAs detailed in \u003ca href=\"http://marionrecord.com/direct/marion_fires_city_administrator+5415marion+4d6172696f6e20666972657320636974792061646d696e6973747261746f72\" target=\"_blank\" rel=\"Follow\"\u003ethe Record\u003c/a\u003e, the city administrator was ultimately fired in December after less than six months on the job. The paper dutifully reminded taxpayers what the search for his job had cost them: at least $7,500.\u003c/p\u003e\u003cp\u003e“If found to be without formal cause, his firing could end up costing the city considerably more than $50,000 in salary and benefits,” Meyer added in the story, apparently considering a possibility that council members had not thought to discuss.\u003c/p\u003e\u003cp\u003eMeyer’s story noted that at one point at the end of the meeting where the administrator was fired, he remained the only member of the public there.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278249623; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003eResident Darvin Markley said the Record is simply reporting on the town’s issues. Meyer taught journalism at the University of Illinois for 25 years, he noted, and said the editor “knows what he’s doing.”\u003c/p\u003e\u003cp\u003e“The problem is, with the public saying that (Meyer is negative), is that they are trying to cover up their own mistakes,” Markley told reporters outside the Record’s office Monday. “This newspaper is very good at investigative reporting. That’s what he does.”\u003c/p\u003e\u003ch3\u003eQuestions remain\u003c/h3\u003e\u003cp\u003eAs readers brought flowers to the newsroom Monday, Meyer was back in the office, mad that he couldn’t get more information about the “outrageously stupid” raid that was captured on the office’s inside surveillance cameras.\u003c/p\u003e\u003cp\u003eA copy of the search warrant lists identity theft and “unlawful acts concerning computers” as the crimes the police chief told Magistrate Judge Laura Viar he had probable cause to believe had been committed.\u003c/p\u003e\u003cp\u003eThe warrant allowed officers and sheriff’s deputies to take correspondence pertaining to business owner Kari Newell, the local restaurateur, along with digital information or items that would establish the use of computers and networks “to participate in the identity theft” of Newell.\u003c/p\u003e\u003cp\u003eChief Cody told \u003ca href=\"https://www.stltoday.com/news/state-and-regional/missouri/kansas-police-and-a-small-newspaper-are-at-the-center-of-a-1st-amendment-fight/article_459979a9-d0de-5780-831b-14fa119bb0f8.html\" target=\"_blank\" rel=\"Follow\"\u003eThe Associated Press\u003c/a\u003e that the affidavits for the warrants, which would provide the probable cause for the searches, would be available “once charges are filed.”\u003c/p\u003e\u003cp\u003eBut on Monday evening, the \u003ca href=\"https://www.kansas.gov/kbi/\" target=\"_self\" rel=\"Follow\"\u003eKansas Bureau of Investigation\u003c/a\u003e took over the case and said it would would “review all prior steps taken” during \u003ca href=\"https://www.kansascity.com/news/state/kansas/article278222757.html\" target=\"_blank\" rel=\"Follow\"\u003ethe probe\u003c/a\u003e. Cody did not respond to a request for comment about the shift Monday night.\u003c/p\u003e\u003cp\u003eCity officials have largely remained silent about the raid that the paper’s attorney said violated state and federal laws.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278253198; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003eMayor David Mayfield said the situation will be handled by lawyers, while Vice Mayor Ruth Herbel — whose \u003ca href=\"https://www.kansascity.com/news/state/kansas/article278220882.html\" target=\"_blank\" rel=\"Follow\"\u003ecellphone and laptop were also seized\u003c/a\u003e Friday at her home — called the newsroom raid “an invasion.”\u003c/p\u003e\u003cp\u003eThe city’s three other council members have not responded to requests for comment.\u003c/p\u003e\u003ch3\u003eSubscriptions surge\u003c/h3\u003e\u003cp\u003eMeyer is a wealth of knowledge about local elected officials. His newspaper has kept residents up to date on their agendas and conflicts, including earlier this year when \u003ca href=\"http://marionrecord.com/direct/herbel_fights_recall_illegal_text_was_just_a_thank_you+5422recall+48657262656c2066696768747320726563616c6c3a2027496c6c6567616c27207465787420776173206a7573742061207468616e6b2d796f75\" target=\"_blank\" rel=\"Follow\"\u003eMayfield led\u003c/a\u003e an unsuccessful effort to recall Herbel, in part, over an alleged Kansas Open Meetings Act violation because she wrote “Thanks” in an accidental reply all email.\u003c/p\u003e\u003cp\u003eAs the newspaper considers a lawsuit, Meyer described holding elected officials accountable as not only important for the town but as good for business. The paper’s circulation and advertisements were up.\u003c/p\u003e\u003cp\u003eSince the raid, the paper has seen a significant spike in online subscribers — more than 1,000 since Friday — which was evident as its phones rang nearly nonstop Monday.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278247093; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003eStill, the raid has already scared at least one person from sharing information with the Record.\u003c/p\u003e\u003cp\u003eThat tipster called Meyer the other day and told him he should see a post on Facebook, but said he did not want to send it to Meyer out of fear that his computer would be confiscated by local law enforcement. \u003c/p\u003e\u003cp\u003e“This town has a history that if you speak up against the people in power, they will get you somehow,” Meyer said. “Which is kind of what has happened to us.”\u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Star’s Jonathan Shorman contributed to this report.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278240263",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Luke Nozicka\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:lnozicka@kcstar.com\"\u003elnozicka@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "“This town has a history that if you speak up against the people in power, they will get you somehow,” the Marion County Record’s editor said. “Which is kind of what has happened to us.”",
+      "lead_media": {
+        "id": "278248523",
+        "url": "https://www.kansascity.com/latest-news/8x7prb/picture278248523",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "EricMeyer_outside_Luke.jpg",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1692127170,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692049612,
+        "thumbnail": "https://www.kansascity.com/latest-news/8x7prb/picture278248523/alternates/FREE_1140/EricMeyer_outside_Luke.jpg",
+        "href": "/web/v1/content/278248523",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "",
+        "dateline": "",
+        "caption": "Eric Meyer, the editor and publisher of the Marion County Record, stands outside the newspaper’s office on Monday. The office and Meyer’s home were raided by police on Friday.",
+        "photographer": "Luke Nozicka",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278277858",
+      "url": "https://www.star-telegram.com/news/state/texas/article278277858.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Fight over who will pay for beer ends with shooting at child’s birthday, Texas cops say",
+      "publication": "star-telegram",
+      "layout_option": "none",
+      "home": "/web/v1/sections/6077",
+      "home_section": {
+        "name": "Texas",
+        "url": "https://www.star-telegram.com/news/state/texas/"
+      },
+      "modified_date": 1692132484,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Man shoots neighbor in argument over paying for beer: TX cop",
+      "originating_url": "https://www.star-telegram.com/news/state/texas/article278277858.html",
+      "meta_description": "Houston, Texas police say neighbors were fighting over who should pay for beer at child’s birthday party, then one man shot the other twice.",
+      "published_date": 1692132416,
+      "thumbnail": "https://www.charlotteobserver.com/news/nation-world/national/zg46tf/picture263422383/alternates/FREE_1140/RTT-ambulanceNight",
+      "authors": [
+        {
+          "name": "Kaitlyn  Alanis",
+          "email": "kalanis@mcclatchy.com"
+        }
+      ],
+      "keywords": "houston, texas, shoot, birthday, beer",
+      "access_tags": [
+        "matbasic",
+        "matopend"
+      ],
+      "additional_sections": [
+        "6077",
+        "6070"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Houston, Texas police say neighbors were fighting over who should pay for beer at child’s birthday party, then one man shot the other twice.",
+      "content": "\u003cp\u003eNeighbors at a child’s birthday party got into a \u003ca href=\"https://abc13.com/birthday-party-shooting-greenspoint-child-shots-fired-at-childs/13648394/\" target=\"_blank\" rel=\"Follow\"\u003efight over paying for beer\u003c/a\u003e, then one shot the other, police told local news outlets. \u003c/p\u003e\u003cp\u003eOfficers with the Houston Police Department in Texas responded to the shooting at about 11:15 p.m. Saturday, Aug. 13, according to a news release. \u003c/p\u003e\u003cp\u003e“A preliminary investigation determined several neighbors were gathered outside of an apartment \u003ca href=\"https://cityofhouston.news/suspect-arrested-charged-in-shooting-at-16803-city-view-place/\" target=\"_blank\" rel=\"Follow\"\u003efor a celebration\u003c/a\u003e when the victim and suspect got into an argument,” police said. \u003c/p\u003e\u003cp\u003eThey were arguing over who should \u003ca href=\"https://www.fox26houston.com/news/houston-shooting-man-shot-during-childrens-birthday-party-on-city-view-place\" target=\"_blank\" rel=\"Follow\"\u003epay for the beer\u003c/a\u003e, police told KTRK and KRIV. \u003c/p\u003e\u003cp\u003eWitnesses told police the 30-year-old man fired his gun into the air, then he started shooting at his neighbor, authorities said. The 39-year-old man was shot twice. \u003c/p\u003e\u003cp\u003eHouston Fire Department paramedics took him to a hospital in stable condition, according to the news release. \u003c/p\u003e\u003cp\u003eThe accused shooter had already drove away from the scene, police said, but he later returned to give a statement to officers. \u003c/p\u003e\u003cp\u003eHe was charged with aggravated assault and booked into the Harris County Jail, authorities said. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:277160273% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:273197930% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:272244133% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278277858",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Kaitlyn  Alanis\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:kalanis@mcclatchy.com\"\u003ekalanis@mcclatchy.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "One man was hospitalized, and the other was arrested, police said. ",
+      "lead_media": {
+        "id": "263422383",
+        "url": "https://www.charlotteobserver.com/news/nation-world/national/zg46tf/picture263422383",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "RTT-ambulanceNight",
+        "publication": "charlotteobserver",
+        "layout_option": "",
+        "home": "/web/v1/sections/8085",
+        "modified_date": 1669917275,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1657721647,
+        "thumbnail": "https://www.charlotteobserver.com/news/nation-world/national/zg46tf/picture263422383/alternates/FREE_1140/RTT-ambulanceNight",
+        "href": "/web/v1/content/263422383",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "8085"
+        ],
+        "credit": "Getty Images/iStockphoto",
+        "dateline": "",
+        "caption": "A child has died after being hit by a car in North Myrtle Beach Tuesday. The incident happened in the Timber Ridge Community after 4 p.m.",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "FortWorth",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278278083",
+      "url": "https://www.star-telegram.com/news/state/texas/article278278083.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Massive sea creature with over 3,000 teeth spotted near Texas coast, video shows",
+      "publication": "star-telegram",
+      "layout_option": "none",
+      "home": "/web/v1/sections/6077",
+      "home_section": {
+        "name": "Texas",
+        "url": "https://www.star-telegram.com/news/state/texas/"
+      },
+      "modified_date": 1692132402,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Huge whale shark spotted near Texas coast, video shows",
+      "originating_url": "https://www.star-telegram.com/news/state/texas/article278278083.html",
+      "meta_description": "Boater spotted something huge swimming in the Texas Gulf, near Port Aransas. It turned out to be a large whale shark, video shows.",
+      "published_date": 1692132402,
+      "thumbnail": "https://www.star-telegram.com/latest-news/14gme/picture278278783/alternates/FREE_1140/Collage%20Maker-15-Aug-2023-03-02-PM-713_fitted.jpeg",
+      "authors": [
+        {
+          "name": "Mitchell Willetts",
+          "email": "mwilletts@mcclatchy.com"
+        }
+      ],
+      "keywords": "whale shark, Texas, coast, gulf, video, ",
+      "access_tags": [
+        "matbasic",
+        "matopend"
+      ],
+      "additional_sections": [
+        "6077",
+        "3188",
+        "6070"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Boater spotted something huge swimming in the Texas Gulf, near Port Aransas. It turned out to be a large whale shark, video shows.",
+      "content": "\u003cp\u003eBoaters recently spotted a mysterious figure moving under the waves in the Texas Gulf, so they jumped in for a closer look, video shows.\u003c/p\u003e\u003cp\u003e“(Blessed) to have witnessed this so close to shore,” \u003ca href=\"https://www.tiktok.com/@alexus_jade/video/7266974877935062303?embed_source=121355058%2C121351166%2C121331973%2C120811592%2C120810756%3Bnull%3Bembed_name\u0026refer=embed\u0026referer_url=www.chron.com%2Flife%2Fwildlife%2Farticle%2Ftexas-whale-fish-18295436.php\u0026referer_video_id=7266974877935062303\" target=\"_blank\" rel=\"Follow\"\u003eAlexus Jade wrote in a TikTok post\u003c/a\u003e, which had been viewed over 110,000 times as of the afternoon of Aug. 15. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278278473% --\u003e\u003c/p\u003e\u003cp\u003eTheir vision fills with bubbles as they plunge into the water, video shows, but the creature quickly comes into focus — a whale shark.\u003c/p\u003e\u003cp\u003eThe blue and white-speckled beast seems unconcerned with the surprise visitor, traveling at a leisurely pace with an entourage of remoras, video shows.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278279048; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003eThough they are the \u003ca href=\"https://www.worldwildlife.org/species/whale-shark\" target=\"_blank\" rel=\"Follow\"\u003elargest of the sharks\u003c/a\u003e — and the largest of all fish — whale sharks are gentle giants, experts say. They’re \u003ca href=\"https://oceana.org/marine-life/whale-shark/\" target=\"_blank\" rel=\"Follow\"\u003efilter feeders \u003c/a\u003eand use their massive mouths to suck in little prey such as plankton or schooling fish, according to Oceana.org.\u003c/p\u003e\u003cp\u003eJade shared the experience with Addison Smith, a friend and founder of \u003ca href=\"https://www.facebook.com/profile.php?id=100093343772041\" target=\"_blank\" rel=\"Follow\"\u003eGulf Magic Charters\u003c/a\u003e, a charter service \u003ca href=\"https://www.chron.com/life/wildlife/article/texas-whale-fish-18295436.php\" target=\"_blank\" rel=\"Follow\"\u003ebased in Port Aransas\u003c/a\u003e, she told the Houston Chronicle.\u003c/p\u003e\u003cp\u003eWhile whale sharks are known to wander warm waters all over the world, including the Gulf of Mexico, it’s rare to see them near the shore, Smith commented on the post.\u003c/p\u003e\u003cp\u003eThey were 6 miles off the coast of Port Aransas, in waters roughly 50 feet deep, he added.\u003c/p\u003e\u003cp\u003eThe shark was “very calm,” Jade told the Houston Chronicle. “You can (see) it just cruising around the water with other sea life swimming around it. It was just swimming around until it finally dove back down.”\u003c/p\u003e\u003cp\u003eDespite their intimidating size and about \u003ca href=\"https://oceana.org/marine-life/whale-shark/\" title=\"https://www.fisheries.noaa.gov/feature-story/new-publication-highlights-whale-shark-movements-gulf-mexico\" target=\"_blank\" rel=\"Follow\"\u003e3,000 tiny teeth\u003c/a\u003e, whale sharks are considered “\u003ca href=\"https://www.floridamuseum.ufl.edu/discover-fish/species-profiles/rhincodon-typus/\" target=\"_blank\" rel=\"Follow\"\u003eharmless to humans\u003c/a\u003e,” according to the Florida Museum of Natural History. “However, there have been a few cases of whale sharks ramming sportfishing boats, possibly after being provoked.”\u003c/p\u003e\u003cp\u003eKnowing it was harmless, some wanted to know why Jade didn’t swim closer to the shark, the Chronicle reported. \u003c/p\u003e\u003cp\u003e“The simple answer to that is we didn’t want to disturb its peace,” she said.\u003c/p\u003e\u003cp\u003eWhale sharks are known to \u003ca href=\"https://www.fisheries.noaa.gov/feature-story/new-publication-highlights-whale-shark-movements-gulf-mexico\" target=\"_blank\" rel=\"Follow\"\u003egrow up to 46 feet\u003c/a\u003e in length and weigh as much as 24,000 pounds, according to the National Oceanic and Atmospheric Administration. It is believed they can live for 100 years or more, though the oldest documented whale shark is 75 years old.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:277027463% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:277896373% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:277243408% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278278083",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Mitchell Willetts\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:mwilletts@mcclatchy.com\"\u003emwilletts@mcclatchy.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "The boaters were surprised to find it swimming in just 50 feet of water.",
+      "lead_media": {
+        "id": "278278783",
+        "url": "https://www.star-telegram.com/latest-news/14gme/picture278278783",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "Collage Maker-15-Aug-2023-03-02-PM-713_fitted.jpeg",
+        "publication": "star-telegram",
+        "layout_option": "",
+        "home": "/web/v1/sections/3188",
+        "modified_date": 1692130374,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692130374,
+        "thumbnail": "https://www.star-telegram.com/latest-news/14gme/picture278278783/alternates/FREE_1140/Collage%20Maker-15-Aug-2023-03-02-PM-713_fitted.jpeg",
+        "href": "/web/v1/content/278278783",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3188"
+        ],
+        "credit": "Screengrabs from TikTok video by @alexus_jade and @addisonsmith817",
+        "dateline": "",
+        "caption": "Boaters spotted massive sea creature swimming in the Texas Gulf, so they jumped in the water for a closer look, video shows.",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "FortWorth",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": [
+        {
+          "name": "mcc-realtime-ta"
+        }
+      ]
+    },
+    {
+      "id": "278278183",
+      "url": "https://www.miamiherald.com/news/nation-world/national/article278278183.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Son helps 78-year-old North Carolina dad confirm big Powerball prize. ‘It was real’",
+      "publication": "miamiherald",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5092",
+      "home_section": {
+        "name": "National",
+        "url": "https://www.miamiherald.com/news/nation-world/national/"
+      },
+      "modified_date": 1692132364,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "78-year-old calls his son to confirm big Maryland win: lotto",
+      "originating_url": "https://www.miamiherald.com/news/nation-world/national/article278278183.html",
+      "meta_description": "A 78-year-old NC man won $50,000 after buying a Powerball ticket while getting gas in Maryland, officials said. He was visiting family.",
+      "published_date": 1692132364,
+      "thumbnail": "https://pics.mcclatchyinteractive.com/news/nation-world/national/7l3h2z/picture276461516/alternates/FREE_1140/RTTcurrency",
+      "authors": [
+        {
+          "name": "Paloma Chavez",
+          "email": "pchavez@mcclatchy.com"
+        }
+      ],
+      "keywords": "Maryland Lottery, 78-year-old, North Carolina, Charlotte, $50,000",
+      "access_tags": [
+        "matbasic",
+        "matopend"
+      ],
+      "additional_sections": [
+        "5092",
+        "3180"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "A 78-year-old NC man won $50,000 after buying a Powerball ticket while getting gas in Maryland, officials said. He was visiting family.",
+      "content": "\u003cp\u003eA North Carolina man won big with a Maryland Lottery ticket but needed some help from his son to figure out the win was real, officials said.\u003c/p\u003e\u003cp\u003eThe 78-year-old Charlotte-area resident was driving to New York to visit family when he stopped in North East \u003ca href=\"https://www.mdlottery.com/north-carolina-man-drives-through-maryland-and-wins-50000/\" target=\"_blank\" rel=\"Follow\"\u003eto get gas\u003c/a\u003e, according to an Aug. 15 news release from the Maryland Lottery. He didn’t realize he’d leave the rest area with a $50,000 prize.\u003c/p\u003e\u003cp\u003eThe retired marina worker bought a Powerball ticket and checked his phone, quickly realizing he’d won, lottery officials said. \u003c/p\u003e\u003cp\u003e“I was quiet. I wanted to keep it to myself,” he told officials.\u003c/p\u003e\u003cp\u003eHe called his son to confirm the win and read the numbers to him, officials said.\u003c/p\u003e\u003cp\u003eThe man’s son “started to get worried” because his dad wasn’t reading the correct numbers back, the release said. \u003c/p\u003e\u003cp\u003eThe lucky winner bought a five-line Quick Pick ticket and two lines had the same Powerball number, officials said. The man had read the wrong line and eventually realized his mistake.\u003c/p\u003e\u003cp\u003e“It was real and I was a winner. I am glad I found the right line,” he said in the release.\u003c/p\u003e\u003cp\u003eThe winner’s only immediate plan for the money is to invest it, officials said. \u003c/p\u003e\u003cp\u003eNorth East is about 50 miles northeast of Baltimore. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:256658952% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278271873% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278269548% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278261698% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278278183",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Paloma Chavez\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:pchavez@mcclatchy.com\"\u003epchavez@mcclatchy.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "“I was quiet. I wanted to keep it to myself,” the man told Maryland Lottery officials. ",
+      "lead_media": {
+        "id": "276461516",
+        "url": "https://pics.mcclatchyinteractive.com/news/nation-world/national/7l3h2z/picture276461516",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "RTTcurrency",
+        "publication": "mcclatchy-newsroom",
+        "layout_option": "",
+        "home": "/web/v1/sections/1152",
+        "modified_date": 1691526594,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1686866493,
+        "thumbnail": "https://pics.mcclatchyinteractive.com/news/nation-world/national/7l3h2z/picture276461516/alternates/FREE_1140/RTTcurrency",
+        "href": "/web/v1/content/276461516",
+        "additional_sections": [
+          "1152",
+          "27",
+          "28"
+        ],
+        "credit": "Getty Images/iStockphoto",
+        "dateline": "",
+        "caption": "An 18-year-old Maryland man won a lottery prize from a ticket purchased by his father.",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Miami",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": [
+        {
+          "name": "mcc-realtime-ta"
+        }
+      ]
+    },
+    {
+      "id": "278271133",
+      "url": "https://www.sacbee.com/news/nation-world/national/article278271133.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Driver pulls over to check noises coming from engine and finds ‘joyriding’ stowaways",
+      "publication": "sacbee",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5758",
+      "home_section": {
+        "name": "National",
+        "url": "https://www.sacbee.com/news/nation-world/national/"
+      },
+      "modified_date": 1692132162,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Woman finds ‘joyriding’ creatures by engine, AZ photos show",
+      "originating_url": "https://www.sacbee.com/news/nation-world/national/article278271133.html",
+      "meta_description": "A driver found a pair of kittens under the hood of her car after hearing noises while driving on Interstate 10 in Phoenix, Arizona.",
+      "published_date": 1692132098,
+      "thumbnail": "https://www.sacbee.com/news/nation-world/national/k45scw/picture278272213/alternates/FREE_1140/Kitten_Rescue.jpg",
+      "authors": [
+        {
+          "name": "Helena Wegner",
+          "email": "hwegner@mcclatchy.com"
+        }
+      ],
+      "keywords": "arizona, kitten, phoenix, interstate 10, car",
+      "access_tags": [
+        "matbasic",
+        "matopend"
+      ],
+      "additional_sections": [
+        "5758",
+        "3182"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "A driver found a pair of kittens under the hood of her car after hearing noises while driving on Interstate 10 in Phoenix, Arizona.",
+      "content": "\u003cp\u003eA driver pulled over on an Arizona highway after she heard noises coming from under her car’s hood. \u003c/p\u003e\u003cp\u003eWhen she took a look, she found two “joyriding kittens.” \u003c/p\u003e\u003cp\u003eThe woman was driving \u003ca href=\"https://www.facebook.com/Ariz.DPS/posts/pfbid02VUgGXjv5NooP5F6nZ4bDajFnhjuekUVSbweMaHPsv6jhDw5A2ryyQHrSkg5gM5Zul\" target=\"_blank\" rel=\"Follow\"\u003ealong Interstate 10\u003c/a\u003e on Aug. 14 in Phoenix when she heard meowing and decided to stop, the Arizona Department of Public Safety said in a Facebook post.\u003c/p\u003e\u003cp\u003e“Turns out that purring sound wasn’t coming from the engine!” troopers said in the post. \u003c/p\u003e\u003cp\u003eIt was two fuzzy kittens \u003cspan id=\"docs-internal-guid-c4a95396-7fff-2b93-7ef7-363083ea645d\"\u003e—\u003c/span\u003e both uninjured.\u003c/p\u003e\u003cp\u003eA trooper and a roadside motorist assistant took her tire off so her husband could pull the kittens out. \u003c/p\u003e\u003cp\u003eNow the cute cats are going home with the couple, troopers said.\u003c/p\u003e\u003cp\u003e“Aww so cute and such a great happy ending for those kittens,” one person commented.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278272773% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:277970858% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:277172213% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:277149378% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278271133",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Helena Wegner\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:hwegner@mcclatchy.com\"\u003ehwegner@mcclatchy.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "She’s taking the fuzzy creatures home with her, troopers in Arizona said. ",
+      "lead_media": {
+        "id": "278272213",
+        "url": "https://www.sacbee.com/news/nation-world/national/k45scw/picture278272213",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "Kitten_Rescue.jpg",
+        "publication": "sacbee",
+        "layout_option": "",
+        "home": "/web/v1/sections/5758",
+        "modified_date": 1692122236,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692122157,
+        "thumbnail": "https://www.sacbee.com/news/nation-world/national/k45scw/picture278272213/alternates/FREE_1140/Kitten_Rescue.jpg",
+        "href": "/web/v1/content/278272213",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "5758",
+          "3182"
+        ],
+        "credit": "Arizona Department of Public Safety",
+        "dateline": "",
+        "caption": "Two kittens were found in a driver’s engine on Aug. 14 in Phoenix, troopers said. Authorities removed her passenger tire to retrieve the cats.",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Sacramento",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": [
+        {
+          "name": "mcc-realtime-ta"
+        }
+      ]
+    },
+    {
+      "id": "278251518",
+      "url": "https://www.kansascity.com/news/article278251518.html",
+      "asset_type": "videoIngest",
+      "brightcove_id": "",
+      "state": "published",
+      "title": "Video shows police raid at Marion County Record newsroom in Kansas",
+      "publication": "kansascity",
+      "layout_option": "",
+      "home": "/web/v1/sections/2579",
+      "home_section": {
+        "name": "News",
+        "url": "https://www.kansascity.com/news/"
+      },
+      "modified_date": 1692131480,
+      "allow_index": true,
+      "allow_follow": false,
+      "meta_title": "Footage shows raid of small newspaper in Kansas",
+      "originating_url": "https://www.kansascity.com/news/article278251518.html",
+      "published_date": 1692055745,
+      "leadtext": [
+        {
+          "text": "Surveillance video from inside the Marion County Record newspaper in central Kansas shows police officers executing a search warrant on Friday, Aug. 11, 2023. The search has been widely condemned by First Amendment advocates. "
+        }
+      ],
+      "thumbnail": "https://img.connatix.com/bb0d82cb-df10-4847-b3c7-dedd095f0353/1_th.jpg",
+      "href": "/web/v1/content/278251518",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "2579",
+        "2415"
+      ],
+      "topic_tags": [],
+      "credit": "Marion County Record",
+      "lead_media": {
+        "id": "278251518",
+        "url": "https://www.kansascity.com/news/article278251518.html",
+        "asset_type": "videoIngest",
+        "brightcove_id": "",
+        "state": "published",
+        "title": "Video shows police raid at Marion County Record newsroom in Kansas",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2579",
+        "modified_date": 1692131480,
+        "allow_index": true,
+        "allow_follow": false,
+        "meta_title": "Footage shows raid of small newspaper in Kansas",
+        "originating_url": "https://www.kansascity.com/news/article278251518.html",
+        "published_date": 1692055745,
+        "leadtext": [
+          {
+            "text": "Surveillance video from inside the Marion County Record newspaper in central Kansas shows police officers executing a search warrant on Friday, Aug. 11, 2023. The search has been widely condemned by First Amendment advocates. "
+          }
+        ],
+        "thumbnail": "https://img.connatix.com/bb0d82cb-df10-4847-b3c7-dedd095f0353/1_th.jpg",
+        "href": "/web/v1/content/278251518",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2579",
+          "2415"
+        ],
+        "topic_tags": [],
+        "credit": "Marion County Record",
+        "summary": "",
+        "content": "",
+        "brightcove_thumbnail": "https://img.connatix.com/bb0d82cb-df10-4847-b3c7-dedd095f0353/0_th.jpg",
+        "photographer": "Marion County Record. ",
+        "allow_ads": true,
+        "ads": [
+          {
+            "publication": "kansascity",
+            "tag": "https://pubads.g.doubleclick.net/gampad/ads?ciu_szs=300x250\u0026correlator=%5Btimestamp%5D\u0026cust_params=sect%3Dnews%26id%3D278251518%26eid%3D278251518%26vidlength%3Dshort%26pl%3D\u0026description_url=%5Breferrer_url%5D\u0026env=vp\u0026gdfp_req=1\u0026hl=en\u0026impl=s\u0026iu=%2F7675%2FKCM.site_kansascity%2FNews\u0026output=vast\u0026sz=400x300\u0026unviewed_position_start=1\u0026url=%5Breferrer_url%5D\u0026vidlength=short\u0026vpos=preroll",
+            "lang": "en",
+            "sz": "400x300",
+            "vpos": "preroll",
+            "cust_params": "sect=news\u0026id=278251518\u0026eid=278251518\u0026vidlength=short\u0026pl="
+          }
+        ],
+        "kicker": "",
+        "allow_comments": false,
+        "videoCMSID": "bb0d82cb-df10-4847-b3c7-dedd095f0353"
+      },
+      "summary": "",
+      "content": "",
+      "brightcove_thumbnail": "https://img.connatix.com/bb0d82cb-df10-4847-b3c7-dedd095f0353/0_th.jpg",
+      "photographer": "Marion County Record. ",
+      "allow_ads": true,
+      "ads": [
+        {
+          "publication": "kansascity",
+          "tag": "https://pubads.g.doubleclick.net/gampad/ads?ciu_szs=300x250\u0026correlator=%5Btimestamp%5D\u0026cust_params=sect%3Dnews%26id%3D278251518%26eid%3D278251518%26vidlength%3Dshort%26pl%3D\u0026description_url=%5Breferrer_url%5D\u0026env=vp\u0026gdfp_req=1\u0026hl=en\u0026impl=s\u0026iu=%2F7675%2FKCM.site_kansascity%2FNews\u0026output=vast\u0026sz=400x300\u0026unviewed_position_start=1\u0026url=%5Breferrer_url%5D\u0026vidlength=short\u0026vpos=preroll",
+          "lang": "en",
+          "sz": "400x300",
+          "vpos": "preroll",
+          "cust_params": "sect=news\u0026id=278251518\u0026eid=278251518\u0026vidlength=short\u0026pl="
+        }
+      ],
+      "kicker": "",
+      "allow_comments": false,
+      "videoCMSID": "bb0d82cb-df10-4847-b3c7-dedd095f0353"
+    },
+    {
+      "id": "278268913",
+      "url": "https://www.kansascity.com/news/nation-world/national/article278268913.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "The inside of this house for sale looks like a luxurious cave. See the Wisconsin digs",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2629",
+      "home_section": {
+        "name": "National",
+        "url": "https://www.kansascity.com/news/nation-world/national/"
+      },
+      "modified_date": 1692131178,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "The inside of this WI house for sale looks like a chic cave",
+      "originating_url": "https://www.kansascity.com/news/nation-world/national/article278268913.html",
+      "meta_description": "A home for sale in New Berlin, Wisconsin, looks like a cave inside and is on the market for $1.45 million. It was featured on TikTok",
+      "published_date": 1692131178,
+      "thumbnail": "https://www.star-telegram.com/latest-news/6wis6f/picture278275718/alternates/FREE_1140/1.jpg",
+      "authors": [
+        {
+          "name": "TJ Macias",
+          "email": "tmacias@mcclatchydc.com"
+        }
+      ],
+      "keywords": "real estate, TikTok, cave house, Wisconsin, ",
+      "access_tags": [
+        "matbasic",
+        "matopend"
+      ],
+      "additional_sections": [
+        "2629",
+        "2415"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "A home for sale in New Berlin, Wisconsin, looks like a cave inside and is on the market for $1.45 million. It was featured on TikTok",
+      "content": "\u003cp\u003eA house for sale in New Berlin, Wisconsin, is one of the most unique houses on the market in the Badger State, but not because of its windowed exterior, but because it’s an entirely different world on the inside.\u003c/p\u003e\u003cp\u003eThe six-bedroom, seven-bathroom residence — \u003ca href=\"https://www.realtor.com/realestateandhomes-detail/M8703121597\" target=\"_blank\" rel=\"Follow\"\u003ewhich is listed for $1.45 million\u003c/a\u003e — recently went through an update that saw almost $400,000 thrown into renovations, the listing on Realtor.com says. \u003c/p\u003e\u003cp\u003e“This unique property is located on 17.49 acres of land with your own private lake and beach,” the listing says. “Outdoor entertainment area has been improved to include gazebo, multiple firepits, sitting areas and much more. Enjoy your fully updated indoor pool. Two brand new game rooms have been added to the property. Pictures truly do not do this property justice.”\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278277843% --\u003e\u003c/p\u003e\u003cp\u003ePhotos show the inside has the appeal of a wonderfully decorated cave with rock walls and ceilings in some rooms — including the great room, where several windows peer into the outside world. Other rooms have a more modern feel, notably the bedrooms and the additional game rooms. Plants round out the nature-like decor, bringing an outside appeal indoors. \u003c/p\u003e\u003cp\u003eThe 6,254-square-foot house was featured on the popular TikTok page \u003ca href=\"https://www.tiktok.com/@zillowtastrophes/video/7266814681266818347\" target=\"_blank\" rel=\"Follow\"\u003e@zillowtastrophes\u003c/a\u003e, and the site’s creator was extremely impressed with the updates. \u003c/p\u003e\u003cp\u003e“It’s a plant lover’s dream,” the creator said of the two-story cave room. “With all the buzz this place gets on social media, it’s perfect for an Airbnd.”\u003c/p\u003e\u003cp\u003eWhile some liked the house, one person was hoping for an actual cave, they said in the comment section.\u003c/p\u003e\u003cp\u003eNew Berlin is about 20 miles southwest of Milwaukee. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278262048% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278268913",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy TJ Macias\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:tmacias@mcclatchydc.com\"\u003etmacias@mcclatchydc.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "The pool area is like a pristine, turquoise blue lagoon.",
+      "lead_media": {
+        "id": "278275718",
+        "url": "https://www.star-telegram.com/latest-news/6wis6f/picture278275718",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "1.jpg",
+        "publication": "star-telegram",
+        "layout_option": "",
+        "home": "/web/v1/sections/3188",
+        "modified_date": 1692126440,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692126440,
+        "thumbnail": "https://www.star-telegram.com/latest-news/6wis6f/picture278275718/alternates/FREE_1140/1.jpg",
+        "href": "/web/v1/content/278275718",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3188"
+        ],
+        "credit": "Screen grab from Realtor",
+        "dateline": "",
+        "caption": "The interior of the home is like nothing you’ve ever seen before",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Real Time",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": [
+        {
+          "name": "mcc-realtime-ta"
+        }
+      ]
+    },
+    {
+      "id": "278265143",
+      "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278265143.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Arrowhead isn’t the highest-ranked NFL stadium on this tailgating list. Here’s why",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2694",
+      "home_section": {
+        "name": "Chiefs",
+        "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/"
+      },
+      "modified_date": 1692130158,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "KC Chiefs stadium ranked 5th best RV-tailgating experience",
+      "originating_url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278265143.html",
+      "meta_description": "Arrowhead Stadium is known for having one of the best tailgating experiences before NFL games. National site RVTrader ranked KC 5th overall.",
+      "published_date": 1692124138,
+      "thumbnail": "https://www.kansascity.com/latest-news/hy7i6x/picture271805992/alternates/FREE_1140/IMG_5591.jpg",
+      "authors": [
+        {
+          "name": "Joseph Hernandez",
+          "email": "jhernandez@kcstar.com"
+        }
+      ],
+      "keywords": "chiefs, tailgate, arrowhead, experience, rv, trailer, kansas city",
+      "access_tags": [
+        "matbasic",
+        "matsport"
+      ],
+      "additional_sections": [
+        "2694",
+        "2533",
+        "93024",
+        "2415",
+        "2598"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Arrowhead Stadium is known for having one of the best tailgating experiences before NFL games. National site RVTrader ranked KC 5th overall.",
+      "content": "\u003cp\u003eNothing bonds fans at GEHA Field at Arrowhead Stadium like grilling hot dogs and hamburgers, along with barbecue goodies, before a Chiefs game. \u003c/p\u003e\u003cp\u003eIt’s one of the many traditions that make \u003ca href=\"https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article267121166.html\" target=\"_self\" rel=\"Follow\"\u003eArrowhead one of the best stadiums in the NFL\u003c/a\u003e.\u003c/p\u003e\u003cp\u003eA recent national study backs up the claim. RVTrader, an online site dedicated to RV lifestyle, ranked \u003ca href=\"https://www.rvtrader.com/blog/2022/09/06/10-best-nfl-stadiums-for-rv-tailgating/\" target=\"_self\" rel=\"Follow\"\u003eArrowhead as the fifth-best stadium\u003c/a\u003e for RV tailgating in the NFL.\u003c/p\u003e\u003cp\u003eHaving parking spots large enough to accommodate RVs is one of the factors that influenced Arrowhead’s ranking.\u003c/p\u003e\u003cp\u003eRVTrader warned \u003ca href=\"https://www.thormotorcoach.com/motorhomes/class-a-motorhomes\" target=\"_self\" rel=\"Follow\"\u003eClass A\u003c/a\u003e or \u003ca href=\"https://www.rvtrader.com/Class-C/rvs-for-sale?type=Class%20C%7C198069\u0026modelkeyword=1\u0026cmp=blog_post_22Q3\" target=\"_self\" rel=\"Follow\"\u003eClass C\u003c/a\u003e motorhome owners that they may have to park in another section if the RV takes up more than two spaces. You will also have to buy an oversized parking pass, \u003ca href=\"https://www.chiefs.com/stadium/parking/faqs\" target=\"_self\" rel=\"Follow\"\u003ewhich costs $120 before fees\u003c/a\u003e.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257865868; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003eRVTrader said you can see fans starting their tailgating as soon as the parking lot gate opens four and a half hours before kickoff. \u003c/p\u003e\u003cp\u003eBefore 2022’s home-opening game against the Los Angeles Chargers, \u003ca href=\"https://www.kansascity.com/sports/spt-columns-blogs/for-petes-sake/article265864171.html\" target=\"_self\" rel=\"Follow\"\u003efans were tailgating at 10:30 a.m.\u003c/a\u003e for a game that didn’t start until 7:15 p.m.\u003c/p\u003e\u003cp\u003eArrowhead ranked behind the stadiums of the Houston Texans, Las Vegas Raiders, New England Patriots and Buffalo Bills. \u003c/p\u003e\u003cp\u003eStart preparing your tailgate for the 2023 season with by looking at \u003ca href=\"https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article268297462.html\" target=\"_self\" rel=\"Follow\"\u003etips from expert Arrowhead tailgaters\u003c/a\u003e.\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278265143",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Joseph Hernandez\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:jhernandez@kcstar.com\"\u003ejhernandez@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "Arrowhead has plenty of space for RVs. But it costs fans extra, which was one of the factors that determined its ranking in this report.",
+      "lead_media": {
+        "id": "271805992",
+        "url": "https://www.kansascity.com/latest-news/hy7i6x/picture271805992",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "IMG_5591.jpg",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1675027244,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1675027244,
+        "thumbnail": "https://www.kansascity.com/latest-news/hy7i6x/picture271805992/alternates/FREE_1140/IMG_5591.jpg",
+        "href": "/web/v1/content/271805992",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "",
+        "dateline": "",
+        "caption": "One tailgate party on Sunday centered on “Vandy Reid,” a custom van with its own Instagram account and fan following.",
+        "photographer": "Jenna Thompson - The Kansas City Star",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278271508",
+      "url": "https://www.kansascity.com/news/local/crime/article278271508.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Months after Overland Park apartment fire, Missouri suspect arrested, charged with arson",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2619",
+      "home_section": {
+        "name": "Crime",
+        "url": "https://www.kansascity.com/news/local/crime/"
+      },
+      "modified_date": 1692130055,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Missouri resident charged with arson after Overland Park fire",
+      "originating_url": "https://www.kansascity.com/news/local/crime/article278271508.html",
+      "meta_description": "Chrissy I. Carter of Lowry City, Missouri, arrested and accused of starting March 19 fire at Sheridan Ridge Townhomes on Farley Street.",
+      "published_date": 1692126396,
+      "thumbnail": "https://www.kansascity.com/latest-news/qq3fbn/picture273353955/alternates/FREE_1140/OP%20fire%20sunday_fitted.jpeg",
+      "authors": [
+        {
+          "name": "Andrea Klick",
+          "email": "aklick@kcstar.com"
+        }
+      ],
+      "keywords": "overland park, fire, johnson county, arson, police",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "2619",
+        "85427",
+        "2414",
+        "2415",
+        "2598"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Chrissy I. Carter of Lowry City, Missouri, arrested and accused of starting March 19 fire at Sheridan Ridge Townhomes on Farley Street.",
+      "content": "\u003cp\u003eA Missouri resident has been arrested and charged with arson in a \u003ca href=\"https://www.kansascity.com/news/local/article273350690.html\"\u003eMarch fire that displaced residents at an apartment complex in Overland Park\u003c/a\u003e, according to court records. \u003c/p\u003e\u003cp\u003eChrissy I. Carter, 28, of Lowry City, Missouri, was \u003ca href=\"https://www.jocosheriff.org/detention-bureau/booking-and-release-report\"\u003earrested August 8 \u003c/a\u003eand charged with three counts of arson with risk of bodily harm, a felony, according to Johnson County Sheriff’s Office arrest and booking records. Carter is being held on $100,000 bond.\u003c/p\u003e\u003cp\u003eAn Overland Park police officer responded around 2:49 a.m. on March 19 to the \u003ca href=\"https://www.sheridanridgeapts.com/\" target=\"_self\" rel=\"Follow\"\u003eSheridan Ridge Townhomes\u003c/a\u003e, 8403 Carter St., where a 911 caller reported someone screaming, according to an affidavit filed in Johnson County District Court. A 911 call taker could hear the person yelling “Come on!” and “What the f*** is wrong with you?”\u003c/p\u003e\u003cp\u003eThe responding officer heard Carter yelling for help and saw heavy, black smoke billowing out of the home. Carter was on the sidewalk in front of the residence, according to the affidavit. \u003c/p\u003e\u003cp\u003ePolice evacuated residents and contacted fire crews who responded around 3 a.m.\u003ca href=\"https://www.sheridanridgeapts.com/\" target=\"_self\" rel=\"Follow\"\u003e\u003cbr/\u003e\u003cbr/\u003e\u003c/a\u003e\u003c/p\u003e\u003cp\u003eWhen asked how the fire started, Carter told police she started cooking hot dogs on the stove but fell asleep on the sofa. The fire had already started when she woke up. Her boyfriend tried to put it out, but it was too late, according to the affidavit. \u003c/p\u003e\u003cp\u003ePolice and detectives said Carter later gave conflicting accounts of how the fire started. \u003c/p\u003e\u003cp\u003eAll residents had evacuated the building safely, but residents from eight units of the two-story complex were displaced, Jason Rhodes, a spokesman for the Overland Park Fire Department, said in March. \u003c/p\u003e\u003cp\u003eCrews had the fire under control within two hours.\u003c/p\u003e\u003cp\u003eNo injuries were reported and a local chapter of the Red Cross helped displaced residents.\u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Star’s Matti Gellman contributed to this report. \u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278271508",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Andrea Klick\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:aklick@kcstar.com\"\u003eaklick@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "Around 3 a.m. March 19, a fire at the Sheridan Ridge Townhomes in Overland Park displaced residents. A Missouri resident is arrested and accused of starting the fire. ",
+      "lead_media": {
+        "id": "273353955",
+        "url": "https://www.kansascity.com/latest-news/qq3fbn/picture273353955",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "OP fire sunday_fitted.jpeg",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1679283941,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1679283941,
+        "thumbnail": "https://www.kansascity.com/latest-news/qq3fbn/picture273353955/alternates/FREE_1140/OP%20fire%20sunday_fitted.jpeg",
+        "href": "/web/v1/content/273353955",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "",
+        "dateline": "",
+        "caption": "Overland Park fire crews arrived at 3 a.m. to the Sheridan Ridge Townhomes apartment complex following calls of a fire. After two hours the heavy smoke and fire in the attic were brought under control. No injuries were reported.",
+        "photographer": "Submitted by Overland Park Fire Department",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    }
+  ]
+}

--- a/data/opinion.json
+++ b/data/opinion.json
@@ -1,0 +1,1755 @@
+{
+  "items": [
+    {
+      "id": "278235918",
+      "url": "https://www.sacbee.com/opinion/op-ed/article278235918.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Investments in mental health care will help alleviate California’s homelessness crisis | Opinion",
+      "publication": "sacbee",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5787",
+      "home_section": {
+        "name": "Viewpoints",
+        "url": "https://www.sacbee.com/opinion/op-ed/"
+      },
+      "modified_date": 1692100800,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "CA’s Newsom focuses on mental health to solve homelessness",
+      "originating_url": "https://www.sacbee.com/opinion/op-ed/article278235918.html",
+      "meta_description": "California Gov. Gavin Newsom and the Legislature are seeking to reform the Mental Health Services Act to alleviate chronic homelessness.",
+      "published_date": 1692100800,
+      "thumbnail": "https://www.sacbee.com/latest-news/j9xzjb/picture277831383/alternates/FREE_1140/SAC_RCB_20230718_HOMELESS0167.JPG",
+      "authors": [
+        {
+          "name": "Darrell Steinberg",
+          "email": ""
+        }
+      ],
+      "keywords": "california, homeless, government, gavin newsom, legislature",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "5787",
+        "3182",
+        "70592",
+        "5779"
+      ],
+      "credit": "Special to The Sacramento Bee",
+      "dateline": "",
+      "summary": "California Gov. Gavin Newsom and the Legislature are seeking to reform the Mental Health Services Act to alleviate chronic homelessness.",
+      "content": "\u003cp\u003eThe encampment on 28th and C in Downtown Sacramento was no different than other homeless encampments throughout California: Around 30 people, most living in tents, having been on the streets for months or years.\u003c/p\u003e\u003cp\u003eEvery day for nearly three months, local outreach teams helped get people off the street. At a city council meeting, I asked: How many were enrolled in comprehensive, “wraparound” mental health and substance abuse treatment services? The stunning answer: Only one.\u003c/p\u003e\u003cp\u003eBut why hasn’t the Mental Health Services Act (MHSA), the millionaire’s tax initiative I led in 2004, done more to alleviate the homeless crisis for the thousands of people with serious mental illness and substance abuse living on our streets? The answer: very little MHSA money is focused on chronic homelessness.\u003c/p\u003e\u003cp\u003eTo be clear, the MHSA’s billions have helped tens of thousands of people get the care they need. And, until recently, it was essentially the primary source for addressing the needs of people without insurance or access to mental health care.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:201347249% --\u003e\u003c/p\u003e\u003cp\u003eNow, nearly 20 years later, Gov. Gavin Newsom and Senator Susan Talamantes Eggman are seeking to modernize the MHSA. \u003ca href=\"https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202320240SB326\" target=\"_blank\" rel=\"Follow\"\u003eSenate Bill 326\u003c/a\u003e, if approved by the voters next March, would give the Legislature greater flexibility in dispersing MHSA funds. Newsom and Egman propose a more aligned approach for counties to spend dollars on proven responses to data-driven needs while retaining local flexibility to meet local needs. Larger percentages of funding will be allocated to housing for people living with serious mental illness or substance abuse and wraparound services, with a specific focus on the chronically homeless and a continuing focus on community care, including prevention and early intervention.\u003c/p\u003e\u003cp\u003eWhile there has been wide support across the state, from mental health advocates and first-responders to local leaders like me, a few changes have drawn a predictable response from some county leaders who suggest that if they’re required to spend more MHSA dollars on chronic homelessness, valuable programs must be cut. \u003c/p\u003e\u003cp\u003eCurrently, California’s 58 counties invest billions of dollars in community-based care with virtually zero state guidance. For the first time, a California governor is proposing that the state has both the right and the obligation to set priorities that address the most serious crisis of our time. Newsom is creating accountability to deliver results and establishing ongoing funding for statewide housing and workforce to ensure our state has the mental health care beds and health care workers it needs.\u003c/p\u003e\u003cp\u003eThe governor’s call to prioritize the chronically homeless mirrors the original intent of the act.\u003c/p\u003e\u003cp\u003eIn 2004, we wrote Proposition 63 to build on a successful pilot program I authored to begin fulfilling then-Governor Ronald Reagan and the legislature’s unkept promise when they shut state hospitals. Their well-intended policy promised to shift 90% of the savings from hospital closures to community-based mental health care, but that never came to fruition. The idea, the language and the campaign for the MHSA in 2004 emphasized addressing the most tragic consequence of that failed promise: the growing numbers of chronically homeless people living with serious mental illness.\u003c/p\u003e\u003cp\u003eNearly two decades later, homelessness remains a top priority for most Californians, as recent studies show the money being spent is not focused enough on addressing this crisis. Newsom’s proposal would bring about much-needed accountability at the local level so Californians can finally see results.\u003c/p\u003e\u003cp\u003eApproximately 82% of unsheltered Californians live with a serious mental health condition, according to UCSF. Current MHSA rules require the majority of direct service funds be directed toward the ‘whatever it takes’ approach, but MHSA’s oversight and accountability commission reported that nine out of 10 counties with the highest homeless population are failing to meet this requirement.\u003c/p\u003e\u003cp\u003eOrange County, the only county meeting the required standard, saw a 17% drop in people experiencing homelessness from 2019 to 2022 — even while the statewide homelessness rate went up. That success is not a coincidence.\u003c/p\u003e\u003cp\u003eAs for concerns about cutting prevention programs, it’s important to note that the modernization of the MHSA is not occurring in a funding vacuum. Over the past decade, state and federal funding for behavioral health has more than doubled. \u003ca href=\"https://steinberginstitute.org/the-steinberg-institute-releases-new-analysis-of-governor-gavin-newsoms-behavioral-health-proposal-finds-governors-plan-makes-urgent-and-necessary-changes-to-the-mhsa/\" target=\"_blank\"\u003eA recent report provides a detailed look at these funding increases\u003c/a\u003e.\u003c/p\u003e\u003cp\u003eUntil now, California has never had a governor who made behavioral health a real priority. Newsom and the Legislature have invested billions of dollars in a complete overhaul of our statewide behavioral health network. Combining these new investments with a more focused and accountable MHSA is the best chance we have to make good on one of California’s longest unfulfilled promises. \u003c/p\u003e\u003cdiv class=\"ng_endnote_contact\"\u003eDarrell Steinberg is the current Mayor of Sacramento, former president of the California State Senate and led the Proposition 63 initiative in 2004.\u003c/div\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278235918",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Darrell Steinberg\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eSpecial to The Sacramento Bee\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "“Until now, California has never had a governor who made behavioral health a real priority,” writes Sacramento Mayor Darrell Steinberg. ",
+      "lead_media": {
+        "id": "277831383",
+        "url": "https://www.sacbee.com/latest-news/j9xzjb/picture277831383",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "SAC_RCB_20230718_HOMELESS0167.JPG",
+        "publication": "sacbee",
+        "layout_option": "",
+        "home": "/web/v1/sections/3182",
+        "modified_date": 1690840041,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1690840041,
+        "thumbnail": "https://www.sacbee.com/latest-news/j9xzjb/picture277831383/alternates/FREE_1140/SAC_RCB_20230718_HOMELESS0167.JPG",
+        "href": "/web/v1/content/277831383",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3182"
+        ],
+        "credit": "rbyer@sacbee.com",
+        "dateline": "",
+        "caption": "Homeless camper Chadwick Justin Foy, 41, right, says he has no idea where he will move while resting in the shade at the intersection of 28th and C streets on Tuesday, July 18, 2023. The city has given notices to dozens of people living in tents on the sidewalks in that area, near Leland Stanford Park, telling them to move by Wednesday. The notices cite violation of city codes regarding sidewalk obstruction and storage of personal property on public property.",
+        "photographer": "Renée C. Byer",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Sacramento",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": [
+        {
+          "name": "mcc-local-oped"
+        }
+      ]
+    },
+    {
+      "id": "278237488",
+      "url": "https://www.sacbee.com/opinion/article278237488.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Epic failure: How the city of Sacramento gambled with taxpayer money and lost big | Opinion",
+      "publication": "sacbee",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5779",
+      "home_section": {
+        "name": "Opinion",
+        "url": "https://www.sacbee.com/opinion/"
+      },
+      "modified_date": 1692119504,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Losing a $26 million settlement is a disaster for Sacramento",
+      "originating_url": "https://www.sacbee.com/opinion/article278237488.html",
+      "meta_description": "By losing a $26 million settlement to developer Paul Petrovich, Sacramento paid for treating Petrovich unfairly and for risking with public money.",
+      "published_date": 1692100800,
+      "thumbnail": "https://www.sacbee.com/opinion/op-ed/soapbox/ozaidb/picture194153194/alternates/FREE_1140/IMG_20151117.AS.GasStati_2_1_7Q76D0O7_L195224649",
+      "authors": [
+        {
+          "name": "The Sacramento Bee Editorial Board",
+          "email": "opinion@sacbee.com"
+        }
+      ],
+      "keywords": "sacramento, lawsuit, paul petrovich, development",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "5779",
+        "5781",
+        "3182",
+        "70592"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "By losing a $26 million settlement to developer Paul Petrovich, Sacramento paid for treating Petrovich unfairly and for risking with public money.",
+      "content": "\u003cp\u003eA spectacularly unfortunate chapter for the Sacramento City Council does not end because the city is paying a $26 million settlement to developer Paul Petrovich, who soundly beat the city in court for its handling of his Curtis Park development project. \u003c/p\u003e\u003cp\u003eThe headache only continues due to the city’s decision to buy from Petrovich a near-empty office building on one of the most distressed blocks on K Street in downtown Sacramento.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:201347249% --\u003e\u003c/p\u003e\u003cp\u003eThe city confirmed that it had to dig into its own coffers to make Petrovich whole. Insurance money is not covering the purchase of the Hale’s Building at 831 K Street (site of the former Rite Aid store) from a Petrovich firm for $18.5 million. That is roughly the same amount that the city spends from its general fund on directly homeless services in a year. This is a big deal; it is the city’s living legacy of council meetings that courts found had acted in a \u003ca href=\"https://www.sacbee.com/news/local/article277858738.html\" target=\"_blank\" rel=\"Follow\"\u003ebiased manner\u003c/a\u003e. \u003c/p\u003e\u003cp\u003eThe settlement also includes $7.5 million in direct settlement payments. The sources of funds, according to the settlement, will include “the city and by one or more of the defendants’ insurers.” According to city spokesman Tim Swanson, the city will entirely fund the purchase of the office building at 831 K Street from the general fund and a “risk fund” that is used to pay liabilities not covered by insurance.\u003c/p\u003e\u003cp\u003eHow great a time is it for the city to get into the office business on this block of K Street? Consider that just a few steps away, the 28-story Renaissance Tower at 801 K Street is approximately\u003ca href=\"https://www.commercialcafe.com/commercial-property/us/ca/sacramento/renaissance-tower-1/\" target=\"_blank\" rel=\"Follow\"\u003e two-thirds empty\u003c/a\u003e, based on lease availability. Across the street, 830 K Street is \u003ca href=\"https://www.commercialcafe.com/commercial-property/us/ca/sacramento/830-k-street/\" target=\"_blank\" rel=\"Follow\"\u003emost empty\u003c/a\u003e And the Kress Building at 818 K Street is \u003ca href=\"https://www.commercialcafe.com/commercial-property/us/ca/sacramento/the-kress-building/\" target=\"_blank\" rel=\"Follow\"\u003ealmost entirely empty\u003c/a\u003e. \u003c/p\u003e\u003cp\u003eThe city will also \u003ca href=\"https://www.sacbee.com/news/local/article235311182.html\" target=\"_blank\" rel=\"Follow\"\u003erename the Crocker Village park \u003c/a\u003eas the “Petrovich Family Playfield,” with a plaque honoring the developer’s father, John “Pete” Petrovich. It has also apologized in writing to Petrovich “for conducting an unfair hearing.”\u003c/p\u003e\u003cp\u003eAll this money and angst was over a proposed gas station. \u003c/p\u003e\u003cp\u003ePetrovich’s proposal to build a gas station as part of his Crocker Village retail complex took on a larger-than-life quality to the neighborhood. The opposition in the neighborhood saw it as creating pollution and traffic. Petrovich saw it as an important amenity for the complex. \u003c/p\u003e\u003cp\u003eLeading the charge against the gas station on behalf of the neighborhood was its representative on the city council, Jay Schenirer. He has been a true public servant for years in Sacramento on the council and the board of the Sacramento City Unified Schools District. But he went too far. In one ruling\u003ca href=\"https://www.sacbee.com/news/business/article241860466.html\" target=\"_blank\" rel=\"Follow\"\u003e Sacramento Superior Court Judge Michael Kenny\u003c/a\u003e wrote that Schenirer “demonstrated “an unacceptable probability of actual bias.” \u003c/p\u003e\u003cp\u003eWhen a council doesn’t give an applicant a fair hearing, it has crossed a legal line into trouble. As an appellate panel wrote, “Councilmember Schenirer acted as advocate, not a neutral and impartial decision maker, and should have recused himself from voting on the appeal.”\u003c/p\u003e\u003cp\u003eSchenirer served on the council from 2010 to 2022 and was a signatory to the settlement. He did not apologize.\u003c/p\u003e\u003cp\u003eThere is a broader lesson to be learned here. It is for city council members to recuse themselves when they have become so biased as to be unable to be fair. Or a city attorney can advise that the council member step down from voting out of the same concern because voting could expose the city to legal liability. Neither happened. And now Sacramento will pay dearly.\u003c/p\u003e\u003cp\u003eWhat is the city’s plan for its office “investment” at 831 K Street? To convert the building into some other use other than an empty building, where is the money going to come? The drain on city funds could only be beginning.\u003c/p\u003e\u003cp\u003ePetrovich has been among that rare breed of developers who has shunned the relative simplicity of suburban development for the grit of urban redevelopment, in this case converting the once-polluted Curtis Park rail yard into a modern urban neighborhood. The political environment surrounding the redevelopment project ended up creating its own kind of toxic environment. \u003c/p\u003e\u003cp\u003eIt took no less than three lawsuits and untold massive legal bills (the city spent more than $2 million on lawyers) for Petrovich to finally get justice. The city fought and fought until it simply ran out of options. The city council and Mayor Darrell Steinberg, in directing this litigation through decisions in closed sessions, behaved like gamblers. They doubled down after losing one ruling after another until their pockets were empty of legal theories. \u003c/p\u003e\u003cp\u003eThey gambled with our money. \u003c/p\u003e\u003cp\u003eWho knows how often local governments act so unfairly that it is downright illegal. It takes a very deep pocket and years of patience to prove it. Paul Petrovich did it. Hopefully the Curtis Park gas station fiasco does not haunt 831 K like a ghost.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:239341538% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278237488",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy The Sacramento Bee Editorial Board\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:opinion@sacbee.com\"\u003eopinion@sacbee.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "The price of treating developer Paul Petrovich unfairly was $26 million for the city of Sacramento. Though this headache is not yet over for the city",
+      "lead_media": {
+        "id": "194153194",
+        "url": "https://www.sacbee.com/opinion/op-ed/soapbox/ozaidb/picture194153194",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "IMG_20151117.AS.GasStati_2_1_7Q76D0O7_L195224649",
+        "publication": "sacbee",
+        "layout_option": "",
+        "home": "/web/v1/sections/6672",
+        "modified_date": 1692119413,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1515690213,
+        "thumbnail": "https://www.sacbee.com/opinion/op-ed/soapbox/ozaidb/picture194153194/alternates/FREE_1140/IMG_20151117.AS.GasStati_2_1_7Q76D0O7_L195224649",
+        "href": "/web/v1/content/194153194",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "6672"
+        ],
+        "credit": "Sacramento Bee file",
+        "dateline": "",
+        "caption": "Developer Paul Petrovich waits to speak to the Sacramento City Council in November 2015 on a gas station in Curtis Park Village.",
+        "photographer": "Andrew Seng",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Sacramento",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278179827",
+      "url": "https://www.sacbee.com/opinion/article278179827.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Bee Opinionated: County’s $1B jail + Community responsibility for homeless + Sac DA goes to war",
+      "publication": "sacbee",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5779",
+      "home_section": {
+        "name": "Opinion",
+        "url": "https://www.sacbee.com/opinion/"
+      },
+      "modified_date": 1691978410,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Sacramento county to spend 1 billion for jail expansion",
+      "originating_url": "https://www.sacbee.com/opinion/article278179827.html",
+      "meta_description": "Sacramento County Supervisors prioritize funding jail expansion over health services and housing projects, cause public criticism and protests",
+      "published_date": 1691978400,
+      "thumbnail": "",
+      "authors": [
+        {
+          "name": "Robin Epley",
+          "email": "repley@sacbee.com"
+        }
+      ],
+      "keywords": "sacramento, county, homeless, unhoused, supervisor",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "5779",
+        "88678",
+        "3182",
+        "70592"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Sacramento County Supervisors prioritize funding jail expansion over health services and housing projects, cause public criticism and protests",
+      "content": "\u003cp\u003e\u003ci\u003eWe send Bee Opinionated to newsletter subscribers first. Get it in your inbox before it publishes online:\u003c/i\u003e\u003ca href=\"https://t.news.sacbee.com/webApp/mccSignUp?newsletter=sacbee_beeopinionated_newsletter\"\u003e\u003ci\u003e \u003c/i\u003e\u003ci\u003eSign up here.\u003c/i\u003e\u003c/a\u003e\u003c/p\u003e\u003cp\u003eIt’s \u003cb\u003eRobin Epley\u003c/b\u003e with \u003cb\u003eThe Sacramento Bee Editorial Board \u003c/b\u003eonce again, bringing you the best of California’s opinion journalism.\u003c/p\u003e\u003cp\u003eWhat would you do with almost a billion dollars? \u003c/p\u003e\u003cp\u003eLast Tuesday, three of the five \u003cb\u003eSacramento County Supervisors\u003c/b\u003e voted to begin a process that \u003ca href=\"https://www.sacbee.com/opinion/article278082942.html#storylink=cpy\" target=\"_blank\" rel=\"Follow\"\u003ewill cost residents close to $1 billion\u003c/a\u003e in the coming years to expand the County’s \u003cb\u003eMain Jail\u003c/b\u003e and provide a mere 100 new beds in a mental health facility — in spite of more than three hours of spirited public comment, and all of it entirely in protest. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:254113973% --\u003e\u003c/p\u003e\u003cp\u003eThis is, by far, \u003ca href=\"https://agendanet.saccounty.gov/BoardofSupervisors/Documents/ViewDocument/RES%20-%20Reimbursement%20Resolution%20v4.docx.pdf?meetingId=7965\u0026documentType=Agenda\u0026itemId=414376\u0026publishId=1262220\u0026isSection=false\" target=\"_blank\" rel=\"Follow\"\u003ethe largest debt the county has ever taken on\u003c/a\u003e. It also forces county leaders to prioritize funding jail construction over health services and housing. \u003c/p\u003e\u003cp\u003e\u003ci\u003e“The existing jail is the most expensive and least effective place to comply with a court decree to provide mental health services to inmates who need it,” \u003c/i\u003ewrote The Sacramento Bee Editorial Board. \u003ci\u003e“There are such better options if the county would only try.” \u003c/i\u003e\u003c/p\u003e\u003cp\u003eWe believe supervisors \u003cb\u003ePatrick Kennedy\u003c/b\u003e and\u003cb\u003e Phil Serna\u003c/b\u003e deserved some credit for challenging staff and voting against the two agenda items, which now authorize a $654 million mental health annex at the downtown jail and also approves overall county expenditures of up to $925 million.\u003c/p\u003e\u003cp\u003e“This was a fear-based decision by the supervisors, running scared from a threatened federal receivership. The county has been hopelessly out of compliance with a 2018 federal consent decree, the result of a class-action lawsuit seeking better treatment of prisoners with disabilities. The county is bound by law to prove they are moving toward a solution to those findings, and the board clearly felt they had no other option but to vote to move forward.”\u003c/p\u003e\u003ch3\u003eNo Place Like Home\u003c/h3\u003e\u003cp\u003e\u003ci\u003e“Homelessness is not a uniquely Sacramento problem, but for far too long, leaders in Sacramento, and in other California communities and beyond, have allowed NIMBYs to slow potential solutions. As someone who doesn’t live in Sacramento, it was fascinating to watch elected city leaders delegate the authority of finding suitable encampments for homeless people to \u003cb\u003eC\u003c/b\u003e\u003c/i\u003e\u003cb\u003e\u003ci\u003eity Manager Howard Chan,\u003c/i\u003e\u003c/b\u003e\u003ci\u003e who was not elected by voters.”\u003c/i\u003e\u003c/p\u003e\u003cp\u003eSo wrote our new summer intern, \u003cb\u003eBrian Zhang\u003c/b\u003e, \u003ca href=\"https://www.sacbee.com/opinion/article278041318.html#storylink=cpy\" target=\"_blank\" rel=\"Follow\"\u003ein his first column last week\u003c/a\u003e. Brian will be with us for the months of August and he’s already churning out some great work for the Opinion team; he’s a rising junior at Yale, and lives in Brooklyn, New York. \u003c/p\u003e\u003cp\u003e\u003ci\u003e“When leaders are slow to make collaborative, educational approaches to poverty, it turns the most vulnerable against each other instead of making new leaders out of us,” \u003c/i\u003eBrian wrote. \u003c/p\u003e\u003cp\u003e\u003ci\u003e“What can California learn from New York’s prior examples and Houston’s unified homelessness response, which has brought together public housing committees, philanthropy, religion, private foundations and dozens of nonprofits? On a national scale, nearly all American melting pots are scrambling to house and feed asylum-seeking migrants on limited funds and space. Who are we to disapprove of homeless individuals walking in any one of our neighborhoods?”\u003c/i\u003e\u003c/p\u003e\u003ch3\u003eOp-Ed Roundup\u003c/h3\u003e\u003cp\u003e\u003ca href=\"https://www.sacbee.com/opinion/op-ed/article277833458.html#storylink=cpy\" target=\"_blank\" rel=\"Follow\"\u003e“Forever chemicals” are in our bodies and drinking water. We must stop using them\u003c/a\u003e by \u003cb\u003ePhil Ting, California State Assembly representative\u003c/b\u003e for the 19th District, and \u003cb\u003eAndria Ventura\u003c/b\u003e, the legislative and policy director for \u003cb\u003eClean Water Action California\u003c/b\u003e.\u003c/p\u003e\u003cp\u003e\u003ci\u003e“Advocates have been sounding the alarm about California’s \u003c/i\u003e\u003cb\u003e\u003ci\u003ePFAS \u003c/i\u003e\u003c/b\u003e\u003ci\u003ecrisis for years, but the pace of progress does not yet match the urgency of this growing problem. We don’t manufacture PFAS products in California, but they are nonetheless found everywhere, from \u003c/i\u003e\u003ca href=\"https://www.kcra.com/article/study-shows-dangerously-high-levels-toxins-fish-northern-california-rivers/42747129\"\u003e\u003ci\u003erivers\u003c/i\u003e\u003c/a\u003e\u003ci\u003e and \u003c/i\u003e\u003ca href=\"https://calmatters.org/projects/california-water-contaminated-forever-chemicals/\"\u003e\u003ci\u003egroundwater\u003c/i\u003e\u003c/a\u003e\u003ci\u003e to our \u003c/i\u003e\u003ca href=\"https://www.cnn.com/2023/03/20/health/pfas-children-wellness/index.html\"\u003e\u003ci\u003eown bodies\u003c/i\u003e\u003c/a\u003e\u003ci\u003e.”\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ca href=\"https://www.sacbee.com/opinion/op-ed/article278028868.html#storylink=cpy\" target=\"_blank\" rel=\"Follow\"\u003eDespite what Sacramento DA Thien Ho might say, being unhoused isn’t a crime\u003c/a\u003e by \u003cb\u003eErwin Chemerinsky\u003c/b\u003e, the dean of and a professor at the \u003cb\u003eUC Berkeley School of Law\u003c/b\u003e.\u003c/p\u003e\u003cp\u003e\u003ci\u003e“It is possible that the dispute between the DA and the city attorney could go to court if Ho decides to initiate an action against city officials. Such a suit would be frivolous and likely to be quickly thrown out of court. If Ho decides to initiate prosecutions against the unhoused, these will fail based on the Ninth Circuit’s decisions. Indeed, there almost certainly would be a suit in federal court to enjoin Ho, which will make it back to the court of appeals in a year or two.”\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ca href=\"https://www.sacbee.com/opinion/op-ed/article275753176.html#storylink=cpy\" target=\"_blank\" rel=\"Follow\"\u003eFor Sacramento’s homeless population, summertime is about surviving the heat\u003c/a\u003e by \u003cb\u003eKatherine Hunter\u003c/b\u003e, a Sacramentan currently residing in New York City.\u003c/p\u003e\u003cp\u003e\u003ci\u003e“To some residents of Sacramento, \u003c/i\u003e\u003cb\u003e\u003ci\u003eCesar Chavez Plaza\u003c/i\u003e\u003c/b\u003e\u003ci\u003e is an eyesore, with anywhere from 20 to 30 or more unhoused individuals set up in tents, sprawled out in the sun or gathered in small groups around the fountain. But for the folks who spend their days or nights here, this park is their home. It’s a home with no air conditioning, water or fans. And in the summertime, when Sacramento sees triple-digit temperatures, no one feels the impact of the heat more than the city’s unhoused residents.”\u003c/i\u003e\u003c/p\u003e\u003ch3\u003eOpinion of the Week\u003c/h3\u003e\u003cp\u003e\u003ci\u003e“This is all Ho’s doing.”\u003c/i\u003e\u003ci\u003e — \u003c/i\u003e\u003ca href=\"https://www.sacbee.com/opinion/op-ed/article278028868.html#storylink=cpy\" target=\"_blank\" rel=\"Follow\"\u003eThe Sacramento Bee Editorial Board \u003c/a\u003eon \u003cb\u003eSacramento County DA Thien Ho\u003c/b\u003e’s announcement that he has launched an investigation into certain, unnamed City of Sacramento officials over their “failure” to enforce state public nuisance laws and allowing homeless encampments within the city limits.\u003c/p\u003e\u003cp\u003e\u003ci\u003eGot thoughts? What would you like to see in this newsletter every week? Got a story tip or an opinion to tell the world? Let us know what you think about this email and our work in general by emailing us at any time via \u003c/i\u003e\u003ca href=\"mailto:opinion@sacbee.com\"\u003e\u003cb\u003e\u003ci\u003eopinion@sacbee.com\u003c/i\u003e\u003c/b\u003e\u003c/a\u003e\u003ci\u003e. \u003c/i\u003e\u003c/p\u003e\u003cp\u003eCongrats on reading this whole newsletter,\u003c/p\u003e\u003cp\u003eRobin\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278179827",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Robin Epley\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:repley@sacbee.com\"\u003erepley@sacbee.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "In this week’s Bee Opinionated, we ask: What would you do with almost a billion dollars? Sacramento County wants to use it for a new annex at the jail.",
+      "lead_media": {
+        "id": "259836150",
+        "url": "https://www.sacbee.com/latest-news/whfoys/picture259836150",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "Sacramento Bee Opinionated Newsletter Logo Image",
+        "publication": "sacbee",
+        "layout_option": "",
+        "home": "/web/v1/sections/3182",
+        "modified_date": 1648410933,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1648410933,
+        "thumbnail": "https://www.sacbee.com/latest-news/whfoys/picture259836150/alternates/FREE_1140/Sacramento%20Bee%20Opinionated%20Newsletter%20Logo%20Image",
+        "href": "/web/v1/content/259836150",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3182"
+        ],
+        "credit": "McClatchy Design",
+        "dateline": "",
+        "caption": "-",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Sacramento",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278177287",
+      "url": "https://www.sacbee.com/opinion/article278177287.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Sweeps kill, so why is Sacramento still doing them against a court order to stop? | Opinion",
+      "publication": "sacbee",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5779",
+      "home_section": {
+        "name": "Opinion",
+        "url": "https://www.sacbee.com/opinion/"
+      },
+      "modified_date": 1691785244,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Sacramento city swept two homeless camps against court order",
+      "originating_url": "https://www.sacbee.com/opinion/article278177287.html",
+      "meta_description": "City of Sacramento violated a court order and swept two homeless camps in front of City Hall last week; they just called it “an oversight”",
+      "published_date": 1691785244,
+      "thumbnail": "",
+      "authors": [
+        {
+          "name": "Robin Epley",
+          "email": "repley@sacbee.com"
+        }
+      ],
+      "keywords": "homeless, sacramento, county, court order, sweeps",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "5779",
+        "88678",
+        "3182",
+        "70592"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "City of Sacramento violated a court order and swept two homeless camps in front of City Hall last week; they just called it “an oversight”",
+      "content": "\u003cp\u003eIn \u003ca href=\"https://docs.justia.com/cases/federal/district-courts/california/caedce/2:2022cv01095/412699/39\" target=\"_blank\" rel=\"Follow\"\u003edirect violation of a court order,\u003c/a\u003e the city of Sacramento has swept at least two homeless encampments this week. \u003c/p\u003e\u003cp\u003eThe city’s excuse? That the sweeps were “unintentional oversights.”\u003c/p\u003e\u003cp\u003e“The city has communicated the information contained in the order to its employees, including those in the Sacramento Police Department, code enforcement and other departments and divisions,” \u003ca href=\"https://www.sacbee.com/news/local/article278070927.html\" target=\"_blank\" rel=\"Follow\"\u003esaid city spokesman Tim Swanson.\u003c/a\u003e “However, the city was previously not as effective in communicating with one of its contractors and their employees, leading to the unintentional oversights that occurred Friday and Monday.” \u003c/p\u003e\u003cp\u003eThe Sacramento Homeless Union, which brought forward the lawsuit against the city that resulted in the court order, says there was also a third sweep in front of City Hall that occurred on Tuesday, but the city denies it. \u003c/p\u003e\u003cp\u003ePutting lives at risk and disregarding a court order can hardly be called a simple oversight. The fact that these sweeps literally occurred in front of City Hall is unacceptable and gives the impression that the city has no control over its employees.\u003c/p\u003e\u003ch3\u003eSweeps kill\u003c/h3\u003e\u003cp\u003eThere is \u003ca href=\"https://48hills.org/2023/04/sweeps-of-homeless-people-are-in-fact-deadly-new-medical-study-shows/\" target=\"_blank\" rel=\"Follow\"\u003eoverwhelming evidence\u003c/a\u003e that sweeps kill, especially in extreme weather conditions such as summer heat over 90 degrees. \u003c/p\u003e\u003cp\u003eA \u003ca href=\"https://news.cuanschutz.edu/news-stories/study-shows-involuntary-displacement-of-people-experiencing-homelessness-may-cause-significant-spikes-in-mortality-overdoses-and-hospitalizations\"\u003estudy published earlier this year\u003c/a\u003e in the Journal of the American Medical Association found that “encampment sweeps, bans, move-along-orders and cleanups that forcibly relocate individuals away from essential services (leads to) substantial increases in overdose deaths, life-threatening infections and hospitalizations.”\u003c/p\u003e\u003cp\u003eSweeps are often violent and are designed that way on purpose to scare and harass homeless people. \u003c/p\u003e\u003cp\u003ePeople’s possessions are demolished or stolen, clothes and bedding are lost, and lifesaving medications get destroyed — and all for what? An increased risk of overdose, hospitalization and death.\u003c/p\u003e\u003cp\u003eIt’s also incredibly expensive to conduct a sweep. \u003ca href=\"https://shnny.org/uploads/Florida-Homelessness-Report-2014.pdf\" target=\"_self\" rel=\"Follow\"\u003eResearch shows it costs taxpayers\u003c/a\u003e more than $30,000 every year to criminalize just one unhoused person, while the yearly cost for providing that same person supportive housing is around $10,000. \u003c/p\u003e\u003cp\u003eThe city of Sacramento should be held accountable for these “oversights” and found in contempt of the court order. Then, let the punishment fit the crime, and force the city to donate every penny that was spent on this sweep to the services and assistance these people deserved in the first place. \u003c/p\u003e\u003cp\u003eSacramento must end its practice of homeless camp sweeps, effective immediately. \u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278177287",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Robin Epley\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:repley@sacbee.com\"\u003erepley@sacbee.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "In direct violation of a court order, the city of Sacramento has swept at least two homeless encampments this week.",
+      "lead_media": {
+        "id": "277476873",
+        "url": "https://www.sacbee.com/latest-news/z5n30y/picture277476873",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "SAC_RCB_20230719_HOMELESSSWEEP0746.JPG",
+        "publication": "sacbee",
+        "layout_option": "",
+        "home": "/web/v1/sections/3182",
+        "modified_date": 1689801836,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1689801836,
+        "thumbnail": "https://www.sacbee.com/latest-news/z5n30y/picture277476873/alternates/FREE_1140/SAC_RCB_20230719_HOMELESSSWEEP0746.JPG",
+        "href": "/web/v1/content/277476873",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3182"
+        ],
+        "credit": "rbyer@sacbee.com",
+        "dateline": "",
+        "caption": "Alicia Peterson, 55, who had just gotten out of the hospital four days ago and suffered neuropathy and a broken wrist, was one of the last to pack up her belongings during a homeless encampment sweep along C street between 27th and 28th streets in Sacramento on Wednesday, July 19, 2023. She was hoping to keep her tent and was unsure where she might go.",
+        "photographer": "Renée C. Byer",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Sacramento",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278148932",
+      "url": "https://www.sacbee.com/opinion/article278148932.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "This Sacramento influencer shows you don’t need to leave town to have fun | Opinion",
+      "publication": "sacbee",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5779",
+      "home_section": {
+        "name": "Opinion",
+        "url": "https://www.sacbee.com/opinion/"
+      },
+      "modified_date": 1692032115,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "A Sacramento social media influencer highlights the city",
+      "originating_url": "https://www.sacbee.com/opinion/article278148932.html",
+      "meta_description": "Maddy Eccles, a Sacramento-based social media influencer, goes viral with videos highlighting the city’s amenities, businesses and events.",
+      "published_date": 1691928000,
+      "thumbnail": "",
+      "authors": [
+        {
+          "name": "Robin Epley",
+          "email": "repley@sacbee.com"
+        }
+      ],
+      "keywords": "sacramento, maddy eccles, social media, influencer",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "5779",
+        "5853",
+        "93956",
+        "3182",
+        "70592",
+        "5709"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Maddy Eccles, a Sacramento-based social media influencer, goes viral with videos highlighting the city’s amenities, businesses and events.",
+      "content": "\u003cp\u003eLast week, a riverboat cruise company offering \u003ca href=\"https://www.americancruiselines.com/\"\u003eluxury rides on the Sacramento River\u003c/a\u003e for tickets between $6,000 and $12,000 \u003ca href=\"https://www.sacbee.com/news/local/article277977293.html\"\u003escrapped the watery venture\u003c/a\u003e after just four trips. \u003c/p\u003e\u003cp\u003eFor some, it was yet another sign that Sacramento’s tourism economy struggles to compete in a false competition with the state’s larger and better-known cities like San Francisco and Los Angeles, which, respectively, drew in \u003ca href=\"https://www.sfchronicle.com/sf/article/s-f-tourism-spending-doubled-2022-17846480.php#:~:text=San%20Francisco%20tourism%20spending%2C%20which,in%202019%2C%20before%20the%20pandemic.\"\u003e$7.4 billion\u003c/a\u003e and \u003ca href=\"https://www.discoverlosangeles.com/los-angeles-tourism-announces-tourism-industry-generated-345-billion-in-total-business-sales-in#:~:text=Media-,LOS%20ANGELES%20TOURISM%20ANNOUNCES%20TOURISM%20INDUSTRY%20GENERATED%20%2434.5%20BILLION%20IN,%243%20BILLION%20IN%20TAX%20REVENUES\"\u003e$34.5 billion\u003c/a\u003e in tourism last year to Sacramento’s \u003ca href=\"https://www.cityofsacramento.org/Economic-Development/Key-Industries/Linking-Industries\" target=\"_self\" rel=\"Follow\"\u003e$2.1 billion\u003c/a\u003e.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:254113973% --\u003e\u003c/p\u003e\u003cp\u003eThe ill-fated river cruise was originally supposed to leave from San Francisco Bay, and Old Sacramento only became the replacement when the \u003ca href=\"https://www.sacbee.com/entertainment/article274319885.html\"\u003ecompany couldn’t come to business terms\u003c/a\u003e with the San Francisco Port Authority. \u003c/p\u003e\u003cp\u003eAlso, it was entitled “Napa Valley River Cruises,” despite there being no river I know of connecting Napa and Old Sac.\u003c/p\u003e\u003cp\u003eFar too often, Sacramento is billed as an attraction only because of its proximity to other, “better” places. How many times have you heard some variation of “only two hours from the Bay, and two hours from the mountains”? \u003c/p\u003e\u003cp\u003eSacramento has been fighting and losing that battle for decades, and I think it’s time to stop. No one wants a glossy, $6,000 boat ride down our river. We want to see Sacramento celebrated for what it has to offer now, in 2023 — and that’s much more than you might think. \u003c/p\u003e\u003ch3\u003eSacramento seen her way\u003c/h3\u003e\u003cp\u003eConsider the (often-unpaid) work of Maddy Eccles, a 34-year-old, Sacramento-based social media influencer whose videos on Instagram and TikTok highlighting the city are all anyone in my social circles seem to be talking about. \u003c/p\u003e\u003cp\u003eShe’s far from the only influencer Sac can boast of, but Eccles seems to have hit local consciousness in a new way lately, and several of her videos have gone viral with more than a million views. She uses her platform to reach an audience of 25- to 45-year-olds who see Sacramento not as a jumping off point to other locations, but as a city to be proud of in its own right. \u003c/p\u003e\u003cp\u003eEccles’ recent videos feature businesses like \u003ca href=\"https://www.instagram.com/p/CvisbopLISd/\"\u003eMidtown Spirits’ boozy slushies\u003c/a\u003e for hot summer days; local sights like the the \u003ca href=\"https://www.instagram.com/p/CuZ3JTjOoKm/\"\u003e“purple palace”\u003c/a\u003e on P Street; regular events like First Fridays on R Street or Second Saturdays in Midtown; the Citizen Hotel for \u003ca href=\"https://www.instagram.com/p/Cucv_RLx1kr/\"\u003ea treat-yourself staycation\u003c/a\u003e; and even a \u003ca href=\"https://www.instagram.com/p/Ct2Ni5gvnzA/\"\u003eshockingly great wine selection\u003c/a\u003e at an ampm in Elk Grove.\u003c/p\u003e\u003cp\u003eShe \u003ca href=\"https://www.instagram.com/p/Ctfz6VtvYby/\"\u003ealso blends\u003c/a\u003e\u003ca href=\"https://www.instagram.com/p/CtjjoKixMGP/?img_index=1\"\u003e local humor\u003c/a\u003e into her videos, like when she touched on the special brand of torture that is the downtown freeway interchange, or talked about how the city’s heat index could rival Satan’s sweaty armpit in the summertime. Her comment sections are filled with people who say they’re grateful for her videos and had no idea there were so many fun things going on in our area. \u003c/p\u003e\u003cp\u003e“It’s an underrated city,” Eccles told me. “People have lived their whole lives here, and they grew up thinking Sacramento was a cow town and there’s nothing to do, but now there’s so much.”\u003c/p\u003e\u003cp\u003eEccles, a San Diegan by birth who moved to Sacramento from Texas nearly five years ago, created the \u003ca href=\"https://www.instagram.com/explore/tags/beginnersguidetosac/\"\u003e#BeginnersGuideToSac\u003c/a\u003e on her blog, but says her posts on social media didn’t really take off until the pandemic when people were looking for ways to get out of their house. \u003c/p\u003e\u003cp\u003eNow, she focuses more on video content, has more than 100,000 followers across multiple platforms, was recently hired as an independent contractor with Visit California and is trying to make a full-time career out of promoting Sacramento.\u003c/p\u003e\u003cp\u003e“Sacramento is very possessive about their community,” she said. “I think that it’s a big town that feels like a small town. I can walk down the street and run into people I know, but I can also easily talk to business owners and chefs.”\u003c/p\u003e\u003ch3\u003eA different side of the city\u003c/h3\u003e\u003cp\u003eSacramento often gets a bad rap for being “boring,” but Eccles uses her pages to showcase a different side of the city, one that’s bursting with events and businesses catering to a younger demographic. It’s hardly curated and only barely edited, Eccles told me, but her Millennial and Gen Z audience prefers that. \u003c/p\u003e\u003cp\u003e“I just want to be as authentic as possible,” Eccles said. “I think that content that looks too much like an ad is a turn off. It’s more entertaining and easier to watch when it’s a real person, not a paid actor.”\u003c/p\u003e\u003cp\u003eSo when you see the news that this city can’t hold onto a luxury river cruise, stop and consider the facts: That exorbitantly priced voyage was never about highlighting what Sacramento has to offer, it was an East Coast-based company appealing to wealthy consumers that have too much cash to burn.\u003c/p\u003e\u003cp\u003eYoung Sacramentans aren’t impressed by costly, luxury experiences or the city’s proximity to “better” locations. We have less money than ever in our pockets and we want to love the city we live in. We’ve spent too much of our youth cooped up inside and we’re ready to bust out; meet us on our level and we’ll show Sac the love. \u003c/p\u003e\u003cp\u003e(And hey, if you want a riverboat ride, you can get one for \u003ca href=\"https://www.cityexperiences.com/sacramento/city-cruises/private-events/?gclid=Cj0KCQjwldKmBhCCARIsAP-0rfxmZCVEev12hpY-42Via7WlwZoTSdmul1OftMBqKeKF2Uk-SArUMocaAqRKEALw_wcB\"\u003e$30 with a full bar\u003c/a\u003e. See you there?)\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278148932",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Robin Epley\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:repley@sacbee.com\"\u003erepley@sacbee.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "“People think Sacramento is a cow town and there’s nothing to do, but there’s so much,” says Maddy Eccles, a Sacramento-based social media influencer.",
+      "lead_media": {
+        "id": "278235388",
+        "url": "https://www.sacbee.com/latest-news/47oq71/picture278235388",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "Maddy Eccles influencer",
+        "publication": "sacbee",
+        "layout_option": "",
+        "home": "/web/v1/sections/3182",
+        "modified_date": 1692033288,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692032091,
+        "thumbnail": "https://www.sacbee.com/latest-news/47oq71/picture278235388/alternates/FREE_1140/Maddy%20Eccles%20influencer",
+        "href": "/web/v1/content/278235388",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3182"
+        ],
+        "credit": "repley@sacbee.com",
+        "dateline": "",
+        "caption": "Maddy Eccles, a Sacramento-based influencer with more than 100,000 followers, uses her smartphone to capture a picture of a meal at La Venadita, a restaurant in Oak Park on August 9, 2023.",
+        "photographer": "Robin Epley",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Sacramento",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278147227",
+      "url": "https://www.sacbee.com/opinion/letters-to-the-editor/article278147227.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "The real deal: Violent crime is down significantly across almost all of California | Opinion",
+      "publication": "sacbee",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5785",
+      "home_section": {
+        "name": "Letters to the Editor",
+        "url": "https://www.sacbee.com/opinion/letters-to-the-editor/"
+      },
+      "modified_date": 1691928014,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Violent crime is down significantly across almost all of CA",
+      "originating_url": "https://www.sacbee.com/opinion/letters-to-the-editor/article278147227.html",
+      "meta_description": "Tough-on-crime law enforcement policies and rhetoric are unnecessary when the reality is that violent crime is down across all of California",
+      "published_date": 1691928000,
+      "thumbnail": "https://www.miamiherald.com/latest-news/efexy/picture274783716/alternates/FREE_1140/AP19227835052937%20(2).jpg",
+      "authors": [
+        {
+          "name": "The Sacramento Bee letter writers",
+          "email": ""
+        }
+      ],
+      "keywords": "crime, california, violence, law enforcement",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "5785",
+        "5853",
+        "3182",
+        "70592",
+        "5709",
+        "5779"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Tough-on-crime law enforcement policies and rhetoric are unnecessary when the reality is that violent crime is down across all of California",
+      "content": "\u003ch3\u003eThe whole picture\u003c/h3\u003e\u003cp\u003e“\u003ca href=\"https://www.sacbee.com/news/local/crime/article277477423.html\"\u003eSee crime trend for communities in the Sacramento region\u003c/a\u003e,” (sacbee.com, July 21)\u003c/p\u003e\u003cp\u003eThis article skews the truth by conveniently leaving out the fact that violent crime is down significantly across almost all of California in 2023. By focusing on a small spike among a decades-long trend of lowering violent crime rates, this piece is fueling dangerous fear-based narratives.\u003c/p\u003e\u003cp\u003eNewly released data compiled by the Major Cities Chiefs Association, an international association of police executives, show that violent crime has declined across California in the first three months of 2023 compared to the same period in 2022. The drop in violent crime so far this year is greater in California than in other parts of the U.S.\u003c/p\u003e\u003cp\u003eTwisting data to produce fear-based rhetoric is dangerous for our community, and helps to push public opinion toward ineffective ‘tough-on-crime’ strategies that continue to fail us.\u003c/p\u003e\u003cp\u003eLiz Blum\u003c/p\u003e\u003cp\u003eSacramento\u003c/p\u003e\u003ch3\u003eHelp is always available\u003c/h3\u003e\u003cp\u003e“\u003ca href=\"https://www.sacbee.com/news/local/health-and-medicine/article263652123.html\"\u003e988 suicide prevention hotline launches in CA, what it means\u003c/a\u003e,” (sacbee.com, July 24, 2022)\u003c/p\u003e\u003cp\u003e988, the nationwide mental health crisis helpline, is one year old. According to the Substance Abuse and Mental Health Services Administration, 98% of people who connect with 988 are helped by a trained crisis counselor (without involving 911). \u003c/p\u003e\u003cp\u003eThis service is free, confidential and available 24/7, 365 days a year. It connects individuals experiencing a mental health, substance use or suicidal crisis with trained crisis counselors. Access is available through every landline, cell phone and voice-over internet device, with call/text services available in Spanish and interpretation services in over 150 languages. \u003c/p\u003e\u003cp\u003eIf someone you know is experiencing an emotional crisis or thoughts of suicide, call 988 or seek help at a licensed behavioral health facility.\u003c/p\u003e\u003cp\u003eTami Brooks, LCSW/MBA-™\u003c/p\u003e\u003cp\u003eCEO, Sierra Vista Hospital \u003c/p\u003e\u003cp\u003eYannis Angouras, MHA \u003c/p\u003e\u003cp\u003eCEO, Heritage Oaks Hospital\u003c/p\u003e\u003cp\u003eLindsay Lopez, LCSW\u003c/p\u003e\u003cp\u003eCEO, Health Link Now\u003c/p\u003e\u003ch3\u003eWhat went wrong?\u003c/h3\u003e\u003cp\u003e“\u003ca href=\"https://www.sacbee.com/news/local/article277858738.html#:~:text=A%20costly%20eight%2Dyear%20legal,him%20an%20additional%20%247.5%20million.\"\u003eSacramento and developer Paul Petrovich complete settlement\u003c/a\u003e,” (sacbee.com, Aug. 3)\u003c/p\u003e\u003cp\u003eThe city agreed to pay $26 million to a developer after a state appeals court ruled in 2020 that the city denied the developer a “fair hearing” regarding his Crocker Village residential development. The article goes on to state that the “ruling now serves as precedent for establishing thresholds for personal bias in California.”\u003c/p\u003e\u003cp\u003eResidents might recall the eight-year legal battle which cost city taxpayers $2.3 million for the city to defend itself against a suit brought by the developer. Who at the city level was responsible for this “unfair hearing” and personal bias? It was the mayor and several members of the current council — including a council member who is no longer in office. Yet there was no mention of that pertinent information.\u003c/p\u003e\u003cp\u003eWhat went wrong?\u003c/p\u003e\u003cp\u003eBill Motmans\u003c/p\u003e\u003cp\u003eSacramento\u003c/p\u003e\u003ch3\u003eUltimate irony\u003c/h3\u003e\u003cp\u003e“\u003ca href=\"https://www.sacbee.com/news/article277480968.html#storylink=cpy\"\u003eCalifornia Sen. Feinstein seeks more control over her late husband’s trust to pay medical bills\u003c/a\u003e,” (sacbee.com, July 20)\u003c/p\u003e\u003cp\u003eIt is a towering irony that Sen. Feinstein’s opposition to universal medical care coverage with a publicly financed, single-payer health care system, would be the solution to her serious illness and hospitalization costs. Despite her enormous wealth, she now faces the onerous (unspecified) costs that terrify every ordinary individual’s ability to pay, when sick, instead of having guaranteed quality and security of coverage, which is ethically due to all residents of California and the U.S. \u003c/p\u003e\u003cp\u003eIt’s time we transformed our aggressively privatized and profit-driven, class and race-distorted, alienated medical system into a comprehensive, compassionate, publicly accountable, affordable and population owned ‘utility,’ including the Senator as just another one of us.\u003c/p\u003e\u003cp\u003eWilliam Bronston, MD\u003c/p\u003e\u003cp\u003eCarmichael\u003c/p\u003e\u003ch3\u003eProtect franchise owners\u003c/h3\u003e\u003cp\u003e“\u003ca href=\"https://www.sacbee.com/news/politics-government/capitol-alert/article277860958.html\"\u003eFast food spent $4 million fighting California bill holding them accountable for employee abuse\u003c/a\u003e,” (sacbee.com, Aug. 7)\u003c/p\u003e\u003cp\u003eAs a local franchised restaurant owner, I’m deeply troubled by Assembly Bill 1228, which is an attack on the rights of local restaurant owners.\u003c/p\u003e\u003cp\u003eAB 1228 will upend fast food franchising in California by forcing national fast-food corporations to exert more control over the operations of local franchised restaurants. It does this by making the corporations legally liable for local employment decisions at our restaurants and taking control away from franchisees like me. Ultimately, the bill could lead to fewer franchising opportunities altogether.\u003c/p\u003e\u003cp\u003eThe franchise model — and fast food restaurants specifically — have a much higher percentage of minority ownership than other comparable sectors. AB 1228 will cut off this pipeline for thousands of underrepresented and immigrant families to become small business owners. \u003c/p\u003e\u003cp\u003eThe legislature should protect local restaurant owners and reject AB 1228.\u003c/p\u003e\u003cp\u003eJay Hazari\u003c/p\u003e\u003cp\u003eMcDonald’s franchisee\u003c/p\u003e\u003cp\u003eSacramento\u003c/p\u003e\u003ch3\u003eNever meant to be farmed\u003c/h3\u003e\u003cp\u003e“\u003ca href=\"https://www.sacbee.com/opinion/op-ed/article277639943.html\"\u003eCalifornia must raise Shasta Dam to increase water supply\u003c/a\u003e,” (sacbee.com, Aug. 6)\u003c/p\u003e\u003cp\u003eWhen completed in 1947, Shasta Lake flooded over 90% of the Winnemem Wintu Tribes’ historical village sites, resource-gathering sites and sacred sites along the McCloud, Pit and Sacramento rivers. \u003c/p\u003e\u003cp\u003eThe enlargement of Shasta Dam would inundate the few remaining sacred places, burial sites, resource-gathering areas and villages that the Winnemem Wintu Tribe still use today. A thousands-year-old culture would be destroyed by more flooding of the McCloud River. What writer Tom Birmingham really cares about is to get even more water for Westlands Water District down in the arid San Joaquin Valley, a region with soil never meant to be farmed.\u003c/p\u003e\u003cp\u003eThe proposed 18.5-feet rise of the dam would leave little water for fish, and much more water for diversion. It is all there in the plan.\u003c/p\u003e\u003cp\u003eGary Mulcahy\u003c/p\u003e\u003cp\u003eGovernment liaison, Winnemem Wintu Tribe\u003c/p\u003e\u003ch3\u003eNo underage drinking\u003c/h3\u003e\u003cp\u003e“\u003ca href=\"https://www.sacbee.com/news/politics-government/article277266283.html\"\u003eCan parents legally give underage kids alcohol in CA?\u003c/a\u003e” (sacbee.com, July 25)\u003c/p\u003e\u003cp\u003eRegardless of whether it’s legal for parents in California to allow underage drinking at home, it is dangerous and unhealthy for those under 21 to consume alcohol. The brain is still developing during the teenage years, making it more vulnerable to the harmful effects of drinking. Not only are learning and memory impaired, but studies show that drinking alcohol during early teen years raises the risk of developing an alcohol use disorder later in life. \u003c/p\u003e\u003cp\u003eGiven what we know about underage drinking, the focus shouldn’t be whether parents who provide alcohol to their own kids are abiding by the state’s laws. It should be whether or not it’s safe for them to do so.\u003c/p\u003e\u003cp\u003eLeslie Kimball\u003c/p\u003e\u003cp\u003eExecutive director, Responsibility.org\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278147227",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy The Sacramento Bee letter writers\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "“Twisting data to produce fear-based rhetoric is dangerous for our community,” writes Sacramento resident Liz Blum. | Letters to the editor",
+      "lead_media": {
+        "id": "274783716",
+        "url": "https://www.miamiherald.com/latest-news/efexy/picture274783716",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "AP19227835052937 (2).jpg",
+        "publication": "miamiherald",
+        "layout_option": "",
+        "home": "/web/v1/sections/3180",
+        "modified_date": 1682610641,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1682610641,
+        "thumbnail": "https://www.miamiherald.com/latest-news/efexy/picture274783716/alternates/FREE_1140/AP19227835052937%20(2).jpg",
+        "href": "/web/v1/content/274783716",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3180"
+        ],
+        "credit": "AP",
+        "dateline": "",
+        "caption": "Miami-Dade police are handling the investigation into the death of Barry Ellis.",
+        "photographer": "Matt Rourke",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Sacramento",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": [
+        {
+          "name": "mcc-local-oped"
+        }
+      ]
+    },
+    {
+      "id": "278110807",
+      "url": "https://www.sacbee.com/opinion/article278110807.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "California leads the world in innovation but can’t get hearing aids to deaf kids? | Opinion",
+      "publication": "sacbee",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5779",
+      "home_section": {
+        "name": "Opinion",
+        "url": "https://www.sacbee.com/opinion/"
+      },
+      "modified_date": 1691928013,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "California struggles to provide hearing aids for children",
+      "originating_url": "https://www.sacbee.com/opinion/article278110807.html",
+      "meta_description": "Governor Gavin Newsom has not required insurers to provide hearing aids for children who need them. A state program is not reaching most in need.",
+      "published_date": 1691928000,
+      "thumbnail": "",
+      "authors": [
+        {
+          "name": "Tom Philp",
+          "email": "tphilp@sacbee.com"
+        }
+      ],
+      "keywords": "hearing aids, children, California, health care",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "5779",
+        "5853",
+        "93956",
+        "3182",
+        "70592",
+        "5709"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Governor Gavin Newsom has not required insurers to provide hearing aids for children who need them. A state program is not reaching most in need.",
+      "content": "\u003cp\u003eIn 1998, then-Gov. Pete Wilson signed a bill requiring that every child born in the state be evaluated for hearing loss. No governor since then, including Gavin Newsom, has been willing to go the next step and require insurers to cover the only available cure: a set of hearing aids. \u003c/p\u003e\u003cp\u003eNewsom may soon get a second chance. A bill mandating insurance coverage is sailing through the Legislature with unanimous support. One big reason for the support is the general understanding among legislators that a state-run program initiated by the Newsom administration to provide these life-changing devices does not appear to be working effectively. \u003c/p\u003e\u003cp\u003eSigning virtually the same bill that he could have four years ago would be an admission by the governor that he had made a mistake. But such an admission would be the human ⁠— and humane ⁠— thing to do.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:201347249% --\u003e\u003c/p\u003e\u003cp\u003eIf he doesn’t cut his political losses, Newsom faces a small army of impacted parents who aren’t going away. And California would remain one of only 18 states that consider a child’s hearing loss as purely optional for insurance to cover. \u003c/p\u003e\u003cp\u003e“This has been a battle that has played out over many years,” said Nick Janes, a 37-year-old Rocklin resident whose six-year-old son, Jake, has faced severe hearing loss since birth. “To us, it is inconceivable that this wouldn’t be a covered benefit.”\u003c/p\u003e\u003cp\u003eJanes’ wife, Christina, has seared into her memory the moment when a hospital physician described how her newborn son would grow up with a bilateral sensorineural hearing loss, which renders any hushed sound inaudible. \u003c/p\u003e\u003cp\u003e“Twice as likely suicide, half as likely for college,” remembers Christina Janes, a former evening anchor at Sacramento’s CBS affiliate, KOVR, where she worked for nine years. Nick Janes worked at the station as well as a reporter. “That’s what the doctors told you,” she said.\u003c/p\u003e\u003cp\u003eThe Janes have the financial means to afford hearing aids for their son. Jake is “doing great” and starting first grade this month, Christina said. But as the couple has become part of a tight-knit community of parents with the same challenge, they hear of others facing tough financial choices between paying the bills or letting their child hear.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278146677; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003e“In our clinic, we see hard-working families who simply cannot afford hearing aids for their child, and we see the speech and language delays that happen when children who need hearing aids can’t get them,” states Dr. Dylan Chan, director of the Children’s Communication Center at the University of California, San Francisco. “These preventable consequences are not only devastating for the child and family; they are costly to society. Without timely intervention, one child born deaf or hard-of-hearing costs taxpayers up to one million dollars in special education and loss of productivity.”\u003c/p\u003e\u003cp\u003eIronically decades have passed and Sacramento hasn’t mandated hearing aids for children precisely because of the costs.\u003c/p\u003e\u003cp\u003e\u003ca href=\"https://leginfo.legislature.ca.gov/faces/billNavClient.xhtml?bill_id=201920200AB598\" target=\"_blank\" rel=\"Follow\"\u003eAssembly Bill 598\u003c/a\u003e in 2019, a twin of the current effort, was opposed by the California Association of Health Plans out of concern that premiums would go up. In the scheme of California, the amount of money here is modest. Only 1,000 or so children are born in California every year with hearing loss. Annual costs were estimated at $13.6 million.\u003c/p\u003e\u003cp\u003eAB 598 was co-authored by Assemblyman Richard Bloom and Senator Ben Allen, both Democrats from Santa Monica, who were trying to succeed where five previous attempts over the years had failed. Governor Arnold Schwarzenegger had vetoed similar bills three times - in 2004, 2006 and 2007. Two other attempts never made it out of the committee process.\u003c/p\u003e\u003cp\u003eBut with parents like the Janes packing committee rooms, AB 598 made it out of the Legislature without a single no vote. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278146672; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003eBut the bill never made it to the governor. \u003c/p\u003e\u003cp\u003eBloom and Allen killed their own creation; they let AB 598 \u003ca href=\"https://leginfo.legislature.ca.gov/faces/billHistoryClient.xhtml?bill_id=201920200AB598\" target=\"_blank\" rel=\"Follow\"\u003e“die”\u003c/a\u003e (the proper legislative term) by withdrawing the bill from the fact-checking process known as “engrossing,” the final step before legislation is “enrolled” and sent to a governor. \u003c/p\u003e\u003cp\u003eWhy? They knew that the governor was going to veto AB 598.\u003c/p\u003e\u003cp\u003e“Essentially it all came down to administration concerns about costs,” Allen said in a recent interview. \u003c/p\u003e\u003cp\u003eBloom, now a judge in Los Angeles County Superior Court, did not reply to a request for comment advanced to him by a court clerk. \u003c/p\u003e\u003cp\u003eFor the legislators, life moved on. But for parent Michelle Marciniak, “I was incredibly disappointed.” Marciniak leads the activist group \u003ca href=\"https://letcakidshear.com/\" target=\"_blank\" rel=\"Follow\"\u003eLet California Kids Hear.\u003c/a\u003e “This is a developmental emergency.” \u003c/p\u003e\u003cp\u003eNewsom to his credit thought at the time that he had a different, better solution. Rather than insurers paying for the hearing aids from patient premiums, taxpayers would through a new state program he would advance in the following year’s budget. \u003c/p\u003e\u003cp\u003eTrue to his word, next year the state Department of Health Care Services would establish the new \u003ca href=\"https://www.dhcs.ca.gov/services/HACCP/Pages/Home.aspx\" target=\"_blank\" rel=\"Follow\"\u003eHearing Aid Coverage for Children Program\u003c/a\u003e (HACCP). Families of four making $180,000 or less could qualify for $1,500 to help purchase hearing aids (half the benefit of AB 598).\u003c/p\u003e\u003cp\u003eTo seek the subsidy, parents would have to find a \u003ca href=\"https://www.dhcs.ca.gov/services/HACCP/Pages/Families/Find-a-Provider.aspx\" target=\"_blank\" rel=\"Follow\"\u003e“participating provider.” \u003c/a\u003e\u003c/p\u003e\u003cp\u003eThis is where the governor’s idea has fallen short so far. In California, a lot of the medical sector simply avoids dealing with the bureaucracy of state-run programs, a decades-long reality that goes way beyond the issue of hearing aids for children.\u003c/p\u003e\u003cp\u003e“There weren’t many providers that wanted to take it because of the historically low reimbursement rates and the red tape,” Marciniak said. \u003c/p\u003e\u003cp\u003eAccording to the California Department of Health Care Services, HAACP has received 458 applications from July 1, 2021, through August 2, 2023 and has enrolled a total of 255 children into the program. Advocates estimate this is about 7 percent of the eligible population.\u003c/p\u003e\u003cp\u003e“As with any new program launch, engagement and onboarding processes for both providers and targeted populations tend to be slow with ramp up until familiarity is gained with the program on all fronts,” said health department spokesman Anthony Cava. The department “acknowledges the challenges HACCP faced in the first year of its implementation and understands there are ongoing concerns from the consumer advocate community on program enrollment and provider access.” \u003c/p\u003e\u003cp\u003eTo the program’s credit, its online applications portal has options for at least 19 different languages. This may not be for a lack of government trying. It may be that a government-run approach is simply less effective than telling the private insurance sector to cover the device.\u003c/p\u003e\u003cp\u003eAllen voted for SB 635 earlier this year (under new authorship, Caroline Menjivar, D-Van Nuys and Anthony Portantino, D-Burbank) along with all 39 other senators. “Apparently (the Hearing Aid Coverage for Children Program) has been underutilized,” he said. \u003c/p\u003e\u003cp\u003eThe health insurance industry is no longer opposed to the legislation. Instead, it is officially “concerned” about the same cost issue. At the moment, no organization opposes the bill.\u003c/p\u003e\u003cp\u003eSB 635’s last real hurdle is in the cost committee, Assembly Appropriations. Its chair is Chris Holden, D-Pasadena, and he voted for AB 598 back in 2019. \u003c/p\u003e\u003cp\u003eWill the bill reach Newsom? And what would he do? \u003c/p\u003e\u003cp\u003e“I have developed some skepticism over the years,” said Marciniak. And for good reason.\u003c/p\u003e\u003cp\u003eThis would be a revealing moment for the governor. He could sign the legislation and admit that his government-run alternative proved to be both more expensive and less effective than private-sector insurance coverage. Or he could rehash the same cost rationale, kill SB 635 just like its predecessors and hope that his state-run program reaches more children. \u003c/p\u003e\u003cp\u003eMeanwhile, every day a child can’t hear is precious developmental time that is lost. \u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278110807",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Tom Philp\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:tphilp@sacbee.com\"\u003etphilp@sacbee.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "California governors have never required insurance companies to provide hearing aids to needy children. Will Gavin Newsom soon change his mind? ",
+      "lead_media": {
+        "id": "277832493",
+        "url": "https://www.sacbee.com/latest-news/pmdwbw/picture277832493",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "SAC_HearingAid_01_HA_072820",
+        "publication": "sacbee",
+        "layout_option": "",
+        "home": "/web/v1/sections/3182",
+        "modified_date": 1691701038,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1690842029,
+        "thumbnail": "https://www.sacbee.com/latest-news/pmdwbw/picture277832493/alternates/FREE_1140/SAC_HearingAid_01_HA_072820",
+        "href": "/web/v1/content/277832493",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3182"
+        ],
+        "credit": "hamezcua@sacbee.com",
+        "dateline": "",
+        "caption": "Nick and Christina Janes of Rocklin pose for a portrait with their six-year-old son, Jake, who has lived with impaired hearing since birth, on Friday, July 28, 2023. They have campaigned for four years to convince the Legislature and Gov. Gavin Newsom that insurers should be required to cover the cost of hearing aids for all California children.",
+        "photographer": "Hector Amezcua",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Sacramento",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278082942",
+      "url": "https://www.sacbee.com/opinion/article278082942.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "County votes to spend nearly $1B on jail expansion, over powerful protests | Opinion",
+      "publication": "sacbee",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5779",
+      "home_section": {
+        "name": "Opinion",
+        "url": "https://www.sacbee.com/opinion/"
+      },
+      "modified_date": 1691772143,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Sacramento county votes to spend near $1 billion on jail",
+      "originating_url": "https://www.sacbee.com/opinion/article278082942.html",
+      "meta_description": "Sacramento residents are now saddled with a billion-dollar debt for a county jail expansion they do not want",
+      "published_date": 1691668800,
+      "thumbnail": "https://www.sacbee.com/latest-news/k8khtd/picture277263973/alternates/FREE_1140/SAC_KJN_230711_SACSUPES1086%20(1).JPG",
+      "authors": [
+        {
+          "name": "The Sacramento Bee Editorial Board",
+          "email": "opinion@sacbee.com"
+        }
+      ],
+      "keywords": "jail, county, supervisors, sacramento, mays consent",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "5779",
+        "5781",
+        "3182",
+        "70592"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Sacramento residents are now saddled with a billion-dollar debt for a county jail expansion they do not want",
+      "content": "\u003cp\u003eWhat would you do with almost a billion dollars? \u003c/p\u003e\u003cp\u003eOn Tuesday night, three of the five Sacramento County Supervisors voted to begin a process that will cost residents $1 billion in the coming years to expand the County’s main jail and provide a mere 100 new beds in a mental health facility — in spite of more than three hours of spirited public comment, all of it entirely in protest.\u003c/p\u003e\u003cp\u003eThis is, by far, the largest debt the county has ever taken on. It also forces county leaders to prioritize funding jail construction over health services and housing. The existing jail is the most expensive and least effective place to comply with a court decree to provide mental health services to inmates who need it. There are such better options if the county would only try.\u003c/p\u003e\u003cp\u003eSupervisors Patrick Kennedy and Phil Serna deserve credit for challenging staff and voting against the two agenda items, which now authorize a $654 million mental health annex at the downtown jail and also \u003ca href=\"https://agendanet.saccounty.gov/BoardofSupervisors/Documents/ViewDocument/RES%20-%20Reimbursement%20Resolution%20v4.docx.pdf?meetingId=7965\u0026documentType=Agenda\u0026itemId=414376\u0026publishId=1262220\u0026isSection=false\" target=\"_blank\" rel=\"Follow\"\u003eapproves overall county expenditures\u003c/a\u003e of up to $925 million. \u003c/p\u003e\u003cp\u003eResidents who showed up \u003ca href=\"https://agendanet.saccounty.gov/BoardofSupervisors/Documents/ViewDocument/ITEM%2049%20SET%201.pdf.pdf?meetingId=7965\u0026documentType=Agenda\u0026itemId=414376\u0026publishId=1262223\u0026isSection=false\" target=\"_blank\" rel=\"Follow\"\u003eto protest the vote\u003c/a\u003e were quick to draw data-driven connections between incarceration, mental illness and homelessness. They criticized the county for failing yet again to prioritize preventative measures shown to prevent incarceration and recidivism.\u003c/p\u003e\u003cp\u003eBut neither logic nor heartfelt pleas had a place in that boardroom Tuesday night. \u003c/p\u003e\u003cp\u003eThis was a fear-based decision by the supervisors, running scared from a \u003ca href=\"https://www.sacgrandjury.org/docs/reports/22-23/gj-may-final-report-060223.pdf\" target=\"_blank\" rel=\"Follow\"\u003ethreatened federal receivership\u003c/a\u003e. The county has been hopelessly out of compliance with a 2018 federal consent decree, the result of a class-action lawsuit seeking better treatment of prisoners with disabilities.\u003c/p\u003e\u003cp\u003e The county is bound by law to prove they are moving toward a solution to those findings, and the board clearly felt they had no other option but to vote to move forward.\u003c/p\u003e\u003cp\u003e“We all agonize over this,” said Board Chair Rich Desmond. “I certainly do and that turns my stomach, but (it) seems a very dangerous road to go down when we don’t have a plan B.”\u003c/p\u003e\u003cp\u003eI don’t feel good about this, I don’t want to do it, but I will move to approve,” voted Supervisor Pat Hume. \u003c/p\u003e\u003cp\u003eWith that, Sacramento residents are now saddled with a billion-dollar debt that very likely won’t do much to improve the conditions in a jail that is terrible for inmates, the people who work in the facility and a downtown Sacramento community plagued by the crime and homeless conditions exacerbated when county jailers turn prisoners loose in Sacramento’s urban core. \u003c/p\u003e\u003cp\u003eResidents who showed up in person and via phone to the meeting pleaded with the supervisors to vote against the proposal, or at least delay it a few more weeks.\u003c/p\u003e\u003cp\u003e“This is the largest bond the county has ever entered into and it’s not for housing, it’s for a jail,” said Liz Blum co-founder of Decarcerate Sacramento, which joined with nearly two dozen other organizations \u003ca href=\"https://docs.google.com/document/d/1pvjmK91BCeIO21fAgaCSvIprBwRjhSDYs4E60DMcwYM/edit?usp=sharing\" target=\"_blank\" rel=\"Follow\"\u003ein a letter meant to protest the county’s vote.\u003c/a\u003e Their warning largely fell on unlistening ears. \u003c/p\u003e\u003cp\u003e The mentally ill deserve targeted, sustained care from community-oriented social services, which would have overwhelmingly benefited from this level of monetary support by the county. That money could have instead been used to fund an outpatient, community-based site with probably safer and better outcomes for the county’s inmates; or how about just a new facility built somewhere else in the county, rather than spending hundreds of millions to create an annex to the existing jail? \u003c/p\u003e\u003cp\u003eThe greater Sacramento community deserves county leaders who do more than simply give in to a terrible idea that will cost a billion dollars. Annex or no annex, the downtown jail will remain a nightmare. Imagine if the county directed the same amount of bond money toward housing projects and mental health programs.\u003c/p\u003e\u003cp\u003eA community’s budget is a reflection of its principles. The sight of so many people begging the supervisors to reconsider a no-win decision should have communicated that spending nearly $1 billion to further expand an inhumane and inefficient jail does not represent the values of the Sacramento community. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:239341538% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278082942",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy The Sacramento Bee Editorial Board\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:opinion@sacbee.com\"\u003eopinion@sacbee.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "On Tuesday evening, Sacramento County Supervisors voted to begin a process that will cost residents $1 billion to expand the County’s main jail.",
+      "lead_media": {
+        "id": "277263973",
+        "url": "https://www.sacbee.com/latest-news/k8khtd/picture277263973",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "SAC_KJN_230711_SACSUPES1086 (1).JPG",
+        "publication": "sacbee",
+        "layout_option": "",
+        "home": "/web/v1/sections/3182",
+        "modified_date": 1689201408,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1689201408,
+        "thumbnail": "https://www.sacbee.com/latest-news/k8khtd/picture277263973/alternates/FREE_1140/SAC_KJN_230711_SACSUPES1086%20(1).JPG",
+        "href": "/web/v1/content/277263973",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3182"
+        ],
+        "credit": "kneri@sacbee.com",
+        "dateline": "",
+        "caption": "Sacramento County Supervisor Rich Desmond speaks during a meeting on Tuesday, July 11, 2023, in Sacramento.",
+        "photographer": "Kevin Neri",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Sacramento",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278060307",
+      "url": "https://www.sacbee.com/opinion/article278060307.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Sacramento DA Thien Ho chooses to go to war with city officials over homelessness | Opinion",
+      "publication": "sacbee",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5779",
+      "home_section": {
+        "name": "Opinion",
+        "url": "https://www.sacbee.com/opinion/"
+      },
+      "modified_date": 1691525064,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Sacramento DA threatens city of Sacramento over homelessness",
+      "originating_url": "https://www.sacbee.com/opinion/article278060307.html",
+      "meta_description": "Sacramento DA Thien Ho is choosing to go to war with the city of Sacramento over homelessness rather than accept city offers to collaborate.",
+      "published_date": 1691514000,
+      "thumbnail": "https://www.sacbee.com/latest-news/5y5dbj/picture274411720/alternates/FREE_1140/SAC_CC_20230417_InvestigationResultsDSC31166004.JPG",
+      "authors": [
+        {
+          "name": "The Sacramento Bee Editorial Board",
+          "email": "opinion@sacbee.com"
+        }
+      ],
+      "keywords": "sacramento, homeless, thien ho, darrell steinberg",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "5779",
+        "5781",
+        "3182",
+        "70592"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Sacramento DA Thien Ho is choosing to go to war with the city of Sacramento over homelessness rather than accept city offers to collaborate.",
+      "content": "\u003cp\u003eMayor \u003ca href=\"https://www.sacbee.com/opinion/article277222783.html\" target=\"_blank\" rel=\"Follow\"\u003eDarrell Steinberg’s \u003c/a\u003eattempt at a homeless strategy partnership with District Attorney \u003ca href=\"https://www.sacbee.com/opinion/article277472633.html\" target=\"_blank\" rel=\"Follow\"\u003eThien Ho\u003c/a\u003e has resulted in Ho figuratively pointing a gun at the city’s head with a long list of demands and no similar set of actions of his own. \u003c/p\u003e\u003cp\u003eIt is hard to imagine a worse relationship between the top county prosecutor and the largest city as it struggles to solve its largest problem. This is all Ho’s doing. It is a spectacularly unfortunate tactical decision that sets the district attorney and the city on a confrontational path just when the city has made some tough decisions about how to expand its shelter capacity for unhoused individuals.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:201347249% --\u003e\u003c/p\u003e\u003cp\u003eIn a recent interview with members of The\u003ca href=\"https://www.sacbee.com/opinion/election-endorsements/article261402117.html\" target=\"_blank\" rel=\"Follow\"\u003e Bee Editorial Board,\u003c/a\u003e Ho explained that Steinberg had recently contacted him with some proposals on how to work together. Both leaders are frustrated with the proliferation of homeless encampments, the garbage on city streets, the discarded hypodermic needles and the disruption to civic life. \u003c/p\u003e\u003cp\u003eAs events have revealed, the two leaders are polar opposites in approaches. Steinberg has sought a collaborative approach among their respective staffs to prioritize city actions leading to a greater district attorney caseload that hopefully leads to greater use of services such as addiction treatment. \u003c/p\u003e\u003cp\u003eHo, meanwhile, has launched an investigation that may target unnamed city officials. And, on Monday, he responded to Steinberg’s olive branch with a club.\u003c/p\u003e\u003cp\u003eAt a press conference Tuesday morning, Steinberg detailed how he had privately made Ho a very provocative offer. The mayor said he would support something that “I am not comfortable with,” which is citing homeless residents en masse for misdemeanor crimes. In turn, however, Ho would have to adopt a prosecution strategy for these cases that prioritizes “the care they deserve,” namely diversion into substance abuse and mental health services.\u003c/p\u003e\u003cp\u003eHo so far has refused such a partnership. Instead on Monday, he basically offered nothing new from his office while asking the impossible of city hall. He wants shelters with 24-hour security for thousands of homeless (75% of the estimated outdoor population) established in 30 days. He wants four new city attorneys hired in 30 days to prosecute more code infractions, and he wants the 16 identified major encampments eliminated. All in 30 days.\u003c/p\u003e\u003cp\u003eGovernment cannot get through the advertising process for a new hire in 30 days, much less interview and hire new staff members. New ordinances take considerable time to craft and enact. Ho has been in government long enough to know this, yet demands it from Sacramento anyways. He appears to be playing to a different audience than the social service workers, law enforcement officers and non-profit organizations that confront this crisis each and every day. \u003c/p\u003e\u003cp\u003e\u003ca href=\"https://www.sacbee.com/opinion/op-ed/article278028868.html\" target=\"_blank\" rel=\"Follow\"\u003eErwin Chemerinsky\u003c/a\u003e, dean of the UC Berkeley School of Law, argues that Ho’s threat of prosecution is based on a misreading of a court decision that essentially prevents cities from criminalizing homelessness. The humanitarian crisis by definition is both a nuisance and a tragedy. \u003c/p\u003e\u003cp\u003eHo’s investigation is both a waste of precious government resources and is based on a wildly unrealistic set of demands. \u003c/p\u003e\u003cp\u003eThere is, however, a great price to be paid when one government chooses confrontation with another. It destroys the ability to develop a better working relationship. Conflict consumes the energy of both sides, and it reduces the amount of government capacity to confront the actual crisis.\u003c/p\u003e\u003cp\u003eThe city should continue to offer a partnership path to the district attorney. Ho’s “offer,” with its absurd timetable and detail, is not intended to be taken seriously. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:239341538% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278060307",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy The Sacramento Bee Editorial Board\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:opinion@sacbee.com\"\u003eopinion@sacbee.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "It is hard to imagine a worse relationship between the top county prosecutor and the largest city on its largest problem. | Opinion",
+      "lead_media": {
+        "id": "274411720",
+        "url": "https://www.sacbee.com/latest-news/5y5dbj/picture274411720",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "SAC_CC_20230417_InvestigationResultsDSC31166004.JPG",
+        "publication": "sacbee",
+        "layout_option": "",
+        "home": "/web/v1/sections/3182",
+        "modified_date": 1681756942,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1681756942,
+        "thumbnail": "https://www.sacbee.com/latest-news/5y5dbj/picture274411720/alternates/FREE_1140/SAC_CC_20230417_InvestigationResultsDSC31166004.JPG",
+        "href": "/web/v1/content/274411720",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3182"
+        ],
+        "credit": "cclark@sacbee.com",
+        "dateline": "",
+        "caption": "Sacramento County District Attorney Thien Ho addresses the media during a press conference at the Yuba City Police Department on Monday, April 17, 2023.",
+        "photographer": "Cameron Clark",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Sacramento",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278041318",
+      "url": "https://www.sacbee.com/opinion/article278041318.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Sacramento leaders surrendered authority on homelessness because NIMBYs run the show | Opinion",
+      "publication": "sacbee",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5779",
+      "home_section": {
+        "name": "Opinion",
+        "url": "https://www.sacbee.com/opinion/"
+      },
+      "modified_date": 1691782851,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Sacramento is paralyzed politically by the homeless crisis",
+      "originating_url": "https://www.sacbee.com/opinion/article278041318.html",
+      "meta_description": "Sacramento’s homeless crisis mirrors the challenges faced by other cities encountering unhoused people living in encampments in urban areas",
+      "published_date": 1691478000,
+      "thumbnail": "https://www.sacbee.com/latest-news/j9xzjb/picture277831383/alternates/FREE_1140/SAC_RCB_20230718_HOMELESS0167.JPG",
+      "authors": [
+        {
+          "name": "Brian Zhang",
+          "email": "bzhang@sacbee.com"
+        }
+      ],
+      "keywords": "homeless, sacramento, city, encampments",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "5779",
+        "3182",
+        "70592"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Sacramento’s homeless crisis mirrors the challenges faced by other cities encountering unhoused people living in encampments in urban areas",
+      "content": "\u003cp\u003eHomelessness is not a uniquely Sacramento problem, but for far too long, leaders in Sacramento, and in other California communities and beyond, have allowed NIMBYs to slow potential solutions.\u003c/p\u003e\u003cp\u003eAs someone who doesn’t live in Sacramento, it was fascinating to watch elected city leaders delegate the authority of finding suitable encampments for homeless people to City Manager Howard Chan, who was not elected by voters.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:201347249% --\u003e\u003c/p\u003e\u003cp\u003eIn my own neighborhood of Brooklyn, New York, residents have come forward against housing migrants in our recreational centers, including the historic Sunset Park which is a staple in the city’s summertime itineraries. Ironically, the majority of the current residents here — and many of the NIMBY protesters amid recent developments — are immigrants too; people working at minimum wage and struggling to pay the same exorbitant rent. \u003c/p\u003e\u003cp\u003eWhen leaders are slow to make collaborative, educational approaches to poverty, it turns the most vulnerable against each other instead of making new leaders out of us.\u003c/p\u003e\u003cp\u003eTo break a political stalemate driven by community opposition, Sacramento Mayor Darrell Steinberg gave the recommendation in a \u003ca href=\"https://static1.squarespace.com/static/5a67c48df6576e09b7b10ce8/t/64a3618edb2bfa07a6cd392c/1688428942842/Follow+Up+Letter+from+Homeless+Workshop+7.3.23.pdf\" target=\"_blank\" rel=\"Follow\"\u003eJuly 3, 2023 letter to Chan\u003c/a\u003e that he should lead the politically fraught task of where to establish legalized encampments for homeless people within city limits.\u003c/p\u003e\u003cp\u003eThe decision, passed by a marginal 5-4 vote during last Tuesday’s council meeting, has already started dividing the city. While some may feel uncomfortable with concentrating this much power over the city’s most vulnerable in the hands of an unelected official — not to mention, the \u003ca href=\"https://www.sacbee.com/news/local/article276833171.html\" target=\"_blank\" rel=\"Follow\"\u003ehighest-paid city manager in all of California\u003c/a\u003e — businesses, residents and several council members are hopeful that a unilateral body will make rapid progress on getting people into temporary housing.\u003c/p\u003e\u003cp\u003eHowever, whether we are satisfied with Chan’s new position, whether we trust that the new Safe Ground sites will be fairly geographically distributed and whether we believe punting authority to Chan was a way to defer problem-solving, now is not the time for elected politicians, local coalitions and nonprofits, or the residents of Sacramento to take a backseat. \u003c/p\u003e\u003cp\u003eChan’s forthcoming projects have, and \u003ca href=\"https://static1.squarespace.com/static/5a67c48df6576e09b7b10ce8/t/64a3618edb2bfa07a6cd392c/1688428942842/Follow+Up+Letter+from+Homeless+Workshop+7.3.23.pdf\" target=\"_blank\" rel=\"Follow\"\u003eare intended to have\u003c/a\u003e, a very temporary mission. There is no guarantee that they will make a dent in moving vulnerable people off the streets in transformative numbers. Chan’s effort will require institutional memory and support from others in the city and county. Now, more than ever, those entities must remain committed to streamlining wraparound support services and basic needs at Safe Grounds. \u003c/p\u003e\u003cp\u003eThis is Sacramento’s shot at building on that momentum, but we must also monitor Chan’s approach to homelessness ordinances, and to request regular public updates on those efforts. With another pay raise expected for the city manager, city residents need to make sure that their trust and investment in him is well-placed. \u003c/p\u003e\u003cp\u003eAs Chan focuses on the short-term solution for getting people swiftly off the vulnerable streets, fiercer advocacy is required on the municipal, state, and federal levels to incentivize landowners with rental assistance, help connect the homeless with out-of-state opportunities as they arise, and fund innovative private sectors to provide non-duplicative mental health, employment and substance abuse resources. Businesses and private agencies are more adaptable than the government; they can and should build trauma-informed relationships with the community, identifying those most in need of their services.\u003c/p\u003e\u003cp\u003eNew York City, widely regarded as a promising beacon for immigrants and with its signature 1981 mandate of a shelter bed for every person who requests one, is notably reaching a breaking point. There are \u003ca href=\"https://www.nytimes.com/2023/06/28/nyregion/nyc-homeless-shelter-population.html\" target=\"_blank\" rel=\"Follow\"\u003e100,000\u003c/a\u003e individuals without a permanent place to stay here. \u003c/p\u003e\u003cp\u003e\u003ca href=\"https://www.nytimes.com/2022/06/14/headway/houston-homeless-people.html\" target=\"_blank\" rel=\"Follow\"\u003eHouston, whose successful homelessness measures are often up for contrast against Californian cities, rakes up on federal funding and attention despite having very little city monetary investment.\u003c/a\u003e In the last decade, Houston has moved 25,000 people off the streets and into housing. Homelessness in the greater Houston region has been cut by more than 60 percent, according to the most recent homeless counts cited by Houston officials. \u003c/p\u003e\u003cp\u003eWhat can California learn from New York’s prior examples and Houston’s unified homelessness response, which has brought together public housing committees, philanthropy, religion, private foundations and dozens of nonprofits? On a national scale, nearly all American melting pots are scrambling to house and feed asylum-seeking migrants on limited funds and space. Who are we to disapprove of homeless individuals walking in any one of our neighborhoods? \u003c/p\u003e\u003cp\u003eUnhoused individuals are an undeniable part of our day-to-day because the truth is, this is the world that we have created, contributed to, and currently live in. Sacramento and New York — and all the thousands of miles in between — have to make sacrifices, as our personal and financial boundaries permit. It is not an option to opt-out.\u003c/p\u003e\u003cp\u003eOpposing homeless solutions without regard for the dire needs in our communities is selfish. \u003ca href=\"https://www.usich.gov/news/collaborate-dont-criminalize-how-communities-can-effectively-and-humanely-address-homelessness/#:~:text=Criminalizing%20homelessness%20is%20expensive.,not%20moving%20people%20around%20them.\" target=\"_blank\" rel=\"Follow\"\u003eCalling the authorities on nearby encampments for smelling or littering, and creating legislation around anti-homelessness, is not only expensive\u003c/a\u003e — it pales in comparison to all the possibilities for the different types of support services that communities can generate. \u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278041318",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Brian Zhang\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:bzhang@sacbee.com\"\u003ebzhang@sacbee.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "For someone who doesn’t live in Sacramento, it was odd to see city leaders hand so much authority on homelessness to someone who wasn’t elected",
+      "lead_media": {
+        "id": "277831383",
+        "url": "https://www.sacbee.com/latest-news/j9xzjb/picture277831383",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "SAC_RCB_20230718_HOMELESS0167.JPG",
+        "publication": "sacbee",
+        "layout_option": "",
+        "home": "/web/v1/sections/3182",
+        "modified_date": 1690840041,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1690840041,
+        "thumbnail": "https://www.sacbee.com/latest-news/j9xzjb/picture277831383/alternates/FREE_1140/SAC_RCB_20230718_HOMELESS0167.JPG",
+        "href": "/web/v1/content/277831383",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3182"
+        ],
+        "credit": "rbyer@sacbee.com",
+        "dateline": "",
+        "caption": "Homeless camper Chadwick Justin Foy, 41, right, says he has no idea where he will move while resting in the shade at the intersection of 28th and C streets on Tuesday, July 18, 2023. The city has given notices to dozens of people living in tents on the sidewalks in that area, near Leland Stanford Park, telling them to move by Wednesday. The notices cite violation of city codes regarding sidewalk obstruction and storage of personal property on public property.",
+        "photographer": "Renée C. Byer",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Sacramento",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278028868",
+      "url": "https://www.sacbee.com/opinion/op-ed/article278028868.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Despite what Sacramento DA Thien Ho might say, being unhoused isn’t a crime | Opinion",
+      "publication": "sacbee",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5787",
+      "home_section": {
+        "name": "Viewpoints",
+        "url": "https://www.sacbee.com/opinion/op-ed/"
+      },
+      "modified_date": 1691496013,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Sac DA abuses office, threatens city leaders on homeless",
+      "originating_url": "https://www.sacbee.com/opinion/op-ed/article278028868.html",
+      "meta_description": "Sacramento District Attorney Thien Ho is wrong to threaten legal action against city officials for allowing homeless encampments on city streets.",
+      "published_date": 1691496000,
+      "thumbnail": "https://www.sacbee.com/latest-news/z5n30y/picture277476873/alternates/FREE_1140/SAC_RCB_20230719_HOMELESSSWEEP0746.JPG",
+      "authors": [
+        {
+          "name": "Erwin Chemerinsky",
+          "email": ""
+        }
+      ],
+      "keywords": "sacramento, homeless, law, district attorney, opinion",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "5787",
+        "3182",
+        "5779"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Sacramento District Attorney Thien Ho is wrong to threaten legal action against city officials for allowing homeless encampments on city streets.",
+      "content": "\u003cp\u003eThe solution to the homelessness crisis in Sacramento and other California cities will not be found through law enforcement; the law is clear that a city cannot make it a crime or a public nuisance for people to sleep in public unless there are adequate humane alternatives. That’s why Sacramento County District Attorney \u003ca href=\"https://www.sacbee.com/opinion/article277472633.html\" target=\"_blank\" rel=\"Follow\"\u003eThien Ho is plainly wrong\u003c/a\u003e in his threat to investigate city officials for failing to enforce state public nuisance laws and allowing homeless encampments within the city limits.\u003c/p\u003e\u003cp\u003eNo one disputes that homelessness is a serious problem in every major city in California. There are many causes of the problem, but especially a statewide shortage of affordable housing. No easy solutions exist, and every city is struggling with finding ways of providing shelter for their unhoused.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:201347249% --\u003e\u003c/p\u003e\u003cp\u003eWhat is clear is that cities cannot make it a crime or a public nuisance for people to be homeless when there is not adequate shelter space. \u003c/p\u003e\u003cp\u003eIn \u003ca href=\"https://homelesslaw.org/supreme-court-martin-v-boise/\" target=\"_blank\" rel=\"Follow\"\u003eMartin v. City of Boise\u003c/a\u003e, in 2018, the U.S. Court of Appeals for the Ninth Circuit ruled that the Eighth Amendment, which outlaws cruel and unusual punishment, “prohibits the imposition of criminal penalties for sitting, sleeping or lying outside on public property for homeless individuals who cannot obtain shelter.” \u003c/p\u003e\u003cp\u003eJust last month, the Ninth Circuit reaffirmed this in \u003ca href=\"https://law.justia.com/cases/federal/appellate-courts/ca9/20-35752/20-35752-2023-07-05.html\" target=\"_blank\" rel=\"Follow\"\u003eJohnson v. City of Grants Pass\u003c/a\u003e. The court declared an Oregon city’s ordinance was unconstitutional when it stated that “no person may sleep on public sidewalks, streets or alleyways at any time as a matter of individual and public safety.”\u003c/p\u003e\u003cp\u003eThe city’s ordinance also precluded homeless persons from using a blanket, a pillow or a cardboard box for protection from the elements while sleeping within the city’s limits. The Ninth Circuit also declared this unconstitutional because the government cannot punish people — criminally or civilly — for being unhoused.\u003c/p\u003e\u003cp\u003eThese decisions are correct; every human being must sleep. It is cruel and unusual punishment to punish people for conduct where they have no alternative. If there are not adequate shelter beds — which there aren’t in California — then people have no choice but to sleep on public sidewalks and in parks, and they need blankets and cardboard for warmth. \u003c/p\u003e\u003cp\u003eGiven this context, District Attorney Ho’s threats against Sacramento city officials are unfounded and misguided. \u003c/p\u003e\u003cp\u003eIn a letter to members of the Sacramento City Council, Ho rightly declared that “(b)eing unhoused is not a crime and we should not seek to criminalize homelessness.” But then he makes clear that is exactly what he wants to do. \u003c/p\u003e\u003cp\u003e“However, my office has a duty to prosecute offenses in violation of California’s criminal statutes,” he wrote. “In fact, the Sacramento District Attorney’s Office has entire units dedicated to prosecuting misdemeanor and felony cases. The responsibility to enforce and prosecute Sacramento City Ordinances and Code violations rests squarely upon the City of Sacramento and the City Attorney’s Office.” \u003c/p\u003e\u003cp\u003eHo goes even further in his suggestion that he is investigating Sacramento city officials for their failure to take action against the unhoused. The DA is seriously overstepping his authority here. His role is to prosecute crimes; it is just wrong to suggest that city officials might have committed a crime by not enforcing laws, let alone criminal laws that they cannot constitutionally enforce against the unhoused.\u003c/p\u003e\u003cp\u003eSacramento City Attorney Susana Alcala Wood has publicly responded to Ho and pointed out that his letter misinterprets federal court decisions and that he wrongly asserts that California law imposes on government agencies “an affirmative obligation to eliminate public nuisances on their property.”\u003c/p\u003e\u003cp\u003eThe solution to the problem of homelessness is not going to emerge from this unnecessary dispute among government officials or from actions of the DA’s office. Being homeless cannot be made a crime or a public nuisance. \u003c/p\u003e\u003cp\u003eThe answer, as difficult as it is to find, must come through building more shelters and providing more services.\u003c/p\u003e\u003cp\u003eIt is possible that the dispute between the DA and the city attorney could go to court if Ho decides to initiate an action against city officials. Such a suit would be frivolous and likely to be quickly thrown out of court. If Ho decides to initiate prosecutions against the unhoused, these will fail based on the Ninth Circuit’s decisions. Indeed, there almost certainly would be a suit in federal court to enjoin Ho, which will make it back to the court of appeals in a year or two.\u003c/p\u003e\u003cp\u003eThat will provide the Ninth Circuit with another chance to reaffirm a basic principle of law and human decency: The government cannot make it a crime for a person to sleep in public if there is nowhere else for them to sleep.\u003c/p\u003e\u003cdiv class=\"ng_endnote_contact\"\u003eErwin Chemerinsky is the dean and a professor at the UC Berkeley School of Law. \u003c/div\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278028868",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Erwin Chemerinsky\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "The law is clear that a city cannot make it a crime or a public nuisance for people to sleep in public unless there are adequate humane alternatives.",
+      "lead_media": {
+        "id": "277476873",
+        "url": "https://www.sacbee.com/latest-news/z5n30y/picture277476873",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "SAC_RCB_20230719_HOMELESSSWEEP0746.JPG",
+        "publication": "sacbee",
+        "layout_option": "",
+        "home": "/web/v1/sections/3182",
+        "modified_date": 1689801836,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1689801836,
+        "thumbnail": "https://www.sacbee.com/latest-news/z5n30y/picture277476873/alternates/FREE_1140/SAC_RCB_20230719_HOMELESSSWEEP0746.JPG",
+        "href": "/web/v1/content/277476873",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3182"
+        ],
+        "credit": "rbyer@sacbee.com",
+        "dateline": "",
+        "caption": "Alicia Peterson, 55, who had just gotten out of the hospital four days ago and suffered neuropathy and a broken wrist, was one of the last to pack up her belongings during a homeless encampment sweep along C street between 27th and 28th streets in Sacramento on Wednesday, July 19, 2023. She was hoping to keep her tent and was unsure where she might go.",
+        "photographer": "Renée C. Byer",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Sacramento",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": [
+        {
+          "name": "mcc-local-oped"
+        }
+      ]
+    },
+    {
+      "id": "275753176",
+      "url": "https://www.sacbee.com/opinion/op-ed/article275753176.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "For Sacramento’s homeless population, summertime is about surviving the heat | Opinion",
+      "publication": "sacbee",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5787",
+      "home_section": {
+        "name": "Viewpoints",
+        "url": "https://www.sacbee.com/opinion/op-ed/"
+      },
+      "modified_date": 1691413200,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Sac’s homeless population bears the brunt of extreme heat",
+      "originating_url": "https://www.sacbee.com/opinion/op-ed/article275753176.html",
+      "meta_description": "At Sacramento’s Cesar Chavez Plaza, homeless individuals gather under the shade and drink water during the extreme summertime heat",
+      "published_date": 1691413200,
+      "thumbnail": "https://www.sacbee.com/latest-news/cweq9z/picture250126599/alternates/FREE_1140/SAC_RCB_20210218_HOMELESSBIZ0409.JPG",
+      "authors": [
+        {
+          "name": "Katherine Hunter",
+          "email": ""
+        }
+      ],
+      "keywords": "sacramento, homeless, heat, climate change, summer, cesar chavez plaza",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "5787",
+        "3182",
+        "70592",
+        "5779"
+      ],
+      "credit": "Special to The Sacramento Bee",
+      "dateline": "",
+      "summary": "At Sacramento’s Cesar Chavez Plaza, homeless individuals gather under the shade and drink water during the extreme summertime heat",
+      "content": "\u003cp\u003eTo some residents of Sacramento, Cesar Chavez Plaza is an eyesore, with anywhere from 20 to 30 or more unhoused individuals set up in tents, sprawled out in the sun or gathered in small groups around the fountain. But for the folks who spend their days or nights here, this park is their home. \u003c/p\u003e\u003cp\u003eIt’s a home with no air conditioning, water or fans. And in the summertime, when Sacramento sees triple-digit temperatures, no one feels the impact of the heat more than the city’s unhoused residents. \u003c/p\u003e\u003cp\u003eIn the summer of 2021, the weather was relentless. I called up two friends and told them my plan. They brought the coolers, I bought the water and together we drove to Cesar Chavez Plaza.\u003c/p\u003e\u003cp\u003eWe hadn’t been out of the car two minutes before Oliver, who calls Cesar Chavez Plaza his home, appeared next to us. After drinking an entire water bottle in one single gulp, Oliver asked if he could help us distribute waters around the park.\u003c/p\u003e\u003cp\u003eAfterwards, we got to chatting, and I came to find out how Oliver had ended up here. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:201347249% --\u003e\u003c/p\u003e\u003cp\u003eDecades ago, Oliver suffered a brain injury in a work accident. He asked my friends and I how old we were, and when we told him we were in our early 20s. He said that, at our age, he thought he was going to rule the world. He had his whole life ahead of him, a good job, good money and plenty of people around. After his injury, though, things stopped going his way. He could no longer work, he lost a few good friends and then, when the last people in his life who cared enough to take care of him died, he no longer had a home. \u003c/p\u003e\u003cp\u003e“You’re so much closer to this than you’d ever believe,” Oliver warned me. “Just a couple bad days and you’re standing right where I am.”\u003c/p\u003e\u003cp\u003eWhen I asked Oliver about the change in heat over the last few decades, he told me there was nothing like the heat of recent years. While heat waves are nothing new in Sacramento, in the last few years, they’ve gotten much worse. In fact, according to \u003ca href=\"https://climateassessment.ca.gov/\" target=\"_blank\" rel=\"Follow\"\u003eCalifornia’s Fourth Climate Change Assessment\u003c/a\u003e, average global temperatures are expected to increase \u003ca href=\"https://www.energy.ca.gov/sites/default/files/2019-11/20180827_Summary_Brochure_ADA.pdf\" target=\"_blank\" rel=\"Follow\"\u003eby at least 2.7 degrees by the year 2039\u003c/a\u003e. Heat waves are also expected to have higher daytime and nighttime temperatures, last much longer and spread much farther. \u003c/p\u003e\u003cp\u003eWhile 2039 may seem like a long way away, no one knows better than the residents of Cesar Chavez Plaza that you don’t have to wait a couple decades to feel that summers have gotten hotter. One woman I talked to in the park said “there is no escape” from the heat. \u003c/p\u003e\u003cp\u003e“We have nothing that helps and things have gotten much worse,” she told me. “It’s always too hot.”\u003c/p\u003e\u003cp\u003eVulnerable populations, like migrant workers, individuals under the poverty line, the elderly and the unhoused, are most at risk for sickness or death in extreme weather conditions. As temperatures continue to rise, so does the death count. According to the Centers for Disease Control and Prevention, \u003ca href=\"https://ephtracking.cdc.gov/Applications/heatTracker/\" target=\"_blank\" rel=\"Follow\"\u003ean average of 702 heat-related deaths occur every year\u003c/a\u003e.\u003c/p\u003e\u003cp\u003eAs extreme heat becomes a more frequent norm in Sacramento, it seems that resources and aid for those most in need are scarce. Cooling centers in Sacramento are available, but the unhoused residents of Cesar Chavez Plaza mentioned how difficult these shelters are to actually get to because of how far away they’re usually located. Some folks said that, when they do go to these shelters, they are not allowed to bring personal items, so many refuse to go.\u003c/p\u003e\u003cp\u003eEach time I was able to make a trip to Cesar Chavez Plaza that summer to distribute water, I wondered where the help was. If I wasn’t there to offer water, who was? Where was the city? Why is there not been a better policy to help our unhoused neighbors in Sacramento survive the heat? \u003c/p\u003e\u003cp\u003eFor the city’s unhoused residents, it’s not about being uncomfortable in the heat, it’s about surviving it.\u003c/p\u003e\u003cp\u003eAs my friends and I climbed into my car to leave Cesar Chavez Plaza for the last time that summer, I took a moment to look back at the park one last time. I watched as Oliver looked around aimlessly, appearing not to know what to do next or where to go.\u003c/p\u003e\u003cp\u003eAs we drove away from the park, all I could think was: What do we do now?\u003c/p\u003e\u003cdiv class=\"ng_endnote_contact\"\u003eKatherine Hunter is a Sacramento native residing in New York City and pursuing a career in creative nonfiction.\u003c/div\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/275753176",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Katherine Hunter\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eSpecial to The Sacramento Bee\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "“Who really takes the heat for climate change? Sacramento’s unhoused population,” writes Sacramento native Katherine Hunter. | Opinion",
+      "lead_media": {
+        "id": "250126599",
+        "url": "https://www.sacbee.com/latest-news/cweq9z/picture250126599",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "SAC_RCB_20210218_HOMELESSBIZ0409.JPG",
+        "publication": "sacbee",
+        "layout_option": "",
+        "home": "/web/v1/sections/3182",
+        "modified_date": 1616442913,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1616442913,
+        "thumbnail": "https://www.sacbee.com/latest-news/cweq9z/picture250126599/alternates/FREE_1140/SAC_RCB_20210218_HOMELESSBIZ0409.JPG",
+        "href": "/web/v1/content/250126599",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3182"
+        ],
+        "credit": "rbyer@sacbee.com",
+        "dateline": "",
+        "caption": "A homeless man sleeps while others push carts near the  A.J. Stevens statue in Cesar Chavez Plaza in downtown Sacramento on Thursday, Feb. 18, 2021. It’s not uncommon to see large groups of people sleeping in the park.",
+        "photographer": "Renée C. Byer",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Sacramento",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": [
+        {
+          "name": "mcc-local-oped"
+        }
+      ]
+    },
+    {
+      "id": "277907758",
+      "url": "https://www.sacbee.com/opinion/article277907758.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "How some elected officials in California are weaponizing public information | Opinion",
+      "publication": "sacbee",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5779",
+      "home_section": {
+        "name": "Opinion",
+        "url": "https://www.sacbee.com/opinion/"
+      },
+      "modified_date": 1691624829,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "California governments use public information to attack foes",
+      "originating_url": "https://www.sacbee.com/opinion/article277907758.html",
+      "meta_description": "California governments are releasing sensitive public information to advance different political agendas. Public awareness is the best solution.",
+      "published_date": 1691409600,
+      "thumbnail": "",
+      "authors": [
+        {
+          "name": "Tom Philp",
+          "email": "tphilp@sacbee.com"
+        }
+      ],
+      "keywords": "transgender, culture wars, alameda county, sacramento county",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "5779",
+        "3182",
+        "70592"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "California governments are releasing sensitive public information to advance different political agendas. Public awareness is the best solution.",
+      "content": "\u003cp\u003eTransparency in government is generally considered a good thing. But there is a growing trend in California for governments to weaponize it, to release personal information for various agendas that at the moment are trending on both sides of the political spectrum. \u003c/p\u003e\u003cp\u003eReal sunshine can be harmful in large doses. So is government information that is used to scorch people on the wrong side of political leaders. Three recent examples:\u003c/p\u003e\u003cp\u003eAt Southern California’s Chino Valley Unified School District, its board voted 4-1 to notify parents if a student, filling out a form or talking to a teacher, wants to be known by “a name or pronoun other than those listed on the student’s birth certificate” or other records. In other words, if a kid is transgender, that is news to be spread to everybody.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:201347249% --\u003e\u003c/p\u003e\u003cp\u003eTony Thurmond, the California State Superintendent of Public Instruction, recently spoke to the Chino board to oppose the parental notification policy and respect the privacy of its students. Thurmond \u003ca href=\"https://www.latimes.com/california/story/2023-07-21/inland-empire-school-board-meetings-sow-chaos-over-textbooks-trans-students\" target=\"_blank\" rel=\"Follow\"\u003ewas basically ejected \u003c/a\u003efrom this public meeting. When security is necessary to safely escort a state official from a government meeting, something is terribly amiss. \u003c/p\u003e\u003cp\u003eIn Alameda County, District Attorney Pamela Price \u003ca href=\"https://www.berkeleyscanner.com/2023/07/22/courts/pamela-price-critic-facing-misdemeanor-butch-ford-blasts-da-security-breach/\" target=\"_blank\" rel=\"Follow\"\u003ereleased in two court documents\u003c/a\u003e the home address of a rival prosecutor, Amilcor “Butch” Ford. Exposing someone who has put hundreds and hundreds of local residents behind bars was a reckless move that outraged the labor union representing the prosecutors. \u003c/p\u003e\u003cp\u003eThe political backdrop for all of this and much more is a complicated and ongoing court conflict between Ford and Price, who also happens to be facing a bitter recall election. \u003c/p\u003e\u003cp\u003eFinally, there is a recent incident right here in Sacramento. An information rights group asked Sheriff Jim Cooper to stop voluntarily sharing \u003ca href=\"https://www.sacbee.com/news/politics-government/capitol-alert/article276848586.html\" target=\"_blank\" rel=\"Follow\"\u003elicense plate information\u003c/a\u003e with other states, particularly those in states with abortion restrictions that could potentially use the information to track the private movements of patients.\u003c/p\u003e\u003cp\u003eAs a state assemblyman, Cooper had supported a bill that restricted such sharing of information. As sheriff, he apparently changed his mind. On Twitter, Cooper later said that the Electronic Frontier Foundation is “protecting child molesters, fentanyl traffickers, rapists and murderers.”\u003c/p\u003e\u003cp\u003eThat is a pretty curious criticism of \u003ca href=\"https://www.loc.gov/item/lcwaN0004119/\" target=\"_blank\" rel=\"Follow\"\u003ean organization\u003c/a\u003e that has been around for 33 years and is active around the planet on various digital conflicts that can potentially compromise personal privacy. And it does not explain an apparent change of thinking in his conversion from a legislator back into a law enforcement officer.\u003c/p\u003e\u003cp\u003eThe Constitution does not mention the word “privacy,” although it does promote some ways to protect it, particularly in the\u003ca href=\"https://constitution.congress.gov/constitution/amendment-4/\" target=\"_blank\" rel=\"Follow\"\u003e Fourth Amendment’s\u003c/a\u003e prohibition against unreasonable searches and the \u003ca href=\"https://constitution.congress.gov/browse/essay/amdt14-S1-8-8-3/ALDE_00000832/\" target=\"_blank\" rel=\"Follow\"\u003eFourteenth Amendment’s\u003c/a\u003e promotion of equal protection. \u003c/p\u003e\u003cp\u003eIf any student in the Chino Valley Unified School District happens to publicly identify as transgender, it is hard to make the case that the district is protecting this student equally by its notification policy. \u003c/p\u003e\u003cp\u003eThis school board provided the state schools superintendent only a minute to \u003ca href=\"https://docs.google.com/document/d/1909R0JzgDZNs3EM6kNAfgoQmMhEnbrybK7seSrOiXKc/edit\"\u003espeak\u003c/a\u003e. Thurmond tried to make the most of it. \u003c/p\u003e\u003cp\u003e“We can debate all the laws and all of the policies and practices, I ask you to consider this,” he said. “That nearly half of all students who identify as LGBTQ-plus are considering suicide. I ask you to consider this. That the policy that you consider tonight might not only fall outside of the laws that respect privacy and safety for our students, but may put students at risk.”\u003c/p\u003e\u003cp\u003eBoard President \u003ca href=\"https://www.chino.k12.ca.us/Page/53706\" target=\"_blank\" rel=\"Follow\"\u003eSonja Shaw\u003c/a\u003e responded. “Here is the problem. We are here because of people like you. You are in Sacramento proposing things that pervert children.” She rejected Thurmond’s request to respond and temporarily suspended the meeting as the boardroom descended into a chaos of shouting and screaming.\u003c/p\u003e\u003cp\u003eWhat a lesson for any student who happened to be watching.\u003c/p\u003e\u003cp\u003eFor all of us, it is the healthy kind of sunshine, when the public begins to understand when its leaders are misusing information to potentially harm members of the public, that is the best cure of all. \u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/277907758",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Tom Philp\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:tphilp@sacbee.com\"\u003etphilp@sacbee.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "Real sunshine can be harmful. So is government information that is used to scorch people on the wrong side of political leaders. | Opinion",
+      "lead_media": {
+        "id": "277532138",
+        "url": "https://www.sacbee.com/latest-news/2dy8ck/picture277532138",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "THURMOND (1).jpg",
+        "publication": "sacbee",
+        "layout_option": "",
+        "home": "/web/v1/sections/3182",
+        "modified_date": 1689953739,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1689953652,
+        "thumbnail": "https://www.sacbee.com/latest-news/2dy8ck/picture277532138/alternates/FREE_1140/THURMOND%20(1).jpg",
+        "href": "/web/v1/content/277532138",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3182"
+        ],
+        "credit": "Southern California News Group",
+        "dateline": "",
+        "caption": "State Superintendent of Public Instruction Tony Thurmond is escorted out of the Chino Valley school board meeting Thursday, July 20, 2023, by security officers. Board President Sonja Shaw said he went over the one-minute time limit for speakers.",
+        "photographer": " Jordan B. Darling",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Sacramento",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "277940703",
+      "url": "https://www.sacbee.com/opinion/letters-to-the-editor/article277940703.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "El Dorado’s proclamation of a Christian Heritage Month is a Constitutional violation | Opinion",
+      "publication": "sacbee",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5785",
+      "home_section": {
+        "name": "Letters to the Editor",
+        "url": "https://www.sacbee.com/opinion/letters-to-the-editor/"
+      },
+      "modified_date": 1691323213,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "El Dorado County proclaims July as Christian Heritage Month",
+      "originating_url": "https://www.sacbee.com/opinion/letters-to-the-editor/article277940703.html",
+      "meta_description": "El Dorado County officials’ decision to proclaim July as Christian Heritage Month is a massive Constitutional violation",
+      "published_date": 1691323200,
+      "thumbnail": "https://www.sacbee.com/homes/home-sellers/ui1dmd/picture189991814/alternates/FREE_1140/JE8A1121",
+      "authors": [
+        {
+          "name": "The Sacramento Bee letter writers",
+          "email": ""
+        }
+      ],
+      "keywords": "el dorado, christian, constitution, religion, heritage",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "5785",
+        "88678",
+        "3182",
+        "70592",
+        "5779"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "El Dorado County officials’ decision to proclaim July as Christian Heritage Month is a massive Constitutional violation",
+      "content": "\u003ch3\u003e\u003cspan\u003eEmbarrassing proclamation in El Dorado\u003c/span\u003e\u003cbr/\u003e\u003cbr/\u003e\u003c/h3\u003e\u003cp\u003e“\u003ca href=\"https://www.sacbee.com/news/local/article277870393.html#storylink=cpy\"\u003eEl Dorado County declares American Christian Heritage Month. Not all residents are happy\u003c/a\u003e,” (sacbee.com, Aug. 2)\u003c/p\u003e\u003cp\u003eNot only is El Dorado County’s decision to establish July for a particular religious “heritage” an outsized violation of the spirit of the Constitution, it is also telling and embarrassing that their motive for the move is so-called historical education. \u003c/p\u003e\u003cp\u003eI look forward to same-sized treatment for the third of El Dorado residents who are not affiliated with religion as well as those of minority religions. We don’t have enough months in the year available for each, so some of these proclamations might have to share July with Christians. \u003c/p\u003e\u003cp\u003eThank you to the county for opening this wonderful door that will surely lead to corrected proclamation wording and for bringing everyone’s attention to how quickly the El Dorado board can act to similarly honor its other residents whose forefathers contributed to the real secular heritage of this inclusive country.\u003c/p\u003e\u003cp\u003eJudy Saint\u003c/p\u003e\u003cp\u003ePresident, Greater Sacramento Chapter Freedom From Religion Foundation\u003c/p\u003e\u003ch3\u003eThe permanent stain of Trump\u003c/h3\u003e\u003cp\u003e“\u003ca href=\"https://www.sacbee.com/news/politics-government/capitol-alert/article277863638.html\"\u003eDonald Trump to address California Republican convention\u003c/a\u003e,” (sacbee.com, Aug. 1)\u003c/p\u003e\u003cp\u003eTwice impeached during his single, horrifyingly chaotic, perversely divisive presidency, and now three times criminally indicted, Donald Trump apparently ticks all the requisite boxes for a keynote speaking invitation from a political establishment clearly unable to identify and embrace an honorable, respectable figurehead. \u003c/p\u003e\u003cp\u003eEnthusiastic disregard for both rule of law and hallowed conventions of governance, in slavish fealty to Trump, will debase and cripple the GOP for years to come, depriving America of a rational, effective, respectable conservative movement. \u003c/p\u003e\u003cp\u003eHas conservative leadership the courage and will to emerge from the Trump swamp?\u003c/p\u003e\u003cp\u003eDamon Schwartz\u003c/p\u003e\u003cp\u003eSacramento\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:201347249% --\u003e\u003c/p\u003e\u003ch3\u003eStop drilling and fracking\u003c/h3\u003e\u003cp\u003e“\u003ca href=\"https://www.sacbee.com/news/politics-government/capitol-alert/article277730683.html\"\u003eCalifornia’s ambitious 2030 climate target faces serious obstacles, regulator acknowledges\u003c/a\u003e,” (sacbee.com, July 31)\u003c/p\u003e\u003cp\u003eCalifornia can still reach our 2030 climate goals, but only if we stop relying on unproven, unworkable schemes like ‘carbon capture,’ a technology that aims to trap climate pollution before it enters the atmosphere. While that might sound appealing, in the real world carbon capture has been a complete climate failure. The only way to protect our climate from the assault of corporate interests is to stop drilling and fracking for fossil fuels.\u003c/p\u003e\u003cp\u003eGov. Gavin Newsom should use his executive authority today to stop permitting fossil fuel extraction in California. Renewable energy and energy efficiency are reliable, cost-effective and ready for widespread deployment. Given huge advances in production and storage, we could meet 100% of our energy needs with clean, renewable energy. \u003c/p\u003e\u003cp\u003eIt is time for Newsom and California leaders to step up, show real commitment through action and lead our state toward a fully renewable future.\u003c/p\u003e\u003cp\u003eChirag Bhakta\u003c/p\u003e\u003cp\u003eVentura\u003c/p\u003e\u003ch3\u003eWhere are Placer’s Democrats?\u003c/h3\u003e\u003cp\u003e“\u003ca href=\"https://www.sacbee.com/news/politics-government/election/california-elections/article277510753.html#storylink=cpy\"\u003eThese 10 California elections might decide partisan control of U.S. House in 2024\u003c/a\u003e,” (sacbee.com, July 24)\u003c/p\u003e\u003cp\u003eThe Bee says Rep. Kevin Kiley will likely keep his seat in the next election in 2024. We moved to Placer county 29 years ago and have endured the John Doolittle, Tom McClintock and now Kiley years, all the while waiting to feel the impact of Bay Area people moving here for improved quality of life and comparatively lower housing prices, bringing their politics with them. \u003c/p\u003e\u003cp\u003eBut that hasn’t happened. The Democratic Party can’t seem to field candidates. Last election, they brought in Dr. Kermit Jones, but I guess he’s now just a memory.Where are the Democrats?\u003c/p\u003e\u003cp\u003eBrian Keeley\u003c/p\u003e\u003cp\u003eGranite Bay\u003c/p\u003e\u003ch3\u003eScott Alvord’s reputation\u003c/h3\u003e\u003cp\u003e“\u003ca href=\"https://www.sacbee.com/community/roseville-placer/article277331578.html#storylink=cpy\"\u003eRoseville councilman, House of Oliver owner settle defamation case rooted in 2022 campaign\u003c/a\u003e,” (sacbee.com, July 21)\u003c/p\u003e\u003cp\u003eI was happy to see the lawsuit filed by Councilman Scott Alvord was settled in his favor, but unfortunately, the damage was already done by Matthew Oliver and Aaron Park in their conquest to harm Alvord’s reputation by making false accusations. \u003c/p\u003e\u003cp\u003eAlvord has always been a professional leader committed to the well-being of this community. I, for one, am proud that he has served on the Roseville City Council and supports the city and community the way he does. Alvord should have been elected to the County Board of Supervisors, and I firmly believe, had it not been for the interference of Oliver, he would have succeeded. \u003c/p\u003e\u003cp\u003eI sincerely hope the challenge to Oliver’s claims against Alvord and settling this lawsuit will make Oliver think before he speaks — but I have my doubts.\u003c/p\u003e\u003cp\u003eHelen Warren\u003c/p\u003e\u003cp\u003eRoseville\u003c/p\u003e\u003ch3\u003eNapear deserved what he got\u003c/h3\u003e\u003cp\u003e“\u003ca href=\"https://www.sacbee.com/opinion/article277715038.html#:~:text=Napear%20was%20canceled%20in%20May,thought%20of%20Black%20Lives%20Matter.\u0026text=Napear%20responded%20with%20a%20tweet,That%20was%20it.\"\u003eGrant Napear’s career was canceled because of one tweet\u003c/a\u003e,” (sacbee.com, July 31)\u003c/p\u003e\u003cp\u003eI don’t think Napear’s career cancellation stinks as much as Kings fans might think. Napear did this to himself. He’s always had a big mouth and a big ego. He shouldn’t have taken DeMarcus Cousins’ bait. \u003c/p\u003e\u003cp\u003eNapear might not have said the n-word in his “All Lives Matter” all-caps rant, but what he said was wrong. \u003c/p\u003e\u003cp\u003eRobert Truskey Jr.\u003c/p\u003e\u003cp\u003eCitrus Heights\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/277940703",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy The Sacramento Bee letter writers\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "“I look forward to same-sized treatment for the El Dorado residents who aren’t religiously affiliated,” writes Judy Saint. | Letters to the editor",
+      "lead_media": {
+        "id": "189991814",
+        "url": "https://www.sacbee.com/homes/home-sellers/ui1dmd/picture189991814",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "JE8A1121",
+        "publication": "sacbee",
+        "layout_option": "",
+        "home": "/web/v1/sections/47241",
+        "modified_date": 1513364338,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1513364338,
+        "thumbnail": "https://www.sacbee.com/homes/home-sellers/ui1dmd/picture189991814/alternates/FREE_1140/JE8A1121",
+        "href": "/web/v1/content/189991814",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "47241"
+        ],
+        "credit": "",
+        "dateline": "",
+        "caption": "A sign greets welcomes visitors to Placerville. It can be seen off the freeway inviting guests to come and look around.",
+        "photographer": "TONY ARIAS",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Sacramento",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": [
+        {
+          "name": "mcc-local-oped"
+        }
+      ]
+    },
+    {
+      "id": "277930468",
+      "url": "https://www.sacbee.com/opinion/article277930468.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "A Newsom-DeSantis debate is not a sideshow. It could be something much bigger  | Opinion",
+      "publication": "sacbee",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5779",
+      "home_section": {
+        "name": "Opinion",
+        "url": "https://www.sacbee.com/opinion/"
+      },
+      "modified_date": 1691092726,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "DeSantis and Newsom to debate on Fox, Hannity moderating",
+      "originating_url": "https://www.sacbee.com/opinion/article277930468.html",
+      "meta_description": "Accepting California Governor’s Gavin Newsom’s invitation, Florida Governor Ron DeSantis will debate live on Fox News, with Sean Hannity moderating",
+      "published_date": 1691086891,
+      "thumbnail": "",
+      "authors": [
+        {
+          "name": "Tom Philp",
+          "email": "tphilp@sacbee.com"
+        }
+      ],
+      "keywords": "newsom, desantis, debate, hannity",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "5779",
+        "70592"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Accepting California Governor’s Gavin Newsom’s invitation, Florida Governor Ron DeSantis will debate live on Fox News, with Sean Hannity moderating",
+      "content": "\u003cp\u003eThe debate between California Gov. Gavin Newsom and Florida Gov. Ron DeSantis is on. On Wednesday Fox News’ Sean Hannity gave the Florida presidential candidate an offer on live television he literally could not refuse: a stage with Newsom.\u003c/p\u003e\u003cp\u003e“Gavin made the offer, your answer is….” \u003ca href=\"https://twitter.com/ccadelago/status/1686916506163232768?s=20\" target=\"_blank\" rel=\"Follow\"\u003easked Hannity\u003c/a\u003e on his show.\u003c/p\u003e\u003cp\u003eThere was brief silence and a frozen smile from DeSantis.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:201347249% --\u003e\u003c/p\u003e\u003cp\u003e“Absolutely, I’m game,” he said. “Tell me when and where. We’ll do it.”\u003c/p\u003e\u003cp\u003eIt was destiny. And it also happens to be the right thing to do.\u003c/p\u003e\u003cp\u003eIf American politics were a high school, the senior class is either stumbling at speeches, freezing in mid-sentence, being coached how to vote or getting indicted.\u003c/p\u003e\u003cp\u003ePresident Joe Biden’s \u003ca href=\"https://www.youtube.com/watch?v=hNG3Yf-Ajec\" target=\"_blank\" rel=\"Follow\"\u003efootwork\u003c/a\u003e after speaking to the Air Force Academy graduates was painful. The 16 excruciating seconds of \u003ca href=\"http://silence\" target=\"_blank\" rel=\"Follow\"\u003esilence \u003c/a\u003efrom Senate Minority Leader Mitch McConnell, only to turn away from reporters in retreat, showed a similar level of command. California Sen. Dianne Feinstein, shielded from public view until it is inevitable in a Senate meeting, appears \u003ca href=\"https://www.cnn.com/videos/politics/2023/07/27/senator-dianne-feinstein-senate-bill-vote-speech-interrupted-vpx.cnn\" target=\"_blank\" rel=\"Follow\"\u003ebarely able\u003c/a\u003e to perform her duties. \u003c/p\u003e\u003cp\u003eAnd then there is the bully of the senior class, Donald Trump, whose tactics are finally catching up to him. Just hours after Hannity coaxed a ‘yes’ out of DeSantis for the debate with Newsom, Trump was in a Washington D.C. federal court to hear the latest charges against him, this time for his role in \u003ca href=\"https://www.sacbee.com/news/politics-government/article277601093.html\" target=\"_blank\" rel=\"Follow\"\u003eintervening\u003c/a\u003e in the 2020 presidential election process. \u003c/p\u003e\u003cp\u003eThe junior class, the land of vice presidents current and former, is not receiving its traditional due respect. \u003c/p\u003e\u003cp\u003ePolling on Vice President Kamala Harris reveals a public that, for whatever the reasons, does not hold her in high regard. A majority of those \u003ca href=\"https://www.latimes.com/projects/kamala-harris-approval-rating-polls-vs-biden-other-vps/\" target=\"_blank\" rel=\"Follow\"\u003esurveyed\u003c/a\u003e consistently rate her as unpopular. \u003c/p\u003e\u003cp\u003eFormer Trump Vice President Mike Pence, meanwhile, has spectacular name recognition along with \u003ca href=\"https://www.usnews.com/news/elections/articles/2023-07-13/pence-struggles-for-traction-in-gop-primary\" target=\"_blank\" rel=\"Follow\"\u003esingle-digit support\u003c/a\u003e for his presidential candidacy. Any further dipping in the polls, and Pence risks losing invitations to future Republican debates that provide his only chance at a rally.\u003c/p\u003e\u003cp\u003eThis leaves the sophomore class to prepare for the jump to varsity. In other words, this leaves Gavin Newsom. And Ron DeSantis.\u003c/p\u003e\u003cp\u003eSophomores tend to stick together, and Newsom and DeSantis have done so in their unique political glue. From social media rants to airlifts of migrants by DeSantis to Sacramento, to Newsom’s musings about resulting charges of kidnapping, each uses the other to seek the public’s attention. \u003c/p\u003e\u003cp\u003eThey need to be the undisputed leaders of the sophomore class — but for different reasons.\u003c/p\u003e\u003cp\u003eDeSantis is trailing in the polls as he faces a party electorate that, for now, remains steadfast with Trump. It may be impossible for the former president to avoid his day of reckoning in one court or another before the election. Perhaps the enormity of the mounting charges against him will break his hold on the party.\u003c/p\u003e\u003cp\u003eNewsom, America’s presidential candidate in waiting, has been hounding DeSantis for a debate ever since his own appearances with Hannity. Officially, the governor fully respects his Democratic Party’s organizational chart, with Biden as its undisputed leader seeking re-election next year. Newsom’s behavior, from proposing a constitutional amendment to fight gun violence to campaigning in Republican-held states across the country, \u003ca href=\"https://www.forbes.com/sites/saradorn/2023/07/07/heres-why-many-believe-gavin-newsom-is-running-for-president-even-as-he-denies-it/\" target=\"_blank\" rel=\"Follow\"\u003ereveals his national political ambitions\u003c/a\u003e.\u003c/p\u003e\u003cp\u003eThe California governor is \u003ca href=\"https://twitter.com/ccadelago/status/1686923614032183296?s=20\" target=\"_blank\" rel=\"Follow\"\u003eproposing \u003c/a\u003ea 90-minute debate, with the first speaker decided by coin toss. Neither participant can bring notes, but both can bring a blank notepad and pen to their podium. \u003c/p\u003e\u003cp\u003eThe theater of this all but feels pre-ordained. This is also deadly serious.\u003c/p\u003e\u003cp\u003eOne of these two sophomores could be our next president. The senior class is a mess. The juniors appear to have risen to their career pinnacles. And Americans of both parties may be searching for a new leader in the coming months for very different reasons. \u003c/p\u003e\u003cp\u003eBring on the debate, whenever and wherever. It’s only the future of the country that may be at stake.\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/277930468",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Tom Philp\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:tphilp@sacbee.com\"\u003etphilp@sacbee.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "Hounded by California Governor Gavin Newsom’s call to debate, Florida Governor Ron DeSantis finally says on Fox News. Who will be more presidential?",
+      "lead_media": {
+        "id": "277832108",
+        "url": "https://www.kansascity.com/latest-news/fhomyy/picture277832108",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "KCM__RAH7837E",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1691065084,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1690841306,
+        "thumbnail": "https://www.kansascity.com/latest-news/fhomyy/picture277832108/alternates/FREE_1140/KCM__RAH7837E",
+        "href": "/web/v1/content/277832108",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "Special to the Star",
+        "dateline": "",
+        "caption": "Florida Gov. Ron DeSantis’ presidential primary strategy has shifted away from his war on “woke” and focused more on economic issues.",
+        "photographer": "Reed Hoffmann",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Sacramento",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "277876863",
+      "url": "https://www.sacbee.com/opinion/article277876863.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Sacramento took its boldest step to address the homeless crisis. But will it work? | Opinion",
+      "publication": "sacbee",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5779",
+      "home_section": {
+        "name": "Opinion",
+        "url": "https://www.sacbee.com/opinion/"
+      },
+      "modified_date": 1691001336,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Sacramento to establish new managed homeless encampments",
+      "originating_url": "https://www.sacbee.com/opinion/article277876863.html",
+      "meta_description": "The Sacramento City Council took a historic step to approve “Safe Ground” homeless encampments over the objections of council members most impacted by the vote",
+      "published_date": 1690977600,
+      "thumbnail": "https://www.sacbee.com/latest-news/w64zix/picture277441653/alternates/FREE_1140/SAC_RCB_20230718_HOMELESS0020.JPG",
+      "authors": [
+        {
+          "name": "The Sacramento Bee Editorial Board",
+          "email": "opinion@sacbee.com"
+        }
+      ],
+      "keywords": "sacramento, homeless, safe ground, encampment, city council",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "5779",
+        "5781",
+        "3182",
+        "70592"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "The Sacramento City Council took a historic step to approve “Safe Ground” homeless encampments over the objections of council members most impacted by the vote",
+      "content": "\u003cp\u003eFive Sacramento leaders Tuesday night took the most important step yet in the city’s battle against homelessness. Four City Council members and \u003ca href=\"https://www.sacbee.com/opinion/article277222783.html\" target=\"_blank\" rel=\"Follow\"\u003eMayor Darrell Steinberg\u003c/a\u003e directed \u003ca href=\"https://www.sacbee.com/opinion/letters-to-the-editor/article277115313.html\" target=\"_blank\" rel=\"Follow\"\u003eCity Manager Howard Chan \u003c/a\u003eto establish new managed homeless encampments, hopefully starting within 30 to 60 days. \u003c/p\u003e\u003cp\u003eFinally, there is reason to hope for real incremental change that benefits those who live on the streets and those of us who are lucky to live indoors.\u003c/p\u003e\u003cp\u003eIt was one of the most revealing council exchanges in the recent history of the chamber. Some fared better than others.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:201347249% --\u003e\u003c/p\u003e\u003cp\u003eOn this historic night, the outgoing mayor was no lame duck. This may have been the toughest majority Steinberg has ever had to muster in his seven years as mayor. But he did it. \u003c/p\u003e\u003cp\u003eSteinberg offered scant details about this \u003ca href=\"https://homeless.cityofsacramento.org/SafeGround\" target=\"_blank\" rel=\"Follow\"\u003e“Safe Ground”\u003c/a\u003e plan in the official proposal to establish these new city-sanctioned encampments. He offered no plan on how each site will be managed. He suggested no criteria for Chan to select the sites.\u003c/p\u003e\u003cp\u003eThis was part of the sophisticated strategy behind what Steinberg sought to accomplish. \u003c/p\u003e\u003cp\u003eSacramento’s political history has shown that when council members get involved in trying to select new shelter sites or managed encampment sites, nothing happens. The unvarnished delegation of power to a manager who can get it done, combined with the public’s intensifying sense of urgency for the city to do something, were his two greatest arguments. And they prevailed. \u003c/p\u003e\u003cp\u003e“This is like a fire,” Steinberg said at the beginning of the meeting. “This is an emergency. Treat it like an emergency.”\u003c/p\u003e\u003cp\u003eThe mayor’s premise is that Sacramento is better off with city-designated encampment locations than the unmanaged, shifting chaos that too many neighborhoods face today. Safe Ground is a more stable landscape. It also dramatically improves the ability of social service providers to connect regularly with those in need, gain their trust and hopefully open the door to tailored social services. It is the option that can make a difference in a matter of months, not years.\u003c/p\u003e\u003cp\u003eSacramento has lacked the political will to get this done before, so Steinberg and the council majority want Chan to get started immediately instead of letting the process get bogged down by conditions and calls to study the issue further. It’s not that we don’t favor transparency in government decisions, we do. But calls for transparency in the past became vehicles for obstructionism. In this case, the transparency will have to come as the process moves along because Sacramento can’t wait any longer. \u003c/p\u003e\u003cp\u003eEach City Council member faced different repercussions from the mayor’s proposal. Chan’s plan, given the ambitious unofficial timetable, is to look at vacant city-owned land.\u003c/p\u003e\u003cp\u003e“They are vacant for a reason,” Chan told the council. “They are not located in our central district. I want to be clear about it. How do we implement this quickly?”\u003c/p\u003e\u003cp\u003eWhile Chan said there are hundreds of city-owned parcels throughout Sacramento, it was clear that some council members were acutely aware that the truly suitable parcels were in their districts, and they happened to vote accordingly.\u003c/p\u003e\u003cp\u003e“The majority of it will land in District 2,” said Councilman \u003ca href=\"https://www.sacbee.com/opinion/article272662438.html\" target=\"_blank\" rel=\"Follow\"\u003eSean Loloee \u003c/a\u003eof North Sacramento. He voted no.\u003c/p\u003e\u003cp\u003eCouncilwoman Mai Vang of South Sacramento’s District 8 was “actually in agreement” with Loloee — a rare occurrence — for the same reason. She voted no. “Safe ground has to be distributed throughout the city.”\u003c/p\u003e\u003cp\u003eSteinberg was conceptually supportive of distribution, but not enough to require that in delegating site selection to Chan.\u003c/p\u003e\u003cp\u003e Why? It would slow progress down. \u003c/p\u003e\u003cp\u003e“If we are saying that the highest priority item of this council is to have these sites geographically dispersed, it will drive the timeline,” Chan said. “I promise you that.”\u003c/p\u003e\u003cp\u003eCouncilman \u003ca href=\"https://www.sacbee.com/news/local/news-columns-blogs/marcos-breton/article10302575.html\" target=\"_blank\" rel=\"Follow\"\u003eEric Guerra\u003c/a\u003e, who represents District 6, voted yes, citing the mandate of November’s Measure O for the city to make progress. “District 6 doesn’t have any viable public land,” he added. \u003c/p\u003e\u003cp\u003eCouncil members Rick Jennings, Caity Maple and Katie Valenzuela gave Steinberg the slim majority he needed. \u003c/p\u003e\u003cp\u003e“It is kind of amazing that we are here,” said Maple of District 5. \u003c/p\u003e\u003cp\u003e“I think it is a great plan,” said Jennings of District 7.\u003c/p\u003e\u003cp\u003eFor Valenzuela, who represents District 4, the vote was a milestone in “how far we have come.” But she still had questions. She said she would love to know about “sites being considered. If we can see a list.”\u003c/p\u003e\u003cp\u003eChan did not take the bait. “We are compiling some lists,” he said but offered no details.\u003c/p\u003e\u003cp\u003eIt was the complete loss of political control that seemed to lead to the two remaining no votes, Karina Talamantes of District 3 and Lisa Kaplan of District 1.\u003c/p\u003e\u003cp\u003e“The city elected us to be accountable,” said Kaplan, who challenged the mayor’s notion to look beyond the short-term cost of his proposal. “Money is an object. What about our city employees? We are in the middle of negotiating with all of our unions. Do we spend it all on the unhoused or look at what the city employees deserve?”\u003c/p\u003e\u003cp\u003eDuring Talamantes’ exchange with the mayor, the meeting turned personal. \u003c/p\u003e\u003cp\u003e“People are going to be upset about the site locations we propose,” Talamantes said. Regardless, she wanted control. “We are a brand-new council,” she said. “Allow us to identify the sites ourselves. Talk to our neighbors. Don’t force this on us.”\u003c/p\u003e\u003cp\u003eHistory is simply not on Talamantes’ side, as previous attempts to establish legalized encampments in the city died because objections such as hers prevailed. Meanwhile, a homeless problem became a homeless crisis in Sacramento. A slim majority of the council was not going to let this tough decision stall again, even if a majority of those voting yes may very well not have encampments in their districts. \u003c/p\u003e\u003cp\u003eIn frustration, Talamantes turned on Steinberg. “The city has done no good neighborhood policies with my community. When was the last time, mayor, you went out to District 3?”\u003c/p\u003e\u003cp\u003eThe last time she invited him, the mayor replied in an exchange with interruptions. \u003c/p\u003e\u003cp\u003eThe meeting proceeded. Guerra gave Steinberg his majority with some new conditions. He wanted Chan to design buffer zones and policies to inform and engage neighbors of Safe Ground encampments. He also wanted the county to follow through on its commitment to provide services for mental health and addiction treatment to the extent the city can enable it. \u003c/p\u003e\u003cp\u003eWith the outcome clear, Kaplan in her closing returned to the mayor’s exchange with Talamantes.\u003c/p\u003e\u003cp\u003e“I was offended by how you were treating her,” Kaplan said. “We women need to stand up when we feel our opinion is not being valued and heard for what it is.”\u003c/p\u003e\u003cp\u003eSteinberg stayed calm. He had lost two pounds of political flesh by then in the process, one from the personally critical question from Talamantes and then the critique from Kaplan. During a session when Steinberg valiantly tried to maintain chamber decorum, right down to silencing the phone line of “bigots” during public comment, the mayor would not be thrown off his game and incur a self-inflicted wound. \u003c/p\u003e\u003cp\u003eHe was gracious.\u003c/p\u003e\u003cp\u003eIn his signature calm voice, the mayor showed complete command of the moment.\u003c/p\u003e\u003cp\u003e“If I interrupted you and was rude to you in any way, I apologize,” he said to Talamantes. “I do my very best to run this dais to respect everybody. I do. And I think, by and large, I think I do a pretty good job of it. I’m sorry.”\u003c/p\u003e\u003cp\u003eAnd with that, the Sacramento City Council voted.\u003c/p\u003e\u003cp\u003eHow this experiment in homeless management goes, setting up encampment sites in places unknown, with management strategies unknown, is anybody’s guess. But one thing is certain. Steinberg guided Sacramento to a milestone achievement.\u003c/p\u003e\u003cp\u003e“Your tenacity,” Valenzuela said, “is to be commended.”\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:239341538% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/277876863",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy The Sacramento Bee Editorial Board\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:opinion@sacbee.com\"\u003eopinion@sacbee.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "This may have been the toughest majority Darrell Steinberg has ever had to muster in his seven years as mayor. | Opinion",
+      "lead_media": {
+        "id": "277441653",
+        "url": "https://www.sacbee.com/latest-news/w64zix/picture277441653",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "SAC_RCB_20230718_HOMELESS0020.JPG",
+        "publication": "sacbee",
+        "layout_option": "",
+        "home": "/web/v1/sections/3182",
+        "modified_date": 1689716416,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1689716416,
+        "thumbnail": "https://www.sacbee.com/latest-news/w64zix/picture277441653/alternates/FREE_1140/SAC_RCB_20230718_HOMELESS0020.JPG",
+        "href": "/web/v1/content/277441653",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3182"
+        ],
+        "credit": "rbyer@sacbee.com",
+        "dateline": "",
+        "caption": "Homeless camper Chadwick Justin Foy, 41, holds all his belongings on his shoulders as friend Valencia Hardwich, 35, steps behind him in the shade while Sacramento police patrol the intersection of 28th and C streets on Tuesday, July 18, 2023. The city has given notices to dozens of people living in tents on the sidewalks in that area, near Leland Stanford Park, telling them to move by Wednesday. The notices cite violation of city codes regarding sidewalk obstruction and storage of personal property on public property. Hardwick said the church has been very supportive offering them water and food every week and the area was great because there were bathrooms in the park. They city has offered them Miller Park but she was concerned because it made people have curfews and said her friends relocated there said it’s a horrible mix of people that don’t get along. “People are a community here and we ban together where we are safe,” she said.",
+        "photographer": "Renée C. Byer",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Sacramento",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "277707888",
+      "url": "https://www.miamiherald.com/opinion/editorials/article277707888.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Trump betrayed us. He needs to face the Jan. 6 charges — but so do we, the nation | Opinion",
+      "publication": "miamiherald",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5129",
+      "home_section": {
+        "name": "Editorials",
+        "url": "https://www.miamiherald.com/opinion/editorials/"
+      },
+      "modified_date": 1690985566,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Trump must face Jan. 6 indictment like other defendants ",
+      "originating_url": "https://www.miamiherald.com/opinion/editorials/article277707888.html",
+      "meta_description": "Former President Donald Trump’s indictment for the January 6 insurrection is necessary. He must face the charges just like 1,000 others or our laws are meaningless.",
+      "published_date": 1690931499,
+      "thumbnail": "https://www.miamiherald.com/latest-news/rrphtr/picture277860968/alternates/FREE_1140/USATSI_21107242.jpg",
+      "authors": [
+        {
+          "name": "the Miami Herald Editorial Board",
+          "email": ""
+        }
+      ],
+      "keywords": "January 6, indictment, Donald Trump, Jack Smith, insurrection",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "5129",
+        "3180",
+        "49281",
+        "5128",
+        "84423"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Former President Donald Trump’s indictment for the January 6 insurrection is necessary. He must face the charges just like 1,000 others or our laws are meaningless.",
+      "content": "\u003cp\u003eIt finally happened. The big one. The criminal indictment on Tuesday of former President Donald Trump on grounds he tried to overturn the results of the 2020 election. \u003c/p\u003e\u003cp\u003eThe four-count, 45-page indictment came more than 2 1/2 years after Trump incited the Jan. 6, 2021, attack on the U.S. Capitol and, in the process, encouraged an attack on democracy.\u003c/p\u003e\u003cp\u003eWhether you dreaded this day as a terrible time for the country or cheered it as justice too long delayed, the now three-time-indicted former president will finally have to face accusations that he used his power as president to try to subvert the will of the voters and stay in office, even when it was clear he’d lost the election. The indictment charges him with three crimes: conspiring to defraud the United States, conspiring to obstruct an official proceeding and conspiring against people’s rights.\u003c/p\u003e\u003cp\u003eThis extraordinary moment had to come. Trump must be held accountable for his actions — or lack of them, because he did nothing for hours to quell the deadly insurrection in his name. Otherwise, our system of laws will have no meaning. The fact that these charges have been lodged while Trump attempts to regain the same office he betrayed so completely is more proof of the existential danger he poses to our democracy.\u003c/p\u003e\u003cp\u003eTrump issued a statement through his campaign calling the charges “fake” and saying he was being targeted by a “weaponized Department of Justice to interfere with the 2024 Presidential Election.”\u003c/p\u003e\u003ch3\u003eA day of horror\u003c/h3\u003e\u003cp\u003eYes, there are Americans who continue to insist Trump did nothing wrong — and there are many of them, cult-like in their loyalty — but so many others in this country remember the horror of that day and know that something went not just wrong, but dangerously so. We remember the fear in our guts as armed crowds surged past the barricades and overran the brave Capitol police in Washington, D.C. We remember watching seething mobs storm into the building, hunting for members of Congress and for Vice President Mike Pence, threatening to hang him. That was no empty threat: They erected a gallows with a noose on the grounds of the Capitol.\u003c/p\u003e\u003cp\u003eWe remember the shame of seeing the Capitol defiled that way, by our fellow citizens. We remember wondering where the National Guard was, knowing that Trump certainly could have called upon them to defend the beating heart of our democracy.\u003c/p\u003e\u003cp\u003eTrump has been charged, but we, too, as a country, need to face these accusations. Looking the other way, as the Senate did when it refused to impeach Trump after the attack, has only deepened the wound to the nation and emboldened those who seek to undermine our government. Trump himself has become more intent, openly, on expanding his power. And he has spawned the likes of Ron DeSantis, Florida’s governor. \u003c/p\u003e\u003cp\u003eTrump’s actions are unprecedented. He already has been indicted twice before this. One case, in New York in March, accuses him of violating state law by falsifying business records related to alleged hush-money payments to porn star Stormy Daniels prior to the 2016 election. The other, based in Florida, accuses him of taking documents containing national-security secrets, keeping them at his Palm Beach estate, then attempting to obstruct justice in that investigation.\u003c/p\u003e\u003ch3\u003e‘Destabilizing lies’\u003c/h3\u003e\u003cp\u003eAnd now there is this case, the one with the greatest ramifications for democracy because Trump’s actions tried to undermine trust in our elections. As the indictment says, “Each of these conspiracies — which built on the widespread mistrust the defendant was creating through pervasive and destabilizing lies about election fraud — targeted a bedrock function of the United States federal government: the nation’s process of collecting, counting and certifying the results of the presidential election.”\u003c/p\u003e\u003cp\u003eFor those who say Trump should face the consequences of his actions at the ballot box, yes, he should. Many prefer that to time-consuming legal proceedings. But casting a vote against Trump cannot be the only recourse we have if — as seems most certainly to be true — he broke the law in at least one of these cases and probably more. And that’s exactly what trials are for.\u003c/p\u003e\u003cp\u003eRemember that \u003ca href=\"https://www.npr.org/2023/03/25/1165022885/1000-defendants-january-6-capitol-riot\" target=\"_blank\"\u003emore than 1,000 people\u003c/a\u003e have been charged in the Jan. 6 attack, a violent assault that cost five lives, defiled the Capitol and had members of Congress running for their lives. At least 89 of those defendants have come from Florida, where the ex-president lives. Among them was Enrique Tarrio, the former Proud Boys leader who lived in Miami and was convicted in May of seditious conspiracy in the plot to attack the U.S. Capitol. Should we prosecute them but not the ex-president?\u003c/p\u003e\u003cp\u003eIn some ways, certainly, this is yet another new low for the country, attributable to Trump. But it may also show us that our institutions are strong enough to stand up to the kind of prolonged assault that a person like Trump — an amoral person with money, power and a massive, easily wounded ego — has heaped on it. \u003c/p\u003e\u003cp\u003eWe’re about to find out.\u003c/p\u003e\u003cp\u003e\u003ca href=\"mailto:heralded@miamiherald.com\" title=\"Click here to send letter to the editor\" target=\"_blank\" rel=\"Follow\"\u003e\u003c!-- %asset:277535953; alt=\"undefined\"% --\u003e\u003c/a\u003e\u003c/p\u003e\u003cp\u003e\u003ca href=\"mailto:heralded@miamiherald.com\" target=\"_blank\" rel=\"Follow\"\u003eClick here \u003c/a\u003eto send the letter.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:250064099% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/277707888",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy the Miami Herald Editorial Board\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "Many Americans insist the former president did nothing wrong. But so many others remember the horror of that day | Opinion",
+      "lead_media": {
+        "id": "277860968",
+        "url": "https://www.miamiherald.com/latest-news/rrphtr/picture277860968",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "USATSI_21107242.jpg",
+        "publication": "miamiherald",
+        "layout_option": "",
+        "home": "/web/v1/sections/3180",
+        "modified_date": 1690917539,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1690917515,
+        "thumbnail": "https://www.miamiherald.com/latest-news/rrphtr/picture277860968/alternates/FREE_1140/USATSI_21107242.jpg",
+        "href": "/web/v1/content/277860968",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3180"
+        ],
+        "credit": "Bryon Houlgrave/For the Register / USA TODAY NETWORK",
+        "dateline": "",
+        "caption": "Former President Donald Trump on July 28 at the Iowa Events Center in Des Moines.",
+        "photographer": "Bryon Houlgrave/For the Register",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Miami",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "277867873",
+      "url": "https://www.sacbee.com/opinion/article277867873.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "How lame is the California GOP? They embrace Trump on the same day he’s indicted | Opinion",
+      "publication": "sacbee",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5779",
+      "home_section": {
+        "name": "Opinion",
+        "url": "https://www.sacbee.com/opinion/"
+      },
+      "modified_date": 1691021205,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "California GOP hails Trump on the same day he’s indicted ",
+      "originating_url": "https://www.sacbee.com/opinion/article277867873.html",
+      "meta_description": "It’s beyond hilarious that the California GOP would announce Donald Trump as their keynote convention speaker on the same day he is indicted by the feds",
+      "published_date": 1690929196,
+      "thumbnail": "https://www.sacbee.com/latest-news/qened3/picture277868723/alternates/FREE_1140/COVER-LEDE.jpg",
+      "authors": [
+        {
+          "name": "Marcos Bretón",
+          "email": "mbreton@sacbee.com"
+        }
+      ],
+      "keywords": "trump, indicted, california, gop, convention",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "5779",
+        "3182",
+        "5735",
+        "5752",
+        "70592",
+        "5709"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "It’s beyond hilarious that the California GOP would announce Donald Trump as their keynote convention speaker on the same day he is indicted by the feds",
+      "content": "\u003cp\u003eHow lame is California’s Republican party? They announced \u003ca href=\"https://www.sacbee.com/news/local/news-columns-blogs/marcos-breton/article121509247.html\" target=\"_blank\" rel=\"Follow\"\u003eDonald Trump\u003c/a\u003e as the keynote speaker at their September statewide convention on the same day Trump is indicted in a Justice Department investigation on\u003ca href=\"https://www.nytimes.com/live/2023/08/01/us/trump-indictment-jan-6\" target=\"_blank\" rel=\"Follow\"\u003e multiple counts \u003c/a\u003eof conspiracy and obstruction. \u003c/p\u003e\u003cp\u003e“We are thrilled to welcome President Trump back to the CAGOP convention stage for the first time since our 2016 convention,” said \u003ca href=\"https://www.cagop.org/s/\" target=\"_blank\" rel=\"Follow\"\u003eCAGOP \u003c/a\u003eChairwoman Jessica Millan Patterson, just hours before Trump was charged with trying to subvert the results of the 2020 presidential election.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:201347249% --\u003e\u003c/p\u003e\u003cp\u003eOne could ask why Millan Patterson was still employed but then again, the deeper obscenity is that Trump remains the GOP front-runner for the 2024 election and may even benefit from Tuesday’s news that Special Counsel Jack Smith will prosecute Trump. It’s all fruit from the same poisoned tree, a moment in time when American citizens fully embraced a corrupt man over the principles of democracy.\u003c/p\u003e\u003cp\u003e“As California Republicans prepare to play a major role in deciding who our Party’s 2024 presidential nominee will be, I look forward to President Trump speaking with our delegates about his plans to move our country forward. We look forward to a great event and lunch keynote address from President Trump,” Millan Patterson said in a press release which could be satire if Trump hadn’t killed satire long ago.\u003c/p\u003e\u003cp\u003eIf you only care about whatever Trump says or does, he’ll be at the Anaheim Marriott - 700 West Convention Way - on Friday, September 29. Go with God, if that’s the case because you are beyond earthly help at this point.\u003c/p\u003e\u003cp\u003e If you care about what the California Republican Party used to be, it’s past time to give up the charade and make other plans.\u003c/p\u003e\u003cp\u003eIf you care about democracy over party - America over Trump - then Smith’s indictment is a dark day for our country. As \u003ca href=\"https://www.nytimes.com/live/2023/08/01/us/trump-indictment-jan-6\" target=\"_blank\" rel=\"Follow\"\u003ethe New York Times \u003c/a\u003ewrote: “The charges signify an extraordinary moment in United States history: a former president, in the midst of a campaign to return to the White House, being charged over attempts to use the levers of government power to subvert democracy and remain in office against the will of voters.”\u003c/p\u003e\u003cp\u003eThe substance of Smith’s indictment is stunning. “It accuses Mr. Trump of three conspiracies: one to defraud the United States, a second to obstruct an official government proceeding and a third to deprive people of civil rights provided by federal law or the Constitution,” the Times wrote.\u003c/p\u003e\u003cp\u003eWhat’s equally stunning is how a California Republican Party could still be kissing Trump’s backside when he is poison in California. No Republican candidate has won statewide office in decades. The party could not be more irrelevant and yet, like Trump, sinks lower every time you think that’s not possible.\u003c/p\u003e\u003cp\u003eThe state party had to know this indictment was coming and yet recently changed the rules to give Trump a better chance to win the California primary next year.\u003c/p\u003e\u003cp\u003e“The state’s GOP executive committee changed the rules over the weekend so that any candidate getting a simple majority — 50% plus one — wins all of the state’s 169 delegates,” The Bee reported.\u003c/p\u003e\u003cp\u003e“The previous California system awarded delegates according to who won each of the state’s 52 congressional districts. There were also 13 at-large delegates allocated according to the statewide vote total.”\u003c/p\u003e\u003cp\u003eDavid Gilliard, one of the top GOP consultants in California,\u003ca href=\"https://www.sacbee.com/news/politics-government/election/presidential-election/article277825643.html\" target=\"_blank\" rel=\"Follow\"\u003e told The Bee \u003c/a\u003ewhy this was so stupid.\u003c/p\u003e\u003cp\u003e“The rule is also a self-inflicted wound, as candidates now have no incentive to organize and spend money at the district level. Very disappointing.” \u003c/p\u003e\u003cp\u003eThe Bee editorial board endorsed several Republican candidates in the last election who were elected to the state Legislature and government bodies around the region. These are serious lawmakers trying to make a difference in our state.\u003c/p\u003e\u003cp\u003eWhat do they do now? What does the country do now? \u003c/p\u003e\u003cp\u003eIt’s easy: We choose country over party, America over Trump. And we watch as every Trump enabler does a slow march toward infamy.\u003c/p\u003e\u003cp\u003eI’m looking at you Jessica Millan Patterson and your sad sack CAGOP.\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/277867873",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Marcos Bretón\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:mbreton@sacbee.com\"\u003embreton@sacbee.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "The California GOP hailing Donald Trump on the same day he’s invited is fruit from the same poison tree | Opinion",
+      "lead_media": {
+        "id": "277868723",
+        "url": "https://www.sacbee.com/latest-news/qened3/picture277868723",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "COVER-LEDE.jpg",
+        "publication": "sacbee",
+        "layout_option": "",
+        "home": "/web/v1/sections/3182",
+        "modified_date": 1690927212,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1690927212,
+        "thumbnail": "https://www.sacbee.com/latest-news/qened3/picture277868723/alternates/FREE_1140/COVER-LEDE.jpg",
+        "href": "/web/v1/content/277868723",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3182"
+        ],
+        "credit": "AP",
+        "dateline": "",
+        "caption": "Republican presidential candidate and former President Donald Trump gestures as he leaves a campaign rally Saturday in Erie, Pa. On Tuesday, Special Prosecutor Jack Smith secured an indictment over Trump’s alleged role in interfering with the 2020 election.",
+        "photographer": "Sue Ogrocki",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Sacramento",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "277852618",
+      "url": "https://www.sacbee.com/opinion/article277852618.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "To reverse climate change, Californians must wake up to the influence of Big Oil | Opinion",
+      "publication": "sacbee",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5779",
+      "home_section": {
+        "name": "Opinion",
+        "url": "https://www.sacbee.com/opinion/"
+      },
+      "modified_date": 1691240411,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "California must meet its ambitious climate change goals ",
+      "originating_url": "https://www.sacbee.com/opinion/article277852618.html",
+      "meta_description": "California may not meet its ambitious climate goals because the technologies needed to meet them are not yet viable, but the state must try anyway",
+      "published_date": 1691240400,
+      "thumbnail": "https://www.sacbee.com/opinion/op-ed/soapbox/liqch0/picture183688256/alternates/FREE_1140/California%20Climate%20Change%20Q%20and%20A",
+      "authors": [
+        {
+          "name": "The Sacramento Bee Editorial Board",
+          "email": "opinion@sacbee.com"
+        }
+      ],
+      "keywords": "cap, trade, climate, greenhouse gas, CARB",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "5779",
+        "5781",
+        "3182"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "California may not meet its ambitious climate goals because the technologies needed to meet them are not yet viable, but the state must try anyway",
+      "content": "\u003cp\u003eCalifornia may not meet its \u003ca href=\"https://www.sacbee.com/news/politics-government/capitol-alert/article277730683.html\" target=\"_blank\" rel=\"Follow\"\u003eambitious 2030 climate goals\u003c/a\u003e. That is not necessarily a surprise.\u003c/p\u003e\u003cp\u003eAfter all, that’s what the word “ambitious” means. California must set lofty, near-unattainable goals if we’re going to reverse the effects that climate change has created in our state — unprecedented wildfires, searing heat, and floods, to name a few.\u003c/p\u003e\u003cp\u003eCalifornia must continue to be an impatient, pioneering leader for the rest of the nation, as the federal government so often looks to our state to set the highest standard.\u003c/p\u003e\u003cp\u003eThe California Resources Board, in \u003ca href=\"https://lao.ca.gov/Publications/Report/4656\" target=\"_blank\" rel=\"Follow\"\u003eits new 2022 climate change road map\u003c/a\u003e, set an increased target of reducing greenhouse gas emissions by 2030 to 48% below 1990 levels. Previously, the goal was 40%. In meeting that higher objective, the board predicted it would have to rely heavily on the use of \u003ca href=\"https://business.ca.gov/industries/hydrogen/\" target=\"_blank\" rel=\"Follow\"\u003eemerging technologies\u003c/a\u003e that are \u003ca href=\"https://www.sacbee.com/news/politics-government/capitol-alert/article273962810.html\" target=\"_blank\" rel=\"Follow\"\u003eexpected to help remove carbon pollution\u003c/a\u003e from the atmosphere. There are both engineering ways to capture and store industrial emissions and natural approaches to absorbing carbon emissions such as reforestation. There is hope in “green hydrogen,” splitting of water into hydrogen and oxygen using renewable electricity. Green hydrogen could fuel heavy industries such as trucks and power plants and airplanes. But the technology to produce green hydrogen remains a work in progress. \u003c/p\u003e\u003cp\u003eNow regulators say the emerging technologies they were depending on may not be available by 2030. \u003c/p\u003e\u003cp\u003eSo how to meet the goal? CARB may choose to increase the state’s controversial \u003ca href=\"https://ww2.arb.ca.gov/sites/default/files/cap-and-trade/guidance/chapter1.pdf\" target=\"_blank\" rel=\"Follow\"\u003ecap-and-trade program\u003c/a\u003e, which establishes a limit on major emitters of greenhouse gasses, and creates an economic incentive for corporate investment in cleaner technologies. Some participants are given emission allowances with the ability to purchase more. \u003c/p\u003e\u003cp\u003eIncreasing cap-and-trade standards is not only \u003ca href=\"https://lao.ca.gov/Publications/Report/4656\" target=\"_blank\" rel=\"Follow\"\u003ea dubious solution\u003c/a\u003e to reach CARB’s goal of 48%, but could also drive up carbon prices dramatically and push industrial polluters out of California entirely. While that may make California’s numbers look good, it wouldn’t be a solution to the global problem of climate change and would deeply affect the state’s economy, which is already in a downturn after the pandemic.\u003c/p\u003e\u003cp\u003eIn order to meet our climate goals, however lofty, California has to start making difficult emission cuts. \u003c/p\u003e\u003cp\u003eThe reality is that it’s CARB’s duty to make the state’s progressive climate goals work in the real world — no easy task. \u003ca href=\"https://ww2.arb.ca.gov/sites/default/files/2023-07/nc-CapTradeWorkshop_July272023_0.pdf\" target=\"_blank\" rel=\"Follow\"\u003eAt a recent cap-and-trade program workshop\u003c/a\u003e, regulators from CARB hinted for the first time that the department may struggle to meet those 2030 goals. CARB simply cannot be expected to prevail in this alone, and especially not when huge obstacles are placed in its way by oil lobbyists paying millions to keep the status quo in Sacramento.\u003c/p\u003e\u003cp\u003eA political action committee called “Coalition to Restore California’s Middle-Class Including Energy Companies Who Produce Gas, Oil, Jobs and Pay Taxes” was funded by Chevron, Valero, Phillips 66 and Marathon Petroleum. It spent more than $6 million across the state in 2022, funding the electoral campaigns of moderate Democrats and ensuring the election of a new class of politicians who would be wholly amenable to their influence.\u003c/p\u003e\u003cp\u003eIn the Sacramento area, city councilwoman-turned-state-senator Angelique Ashby — who pledged during her campaign not to take any fossil fuel money — \u003ca href=\"https://capitalandmain.com/oil-pac-buys-1-2-million-in-ads-for-california-democrat-who-vowed-not-to-take-their-money\" target=\"_blank\" rel=\"Follow\"\u003ebenefited from some $1.6 million in oil and gas expenditures from that PAC\u003c/a\u003e.\u003c/p\u003e\u003cp\u003eCARB cannot be expected to meet its ambitious goals if the same politicians that must take actions to achieve these emission reduction numbers (and presumably, the penalties for missing them) are under the influence of oil and gas companies with a vested interest in stymieing the work of CARB. Those interests are keeping gas-guzzling cars on the road and the worst emitters in business via loopholes in the laws. \u003c/p\u003e\u003cp\u003eIt is little wonder CARB is setting the stage for the possibility of missing its ambitious goals. Our state government is too vulnerable to the influence of oil and gas companies. Californians must be aware of this corrosive influence and they must insist that powerful oil lobbyists have no sway over climate regulations nor anything that would hinder the progress of meeting our 2030 emission standards. \u003c/p\u003e\u003cp\u003eIn recent years, more than a dozen other states have chosen to follow California’s more stringent emissions standards, rather than the more flexible federal regulations. In total, \u003ca href=\"https://www.cnn.com/2022/09/06/business/california-emissions-regulations/index.html\" target=\"_blank\" rel=\"Follow\"\u003ethose states represent more than 35% of all new auto sales\u003c/a\u003e in America. California, too, has pledged to stop selling cars that are not electric, hydrogen-fueled or at least plug-in hybrid by the year 2035.\u003c/p\u003e\u003cp\u003eThis state is a national and global leader in carbon regulation and greenhouse gas emissions. It must remain at the forefront to have any chance at reversing climate change. That means clearing hurdles and setting lofty targets — even if we miss.\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/277852618",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy The Sacramento Bee Editorial Board\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:opinion@sacbee.com\"\u003eopinion@sacbee.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "California must continue to be an impatient, pioneering leader for the rest of the nation | Opinion",
+      "lead_media": {
+        "id": "183688256",
+        "url": "https://www.sacbee.com/opinion/op-ed/soapbox/liqch0/picture183688256",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "California Climate Change Q and A",
+        "publication": "sacbee",
+        "layout_option": "",
+        "home": "/web/v1/sections/6672",
+        "modified_date": 1510261608,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1510254269,
+        "thumbnail": "https://www.sacbee.com/opinion/op-ed/soapbox/liqch0/picture183688256/alternates/FREE_1140/California%20Climate%20Change%20Q%20and%20A",
+        "href": "/web/v1/content/183688256",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "6672"
+        ],
+        "credit": "AP file",
+        "dateline": "",
+        "caption": "A truck drives into the Valero refinery in Benicia in July.",
+        "photographer": "Rich Pedroncelli",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Sacramento",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "277833458",
+      "url": "https://www.sacbee.com/opinion/op-ed/article277833458.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "‘Forever chemicals’ are in our bodies and drinking water. We must stop using them | Opinion",
+      "publication": "sacbee",
+      "layout_option": "none",
+      "home": "/web/v1/sections/5787",
+      "home_section": {
+        "name": "Viewpoints",
+        "url": "https://www.sacbee.com/opinion/op-ed/"
+      },
+      "modified_date": 1691803088,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "CA must stop using forever chemicals that harm our health",
+      "originating_url": "https://www.sacbee.com/opinion/op-ed/article277833458.html",
+      "meta_description": "California must stop using PFAS, also known as forever chemicals, that are found in everything from our bodies to drinking water and harm our health",
+      "published_date": 1691758800,
+      "thumbnail": "https://www.kansascity.com/latest-news/wxo9hn/picture277289558/alternates/FREE_1140/pfas_map.jpg",
+      "authors": [
+        {
+          "name": "Phil Ting",
+          "email": ""
+        },
+        {
+          "name": "Andria Ventura",
+          "email": ""
+        }
+      ],
+      "keywords": "pfas, forever chemicals, california, health, water",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "5787",
+        "5853",
+        "3182",
+        "5709",
+        "5779"
+      ],
+      "credit": "Special to The Sacramento Bee",
+      "dateline": "",
+      "summary": "California must stop using PFAS, also known as forever chemicals, that are found in everything from our bodies to drinking water and harm our health",
+      "content": "\u003cp\u003eHave you gotten food in a to-go container? Worn waterproof outdoor gear? Sat on a sofa made with stain-resistant fabric? Then you’ve likely been exposed to per- and polyfluoroalkyl substances, harmful substances commonly referred to as PFAS.\u003c/p\u003e\u003cp\u003eAnother popular name for PFAS is “forever chemicals” \u003ca href=\"https://www.hsph.harvard.edu/news/hsph-in-the-news/protecting-against-forever-chemicals/\" target=\"_blank\" rel=\"Follow\"\u003ebecause, according to Harvard\u003c/a\u003e, “they don’t break down in the environment or in our bodies.”\u003c/p\u003e\u003cp\u003eWith so many of these chemicals in our everyday lives, PFAS have been leaching into our drinking water.\u003c/p\u003e\u003cp\u003eFinally, though, there’s something being done about this. For the first time in more than a quarter century, the federal government is \u003ca href=\"https://www.epa.gov/newsreleases/biden-harris-administration-proposes-first-ever-national-standard-protect-communities\" target=\"_blank\"\u003eproposing strong\u003c/a\u003e\u003ca href=\"https://www.epa.gov/newsreleases/biden-harris-administration-proposes-first-ever-national-standard-protect-communities\" target=\"_blank\"\u003e,\u003c/a\u003e\u003ca href=\"https://www.epa.gov/newsreleases/biden-harris-administration-proposes-first-ever-national-standard-protect-communities\" target=\"_blank\"\u003e enforceable drinking water standards for previously unregulated chemicals. \u003c/a\u003eThe Environmental Protection Agency is taking this extraordinary action because these forever chemicals are spreading through the environment like wildfire, making them also “everywhere chemicals.” New studies consistently find that PFAS are more dangerous than previously thought, causing a \u003ca href=\"https://www.epa.gov/pfas/our-current-understanding-human-health-and-environmental-risks-pfas\" target=\"_blank\"\u003erange of health problems\u003c/a\u003e from cancer to developmental delays in children as well as a reduced ability to fight infections.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:201347249% --\u003e\u003c/p\u003e\u003cp\u003eBecause of the seriousness of PFAS contamination in California, legislators and advocates have joined forces to take actions that significantly reduce the use of PFAS in product categories such as textiles, food packaging and compostable materials. We teamed up on Assembly Bill 1817 last year — phasing out the use of PFAS in fabrics to make them water- or stain-resistant — which became law on January 1.\u003c/p\u003e\u003cp\u003eBut we can’t rely on a piecemeal approach for a class of 14,000 chemicals found in everything from dental floss to raincoats, carpets and medicine.\u003c/p\u003e\u003cp\u003eAdvocates have been sounding the alarm about California’s PFAS crisis for years, but the pace of progress does not yet match the urgency of this growing problem. We don’t manufacture PFAS products in California, but they are nonetheless found everywhere, from \u003ca href=\"https://www.kcra.com/article/study-shows-dangerously-high-levels-toxins-fish-northern-california-rivers/42747129\" target=\"_blank\"\u003erivers\u003c/a\u003e and \u003ca href=\"https://www.google.com/url?q=https://calmatters.org/projects/california-water-contaminated-forever-chemicals/\u0026sa=D\u0026source=docs\u0026ust=1679690535397958\u0026usg=AOvVaw0HyA97VQ2HaAep748FDiRS\" target=\"_blank\"\u003egroundwater\u003c/a\u003e to \u003ca href=\"https://www.cnn.com/2023/03/20/health/pfas-children-wellness/index.html\" target=\"_blank\"\u003eour own bodies\u003c/a\u003e.\u003c/p\u003e\u003cp\u003eSo far, officials have only tested about 3% of California’s public water systems, but two out of three (\u003ca href=\"https://www.google.com/url?q=https://calmatters.org/projects/california-water-contaminated-forever-chemicals/\u0026sa=D\u0026source=docs\u0026ust=1679418676917057\u0026usg=AOvVaw1YmsBoCg5QgR7nYtsG_IiK\" target=\"_blank\"\u003e146 water systems serving 16 million people\u003c/a\u003e) were found to contain PFAS. And it’s not just people that are exposed to PFAS through the water. PFAS pollution has made certain fish from the \u003ca href=\"https://www.sfei.org/sites/default/files/biblio_files/PFAS%20Synthesis%20and%20Strategy.pdf\" target=\"_blank\"\u003eSan Francisco Bay\u003c/a\u003e unsafe to eat, posing a particular risk for people that rely on fish for food, including Tribal communities.\u003c/p\u003e\u003cp\u003eStudies also suggest that annual health-related costs of PFAS are already\u003ca href=\"https://www.nga.org/wp-content/uploads/2021/06/Goldenman_NGA-AAAS_20210603.pdf\" target=\"_blank\"\u003e in the billions\u003c/a\u003e. But widespread contamination is also making it more expensive to deliver safe drinking water at a time when many families are struggling to make ends meet. In Orange County, for example, residents \u003ca href=\"https://www.ocregister.com/2021/07/06/orange-county-launches-first-water-plant-to-remove-pfas-toxins/\" target=\"_blank\"\u003ecould see bills go up $20 per month\u003c/a\u003e to cover close to $1 billion in PFAS treatment.\u003c/p\u003e\u003cp\u003eWhile PFAS are everywhere, some of the state’s highest levels have been found in \u003ca href=\"https://www.nrdc.org/bio/anna-reade/ca-pfas-pollution-widespread-disadvantaged-communities\" target=\"_blank\"\u003edisadvantaged communities\u003c/a\u003e that already bear the brunt of other pollution problems, and may lack resources for clean-up. \u003c/p\u003e\u003cp\u003eThe only way to deliver on California’s promise of safe and affordable drinking water for all is to stop pollution at the source and replace PFAS with safer alternatives. California also needs a comprehensive water testing program as soon as possible.\u003c/p\u003e\u003cp\u003eAll of this is, of course, costly, and we can’t saddle consumers and ratepayers with the cost of these fixes, including the EPA’s proposal to treat drinking water that exceeds its PFAS limits. Corporate polluters that have profited from the sale of PFAS must be held responsible for the harm they have caused and pay for testing and treatment.\u003c/p\u003e\u003cp\u003e3M \u003ca href=\"https://apnews.com/article/pfas-forever-chemicals-3m-drinking-water-81775af23d6aeae63533796b1a1d2cdb\" target=\"_blank\"\u003erecently agreed to pay more than $10 Billion\u003c/a\u003e to help clean up drinking water contaminated with PFAS, but this is just a drop in the bucket compared to the astronomical costs facing communities across the state and country.\u003c/p\u003e\u003cp\u003eWith new PFAS sources coming to light every day and a seemingly endless stream of products containing these chemicals, the only way to truly protect Californians is to stop using PFAS.\u003c/p\u003e\u003cdiv class=\"ng_endnote_contact\"\u003ePhil Ting represents the 19th Assembly District, which includes the west side of San Francisco. Andria Ventura is legislative and policy director for Clean Water Action California, and has worked on water safety for more than 25 years.\u003c/div\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/277833458",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Phil Ting and Andria Ventura\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eSpecial to The Sacramento Bee\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Corporate polluters that have profited from the sale of PFAS must be held responsible for the harm they have caused and pay for testing and treatment.",
+      "lead_media": {
+        "id": "277289558",
+        "url": "https://www.kansascity.com/latest-news/wxo9hn/picture277289558",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "pfas_map.jpg",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1689271422,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1689271422,
+        "thumbnail": "https://www.kansascity.com/latest-news/wxo9hn/picture277289558/alternates/FREE_1140/pfas_map.jpg",
+        "href": "/web/v1/content/277289558",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "USGS",
+        "dateline": "",
+        "caption": "The U.S. Geological Survey released a graphic showing where PFAS were detected in drinking water across the country.",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Sacramento",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": [
+        {
+          "name": "mcc-local-oped"
+        }
+      ]
+    }
+  ]
+}

--- a/data/sports.json
+++ b/data/sports.json
@@ -1,0 +1,1908 @@
+{
+  "items": [
+    {
+      "id": "278285568",
+      "url": "https://www.kansascity.com/sports/college/big-12/university-of-kansas/article278285568.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Renovated KU football stadium will be one of the best, NFL Pro Bowler \u0026 former QB say",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2671",
+      "home_section": {
+        "name": "University of Kansas",
+        "url": "https://www.kansascity.com/sports/college/big-12/university-of-kansas/"
+      },
+      "modified_date": 1692147746,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Former Kansas football players react to stadium renovations",
+      "originating_url": "https://www.kansascity.com/sports/college/big-12/university-of-kansas/article278285568.html",
+      "meta_description": "What do Jayhawk legends Chris Harris and Todd Reesing think of the Kansas football stadium renovation plans? Harris says they’re NFL-level.",
+      "published_date": 1692147137,
+      "thumbnail": "https://www.kansascity.com/latest-news/ezyo53/picture278286643/alternates/FREE_1140/KCM_KUSTADIUM081523TL0389F",
+      "authors": [
+        {
+          "name": "Gary Bedore",
+          "email": "gbedore@kcstar.com"
+        }
+      ],
+      "keywords": "Kansas Jayhawks, KU football, Chris Harris, Todd Reesing, stadium renovation",
+      "access_tags": [
+        "matbasic",
+        "matsport"
+      ],
+      "additional_sections": [
+        "2671",
+        "2415",
+        "84653",
+        "83667",
+        "2662"
+      ],
+      "credit": "",
+      "dateline": "Lawrence",
+      "summary": "What do Jayhawk legends Chris Harris and Todd Reesing think of the Kansas football stadium renovation plans? Harris says they’re NFL-level.",
+      "content": "\u003cp\u003eFour-time Pro Bowler Chris Harris, who won a Super Bowl with the Denver Broncos in 2015, has visited — and competed in — a lot of football stadiums during his four years at the University of Kansas and 12 seasons in the NFL.\u003c/p\u003e\u003cp\u003eThe 34-year-old Tulsa, Oklahoma native, who played defensive back at Kansas from 2007 to 2010, is convinced that the Jayhawks’ soon-to-be renovated David Booth Kansas Memorial Stadium will be one of the best places to watch football in the entire country.\u003c/p\u003e\u003cp\u003e“Oh man … from the looks of it, it’s going to fit right in there with a lot of the top NFL stadiums,” Harris said on Tuesday, speaking with media members after KU \u003ca href=\"https://www.kansascity.com/sports/college/big-12/university-of-kansas/article278243263.html\" target=\"_blank\" rel=\"Follow\"\u003ereleased plans for a new-look stadium to open in August of 2025\u003c/a\u003e.\u003c/p\u003e\u003cp\u003e“A lot of NFL teams are starting to redesign their stadiums kind of in this format,” added Harris, who sat on a stage with KU chancellor Douglas Girod, athletic director Travis Goff, Kansas Gov. Laura Kelly, football coach Lance Leipold and running back Devin Neal at a stadium-unveiling extravaganza at the Jayhawk Welcome Center, across from the Kansas Union on campus.\u003c/p\u003e\u003cp\u003e“They are older stadiums doing a lot of reconstruction things. This is the new standard. It’s the new level standard,” Harris added of KU’s upcoming renovated stadium. “It’s going to have multiple events. You are going to have concerts, all types of things going on in this stadium. It’s going to be great. I would call it all-purpose. It’ll be an all-purpose events center to me.”\u003c/p\u003e\u003cp\u003eKU’s stadium renovation plan is part of a proposed Gateway District to campus to include new retail and dining amenities and possibly office spaces, a hotel and maybe even a new campus dorm.\u003c/p\u003e\u003cp\u003eThe \u003ca href=\"https://www.kansascity.com/sports/college/big-12/university-of-kansas/article278283188.html\" target=\"_blank\" rel=\"Follow\"\u003eentire project has a $300 million price tag\u003c/a\u003e, of which $50 million is going to Allen Fieldhouse renovations.\u003c/p\u003e\u003cp\u003eThe actual football field will include seating that is closer to the action on the field. There will be chair-back seating in the west and north seating areas and a videoboard 2 1/2 times larger than the current one — and 60 feet closer to the field.\u003c/p\u003e\u003cp\u003eAlso, there will be a 50% increase in area per seat and 50% more leg room, per a KU release. There will be 2,300 club seats in three different locations, social zones and concourses with four times more food and beverage options than now, as well as new restrooms.\u003c/p\u003e\u003cp\u003eAnother former KU football standout, Todd Reesing, also chimed in on the same question put to Harris: Where will this renovated stadium rank out of all stadiums?\u003c/p\u003e\u003cp\u003e“It’s tough to get the final experience from just the renderings,” the 35-year-old Reesing, who played at KU from 2006 to 2009, said. “From the view of having the Campanile (north of stadium) there from a visual standpoint, coupled with fans being much more on top of the field to create more volume and crowd noise, I think it’s going to be as good as any place to play in the Big 12.”\u003c/p\u003e\u003cp\u003eHe said it’s vital KU improves its football stadium.\u003c/p\u003e\u003cp\u003e“It is a huge recruiting tool,” Reesing said. “The recruiting landscape has changed with NIL, with facilities, with different uniform combinations. All that factors in to try to get the best talent.\u003c/p\u003e\u003cp\u003e“For KU to compete at the level we all want them to compete at, to win championships, to go to bowl games, we have to have facilities that match that. The fact we are putting that as a priority from the chancellor down to the athletic director shows that is an important driver for Kansas to generate more revenue to support other sports, also to create excitement in the university as a whole.”\u003c/p\u003e\u003cp\u003eHarris agreed that college football “has just exploded. With the way the NCAA has changed.”\u003c/p\u003e\u003cp\u003e“With NIL, it’s totally different compared to when I played.,” Harris said. “You’ve got to be able to compete with the other schools. Innovation and things coaches are bringing to the table to get guys, it’s all competition. Recruiting is a competition. We have to have these facilities, this new stadium to be able to keep up with the top schools in the nation.”\u003c/p\u003e\u003cp\u003eReesing actually sampled part of the renovation project on Tuesday. He worked out in KU’s \u003ca href=\"https://www.kansascity.com/sports/college/big-12/university-of-kansas/article278024078.html\" target=\"_blank\" rel=\"Follow\"\u003enewly remodeled weight room in the Anderson Family Football Complex\u003c/a\u003e.\u003c/p\u003e\u003cp\u003e“The weight room … it brought back some memories to get back in there and lift a little bit of weights before we got to the big announcement today,” Reesing said. “To see the first phase of the renovation, the locker room, the weight room, they did an amazing job. I can’t wait to see what they are going to do with the rest of this stuff the next couple years.”\u003c/p\u003e\u003cp\u003eHarris, who played last season with the New Orleans Saints but is not in an NFL camp at this time, did not work out in Lawrence on Tuesday. \u003c/p\u003e\u003cp\u003eNow living in Dallas, he said returning to Lawrence would be a priority each fall from now on.\u003c/p\u003e\u003cp\u003e“I’m looking forward to coming back here, having a great time in that stadium. That’s what I’m looking forward to as a former player,” Harris said. “The guys coming up, guys playing now can build that brick, keep that excitement going so when it’s time to get in that new stadium the excitement is through the roof. That’s their job, to keep the same momentum we have now, to turn it up another level when it’s time for the new stadium to open.”\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278285568",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Gary Bedore\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:gbedore@kcstar.com\"\u003egbedore@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "A former Kansas football player and four-time NFL Pro Bowler says the Jayhawks’ renovated stadium will mirror “a lot of the top NFL stadiums.”",
+      "lead_media": {
+        "id": "278286643",
+        "url": "https://www.kansascity.com/latest-news/ezyo53/picture278286643",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "KCM_KUSTADIUM081523TL0389F",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1692142685,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692142685,
+        "thumbnail": "https://www.kansascity.com/latest-news/ezyo53/picture278286643/alternates/FREE_1140/KCM_KUSTADIUM081523TL0389F",
+        "href": "/web/v1/content/278286643",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "tljungblad@kcstar.com",
+        "dateline": "",
+        "caption": "Former Kansas football player Chris Harris Jr. addresses the crowd as the University of Kansas and Kansas Athletics revealed plans Wednesday, Aug. 15, 2023, for renovations to David Booth Kansas Memorial Stadium and a campus Gateway Project in Lawrence.",
+        "photographer": "Tammy Ljungblad",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278286828",
+      "url": "https://www.kansascity.com/sports/spt-columns-blogs/for-petes-sake/article278286828.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "KU enlisted Kevin Harlan to narrate video of proposed Memorial Stadium renovations",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/6607",
+      "home_section": {
+        "name": "For Pete's Sake",
+        "url": "https://www.kansascity.com/sports/spt-columns-blogs/for-petes-sake/"
+      },
+      "modified_date": 1692145940,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Kevin Harlan narrated video of proposed stadium renovations",
+      "originating_url": "https://www.kansascity.com/sports/spt-columns-blogs/for-petes-sake/article278286828.html",
+      "meta_description": "Legendary broadcaster Kevin Harlan narrated a Kansas Jayhawks video with a look at renovations for David Booth Kansas Memorial Stadium.",
+      "published_date": 1692145940,
+      "thumbnail": "https://www.kansascity.com/latest-news/j768hj/picture278287823/alternates/FREE_1140/KevinHarlan.jpg",
+      "authors": [
+        {
+          "name": "Pete Grathoff",
+          "email": "pgrathoff@kcstar.com"
+        }
+      ],
+      "keywords": "Kevin Harlan, Kansas Jayhawks, video, football stadium",
+      "access_tags": [
+        "matbasic",
+        "matsport"
+      ],
+      "additional_sections": [
+        "6607",
+        "2415",
+        "84653",
+        "2662",
+        "2671"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Legendary broadcaster Kevin Harlan narrated a Kansas Jayhawks video with a look at renovations for David Booth Kansas Memorial Stadium.",
+      "content": "\u003cp\u003eKansas Athletics and the University of Kansas on Tuesday \u003ca href=\"https://www.kansascity.com/sports/college/big-12/university-of-kansas/article278243263.html\" target=\"_blank\" rel=\"Follow\"\u003eshared a look at renderings\u003c/a\u003e for the “Gateway” project and David Booth Kansas Memorial Stadium.\u003c/p\u003e\u003cp\u003eFans who follow Kansas Athletics on X (née Twitter) saw a video with those renderings, and it was narrated by legendary broadcaster Kevin Harlan.\u003c/p\u003e\u003cp\u003eShortly after graduating from the University of Kansas, Harlan became the Chiefs’ radio voice. These days he can be heard calling NFL games on CBS and NBA contests on Turner Sports.\u003c/p\u003e\u003cp\u003eHe is one of the most popular broadcasters working today and a natural choice for the video, given his ties to the University of Kansas.\u003c/p\u003e\u003cp\u003eHere is what Harlan says in the KU video: \u003c/p\u003e\u003cp\u003e\u003ci\u003eFrom the very beginning, Kansans have been known as builders, pioneers, Jayhawkers. Piece by piece, rock by rock, our state and our flagship university were built upon the traits of our forefathers. Unyielding, bold, resilient, relentless in every pursuit. We are trailblazers with a transformative vision to chart a new course. With an eye for innovation, but with an appreciation for our heritage. We launch into a previously unattainable new chapter for the University of Kansas. We are Jayhawks. \u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eNow, 158 years after the university became glorious to view, the stars have aligned for a new vision, one that exhibits the highest commitment to excellence and an unbridled ambition to impact our athletics program, institution, community and state at an even greater level: the “Gateway District” and the new David Booth Kansas Memorial Stadium. The entry point to our beautiful campus. \u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eA place where Rock Chalk is more than our victory chant. It is a connection to the foundation upon which it was built. From the waving wheat fields across the state to the limestone embedded in our hills, this exceptional project will pay heed to our tradition and heritage while revealing a new KU. It is a transformational new home, fit a football program that has gone through its own reconstruction. This is an audacious new era for the University of Kansas.\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eJoin us ever onward ... to the stars.\u003c/i\u003e\u003c/p\u003e\u003cp\u003eHere \u003ca href=\"https://twitter.com/KUAthletics/status/1691535941775577089?s=20\" target=\"_blank\" rel=\"Follow\"\u003eis the video\u003c/a\u003e.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278287028% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278286828",
+      "allow_ads": true,
+      "allow_stn_player": false,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Pete Grathoff\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:pgrathoff@kcstar.com\"\u003epgrathoff@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "The legendary broadcaster is a Kansas graduate.",
+      "lead_media": {
+        "id": "278287823",
+        "url": "https://www.kansascity.com/latest-news/j768hj/picture278287823",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "KevinHarlan.jpg",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1692145477,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692145477,
+        "thumbnail": "https://www.kansascity.com/latest-news/j768hj/picture278287823/alternates/FREE_1140/KevinHarlan.jpg",
+        "href": "/web/v1/content/278287823",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "USA TODAY Sports",
+        "dateline": "",
+        "caption": "Sports broadcaster Kevin Harlan",
+        "photographer": "Brace Hemmelgarn",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": [
+        {
+          "name": "mcc-timely-ta"
+        }
+      ]
+    },
+    {
+      "id": "278243263",
+      "url": "https://www.kansascity.com/sports/college/big-12/university-of-kansas/article278243263.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "KU Jayhawks announce timeline \u0026 release renderings for football stadium renovations",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2671",
+      "home_section": {
+        "name": "University of Kansas",
+        "url": "https://www.kansascity.com/sports/college/big-12/university-of-kansas/"
+      },
+      "modified_date": 1692145922,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Renderings \u0026 timeline for KU’s Memorial Stadium renovation",
+      "originating_url": "https://www.kansascity.com/sports/college/big-12/university-of-kansas/article278243263.html",
+      "meta_description": "The Kansas Jayhawks released a 1st look at football stadium renovations \u0026 updated construction timeline at 11th and Mississippi in Lawrence.",
+      "published_date": 1692128472,
+      "thumbnail": "https://www.kansascity.com/latest-news/eslj31/picture278276808/alternates/FREE_1140/HNTB_KansasStadium_Homeworld_FINAL%20FINAL.png",
+      "authors": [
+        {
+          "name": "Shreyas Laddha",
+          "email": "sladdha@kcstar.com"
+        }
+      ],
+      "keywords": "Kansas Jayhawks, KU football, David Booth Kansas Memorial Stadium, construction, renovation",
+      "access_tags": [
+        "matbasic",
+        "matsport"
+      ],
+      "additional_sections": [
+        "2671",
+        "2414",
+        "97091",
+        "95238",
+        "2415",
+        "94902",
+        "84653",
+        "83667",
+        "2662",
+        "2732"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "The Kansas Jayhawks released a 1st look at football stadium renovations \u0026 updated construction timeline at 11th and Mississippi in Lawrence.",
+      "content": "\u003cp\u003eThe University of Kansas and Kansas Athletics jointly announced on Tuesday morning a new timeline for stadium renovations and circulated renderings for the 11th and Mississippi “Gateway” project.\u003c/p\u003e\u003cp\u003eMost notably, the school’s news release on the project promises “a transformed David Booth Kansas Memorial Stadium to open in August 2025,” with construction to start this December, after the end of the 2023 college football regular season.\u003c/p\u003e\u003cp\u003eThe stadium and surrounding area renovations will take place in two phases. For the 2024 season, Kansas’ Memorial Stadium will have a reduced capacity.\u003cb\u003e \u003c/b\u003e\u003c/p\u003e\u003cp\u003eKansas athletic director Travis Goff emphasized that stadium capacity for the 2024 season will be more than 40,000. He also stressed the importance of fan support \u003ca href=\"https://www.kansascity.com/sports/college/big-12/university-of-kansas/article278283188.html\" target=\"_blank\" rel=\"Follow\"\u003ein fundraising for the stadium project\u003c/a\u003e. \u003c/p\u003e\u003cp\u003eKansas has partnered with Turner Construction Company as the construction manager for the project, per the release, and local design firms HNTB and Multistudio “have taken the design lead on the Gateway District” and stadium.\u003c/p\u003e\u003cp\u003eHere are more details about the project, as announced Tuesday:\u003c/p\u003e\u003ch3\u003eRenovations to David Booth Kansas Memorial Stadium\u003c/h3\u003e\u003cp\u003eRenovations to KU’s football stadium — and surrounding areas — will be carried out over two phases.\u003c/p\u003e\u003cp\u003e\u003cb\u003ePhase 1 renovations:\u003c/b\u003e\u003c/p\u003e\u003cp\u003eThe first stage of renovations will involve changes to the southwest, west and north sides of the stadium. That includes a new conference center on the north end and the expansion of Anderson Family Football Complex (which \u003ca href=\"https://www.kansascity.com/sports/college/big-12/university-of-kansas/article278024078.html\" target=\"_blank\" rel=\"Follow\"\u003eunveiled new locker room and training facilities\u003c/a\u003e last week).\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278080062% --\u003e\u003c/p\u003e\u003cp\u003eThe release said construction on the first phase will begin at the end of the 2023 football season and will be completed by the start of the 2025 season.\u003c/p\u003e\u003cp\u003e“Kansas Athletics has set an initial fundraising goal of $300 million for David Booth Kansas Memorial Stadium and Allen Fieldhouse capital projects, which is currently under construction,” the release said. “A total of $165 million in gifts and commitments have been secured, including $125 million since the project was announced last October.”\u003c/p\u003e\u003cp\u003eAccording to Goff, $250 million will go to the stadium while $50 million will go toward \u003ca href=\"https://www.kansascity.com/sports/college/big-12/university-of-kansas/article276037761.html\" target=\"_blank\" rel=\"Follow\"\u003eAllen Fieldhouse renovations, which are currently underway\u003c/a\u003e.\u003c/p\u003e\u003cp\u003eOther renovations to the Anderson Family Football Complex include a new sports medicine center — featuring hydrotherapy pools, cryotherapy chambers and infrared light therapy equipment — as well as a 2,300-square-foot player lounge.\u003c/p\u003e\u003cp\u003eThere are also plans for a 1,200-square-foot video studio and 2,400-square-foot student services center, as well as a 180-seat team meeting room and 2,400-square-foot “virtual practice walkthrough room,” per the release.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278276808; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003eThe stadium upgrades will include chair-back seating, a video board that is two-and-a-half times bigger, a 50% increase in the area per seat, four times as many food and beverage offerings and “at least 1.5 times more restrooms,” the release said.\u003c/p\u003e\u003cp\u003e\u003cb\u003ePhase 2 renovations:\u003c/b\u003e\u003c/p\u003e\u003cp\u003eThe second phase of stadium renovations will involve the south and east portions of the stadium, including “the development of multi-use facilities to be used throughout the year to generate revenue for academic programming and student success,” per the release.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278277188; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003eThose facilities are still in development but are expected to include dining options, retail space, office space and lodging, as well as space for “arts and entertainment,” the release said.\u003c/p\u003e\u003ch3\u003eParking and Wi-Fi \u003c/h3\u003e\u003cp\u003eKU chancellor Douglas Girod said parking won’t change too much in the first phase. KU is currently looking at two to three different options and “stacked parking” could be a potential option.\u003c/p\u003e\u003cp\u003eGoff said he’s aware the reputation for the stadium isn’t great, but KU plans to fix that — just don’t expect it to happen right away.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278286303; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003e“We’ll make sure we have the best Wi-Fi that exists at the moment it’s installed,” Goff said. “Likely fast-forward to 2025 for major upgrades there.”\u003c/p\u003e\u003ch3\u003eCommunity benefit\u003c/h3\u003e\u003cp\u003eAccording to the release, KU and KU Athletics expect the project to “undoubtedly help in economic growth for the city of Lawrence and University of Kansas.”\u003c/p\u003e\u003cp\u003e“The mixed-use development is projected to amount to $2.4 billion in direct, indirect and induced spending and $1.4 billion in direct, indirect and induced earnings, while supporting an estimated 720 jobs,” the release said. “Construction of the mixed-use development will create an additional 670 temporary jobs, $2.2 million in state sales tax and $2.4 million in state personal income tax.\u003c/p\u003e\u003cp\u003e“An estimated 500,000 prospective students and guests who visit the University of Kansas each year would utilize and benefit from the Gateway District and David Booth Kansas Memorial Stadium.”\u003c/p\u003e\u003cp\u003eKansas Gov. Laura Kelly emphasized the impact the project will have on the state of Kansas as a whole. \u003c/p\u003e\u003cp\u003e“The multi-use campus facilities spoken about have endless possibilities in terms of making Kansas the premier state to host state and national conventions,” Kelly said. “The (David Booth Kansas) Memorial Stadium upgrade is projected to support 2,600 temporary jobs that are underway and 240 permanent jobs once it’s complete. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278286668; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003e“This will generate millions of dollars in sales and income taxes that will go toward making Kansas a better place for everyone in every corner of the state for generations to come.” \u003c/p\u003e\u003ch3\u003eWhat they’re saying\u003c/h3\u003e\u003cp\u003eKU chancellor Douglas Girod, athletic director Travis Goff and football coach Lance Leipold were all quoted in the release announcing the news.\u003c/p\u003e\u003cp\u003e\u003ci\u003eFrom Girod:\u003c/i\u003e\u003c/p\u003e\u003cp\u003e“The Gateway District is a once-in-a-generation project to transform our campus and drive economic development throughout the region. Specifically, this project will create exciting new amenities for students, employees and visitors while providing Kansas Football the facilities it needs to compete at the highest level.”\u003c/p\u003e\u003cp\u003e\u003ci\u003eFrom Goff:\u003c/i\u003e\u003c/p\u003e\u003cp\u003e“The cumulative impact of a world-class football operations complex and one of the finest game day venues in the country catapults Kansas Football, and our entire athletics program, into this critical next chapter. We have a proud history, but this unprecedented investment makes a powerful statement about an even brighter future and provides far-reaching impact for our university community, fans and football program. I am grateful for the leadership of Chancellor Girod and the visionary donors who have propelled this generational project forward.”\u003c/p\u003e\u003cp\u003e\u003ci\u003eFrom Leipold:\u003c/i\u003e\u003c/p\u003e\u003cp\u003e“This project is vital to the continued growth of our program. We are incredibly appreciative of the commitment shown by our generous donors, Chancellor Girod, Travis Goff and many others. The substantial upgrades to David Booth Kansas Memorial Stadium and Anderson Family Football Complex will greatly enhance the student-athlete experience. I am very much looking forward to seeing that come to life.”\u003c/p\u003e\u003cp\u003e\u003ci style=\"\"\u003eAnd from Kansas running back Devin Neal:\u003c/i\u003e\u003c/p\u003e\u003cp\u003e“Nearly 3 1/2 years ago I committed here because I was confident that better days are ahead. As a proud Lawrence native, I wanted to help lay the foundation for the program that was a sleeping giant.\u003c/p\u003e\u003cp\u003e“Momentum is already real, but today It went to another level. Sitting here and seeing the future of David Booth Kansas Memorial Stadium and the ‘Gateway’ just gives you chills. We’re laying another brick today and it’s a major one. Brick by brick, we are changing this football program.”\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278243263",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Shreyas Laddha\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:sladdha@kcstar.com\"\u003esladdha@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "Kansas Athletics has released new renderings of what the renovations to David Booth Kansas Memorial Stadium, and the surrounding areas, will look like.",
+      "lead_media": {
+        "id": "278276808",
+        "url": "https://www.kansascity.com/latest-news/eslj31/picture278276808",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "HNTB_KansasStadium_Homeworld_FINAL FINAL.png",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1692127853,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692127853,
+        "thumbnail": "https://www.kansascity.com/latest-news/eslj31/picture278276808/alternates/FREE_1140/HNTB_KansasStadium_Homeworld_FINAL%20FINAL.png",
+        "href": "/web/v1/content/278276808",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "Contributed by KU Athletics",
+        "dateline": "",
+        "caption": "A first look at renderings of David Booth Kansas Memorial Stadium, with renovations expected to be underway in December of 2023 until August of 2025.",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278266428",
+      "url": "https://www.kansas.com/sports/college/big-12/kansas-state/article278266428.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Three takeaways from Kansas State’s summer basketball game against Israel Select",
+      "publication": "kansas",
+      "layout_option": "none",
+      "home": "/web/v1/sections/3318",
+      "home_section": {
+        "name": "Kansas State University",
+        "url": "https://www.kansas.com/sports/college/big-12/kansas-state/"
+      },
+      "modified_date": 1692145562,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "K-State Wildcats vs. Israel Select: Game recap and analysis",
+      "originating_url": "https://www.kansas.com/sports/college/big-12/kansas-state/article278266428.html",
+      "meta_description": "The Kansas State Wildcats defeated Israel Select in their first basketball game of a trip through the Middle East. Some thoughts on the win.",
+      "published_date": 1692124175,
+      "thumbnail": "https://www.kansas.com/latest-news/uwlhoc/picture274548926/alternates/FREE_1140/20230323_add_jo9_027.JPG",
+      "authors": [
+        {
+          "name": "Kellis Robinett",
+          "email": "krobinett@wichitaeagle.com"
+        }
+      ],
+      "keywords": "Kansas State, K-State, Wildcats, Basketball, Israel",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "3318",
+        "3375",
+        "3035",
+        "3315"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "The Kansas State Wildcats defeated Israel Select in their first basketball game of a trip through the Middle East. Some thoughts on the win.",
+      "content": "\u003cp\u003eThe Kansas State men’s basketball team took the court for its first game of its foreign trip to the Middle East on Tuesday.\u003c/p\u003e\u003cp\u003eThe Wildcats defeated Israel Select 94-87 in a back-and-forth game at Hadar Yosef Arena in Tel Aviv, Israel. \u003c/p\u003e\u003cp\u003e\u003ci\u003eHere are three takeaways from the game before Jerome Tang and his players return to action for their second game of their summer trip later this week:\u003c/i\u003e\u003c/p\u003e\u003ch3\u003eArthur Kaluma is going to be an impact transfer\u003c/h3\u003e\u003cp\u003eIt’s foolish to jump to any grand conclusions about K-State basketball based on the results of a single exhibition game played against foreign competition halfway across the world.\u003c/p\u003e\u003cp\u003eThat being said, it was hard not to be impressed by Arthur Kaluma.\u003c/p\u003e\u003cp\u003eThe Creighton transfer wasted no time making an impact for the Wildcats on the wing, as he scored the first eight points of the day for his team. He opened up the scoring by draining a 3 from the top of the key. Then he knocked down another 3 and converted a layup to give K-State an 8-7 lead.\u003c/p\u003e\u003cp\u003eHe was far from done. Kaluma went on make plays on the perimeter and in the paint on his way to a team-high 23 points.\u003c/p\u003e\u003cp\u003eOne of his best moments came on a fadeaway jumper in the lane that gave the Wildcats a 66-59 lead late in the third quarter. He didn’t settle for anything.\u003c/p\u003e\u003cp\u003eThere were some questions about how long it would take him to fit into Tang’s offense as a newcomer, but it seems like he is making an easy transition to his surroundings. Kaluma should provide a scoring spark on the wing and help K-State replace Keyonte Johnson this season.\u003c/p\u003e\u003cp\u003eIt’s also worth mentioning that Tylor Perry hit some important shots in his first game action with the Wildcats. He scored 17 points. The North Texas transfer wasn’t quite as impressive as Kaluma, but his ability to make shots on the perimeter helped K-State in this one.\u003c/p\u003e\u003ch3\u003eCam Carter appears ready for a bigger role\u003c/h3\u003e\u003cp\u003eK-State relied so heavily on its top three scorers last season that Cam Carter occasionally got lost in the shadows of Markquis Nowell, Nae’Qwan Tomlin and Johnson. But there will be nowhere for him to hide next season. It seems like he is good with that.\u003c/p\u003e\u003cp\u003eCarter looked like a more aggressive player in this game on his way to 17 points.\u003c/p\u003e\u003cp\u003eHe fired away when he was open from 3-point range, broke free for a transition dunk and was involved on defense. He also had a nifty full-court assist in the fourth quarter.\u003c/p\u003e\u003cp\u003eWas it a perfect game for the junior? No, far from it. But it’s clear he is ready, and capable, of being more than just a solid role player for the Wildcats from now on.\u003c/p\u003e\u003cp\u003eR.J. Jones was also a key contributor in the backcourt, as he finished with 13 points.\u003c/p\u003e\u003ch3\u003eWildcats show resilience in exhibition game\u003c/h3\u003e\u003cp\u003eFor a while, it looked like K-State might cruise to an easy victory over Israel Select.\u003c/p\u003e\u003cp\u003eIt didn’t work out that way.\u003c/p\u003e\u003cp\u003eIsrael Select fought back from an early deficit and took a 44-43 lead early into the third quarter. It was a back-and-forth game from there, with Israel Select tying things up at 78-78 with 5:03 to play. It was anybody’s game.\u003c/p\u003e\u003cp\u003eVictory was far from a given on the road against a team of professional basketball players. But the Wildcats dug deep and found a way to pull away for the win.\u003c/p\u003e\u003cp\u003eK-State toughened up on defense and started to get a lot of stops. Kaluma and Perry both hit some big shots to give the Wildcats a lead. Carter got to the free-throw line. Tang was able to celebrate a win on foreign soil.\u003c/p\u003e\u003cp\u003eWinning isn’t always the most important thing on a trip like this. Sometimes it’s more important to spread minutes around and let everyone on the team gain valuable on-court experiences before the season arrives. Tang even said beforehand that he wasn’t concerned about wins or losses in this summer. But K-State found a way to win all the same.\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278266428",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Kellis Robinett\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:krobinett@wichitaeagle.com\"\u003ekrobinett@wichitaeagle.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "The Kansas State Wildcats got off to a winning start in Israel. Here’s what you need to know about their victory on Tuesday",
+      "lead_media": {
+        "id": "274548926",
+        "url": "https://www.kansas.com/latest-news/uwlhoc/picture274548926",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "20230323_add_jo9_027.JPG",
+        "publication": "kansas",
+        "layout_option": "",
+        "home": "/web/v1/sections/3035",
+        "modified_date": 1692124010,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1682021221,
+        "thumbnail": "https://www.kansas.com/latest-news/uwlhoc/picture274548926/alternates/FREE_1140/20230323_add_jo9_027.JPG",
+        "href": "/web/v1/content/274548926",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3035"
+        ],
+        "credit": "USA TODAY NETWORK",
+        "dateline": "",
+        "caption": "Kansas State Wildcats head coach Jerome Tang reacts as he works the bench against the Michigan State Spartans in the first half at Madison Square Garden on March 23, 2023.",
+        "photographer": "Robert Deutsch",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Wichita",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278283188",
+      "url": "https://www.kansascity.com/sports/college/big-12/university-of-kansas/article278283188.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "KU will soon start football stadium renovations. How are the Jayhawks paying for it?",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2671",
+      "home_section": {
+        "name": "University of Kansas",
+        "url": "https://www.kansascity.com/sports/college/big-12/university-of-kansas/"
+      },
+      "modified_date": 1692144670,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "How is Kansas paying for football stadium renovations?",
+      "originating_url": "https://www.kansascity.com/sports/college/big-12/university-of-kansas/article278283188.html",
+      "meta_description": "Kansas is still fundraising for the costs of football stadium renovations and a convention center. State and federal dollars will help KU.",
+      "published_date": 1692144019,
+      "thumbnail": "https://www.kansascity.com/latest-news/edgnr0/picture278286293/alternates/FREE_1140/KCM_KUSTADIUM081523TL0199F",
+      "authors": [
+        {
+          "name": "Katie Bernard",
+          "email": "cbernard@kcstar.com"
+        },
+        {
+          "name": "Shreyas Laddha",
+          "email": "sladdha@kcstar.com"
+        }
+      ],
+      "keywords": "Kansas Jayhawks, KU football, tax dollars, funding, David Booth Kansas Memorial Stadium",
+      "access_tags": [
+        "matbasic",
+        "matsport"
+      ],
+      "additional_sections": [
+        "2671",
+        "2415",
+        "84653",
+        "2662"
+      ],
+      "credit": "",
+      "dateline": "Lawrence",
+      "summary": "Kansas is still fundraising for the costs of football stadium renovations and a convention center. State and federal dollars will help KU.",
+      "content": "\u003cp\u003eBy the end of the year, the University of Kansas will \u003ca href=\"https://www.kansascity.com/sports/college/big-12/university-of-kansas/article278243263.html\" target=\"_blank\" rel=\"Follow\"\u003ebegin construction on a more than $300 million project\u003c/a\u003e to renovate the school’s football stadium and the area around it. \u003c/p\u003e\u003cp\u003eUniversity officials are still working to raise another $135 million for the project. \u003c/p\u003e\u003cp\u003eIn a release Tuesday, university officials said they planned to open the new stadium in time for the 2025 college football season. The “Kansas Gateway District” will ultimately include a new convention center near the stadium as well as a multi-use space to house restaurants, retail, lodging, offices and “arts and entertainment.”\u003c/p\u003e\u003cp\u003eMost of the funding will be dedicated to the football stadium and “Gateway” project, while $50 million \u003ca href=\"https://www.kansascity.com/sports/college/big-12/university-of-kansas/article276037761.html\" target=\"_blank\" rel=\"Follow\"\u003ewill go to Allen Fieldhouse renovations\u003c/a\u003e.\u003c/p\u003e\u003cp\u003eThe university said it planned to primarily use private donors to fund the project and would not use student tuition dollars or the Kansas state general fund, the primary fund of tax revenues which builds the state’s yearly budget. \u003c/p\u003e\u003cp\u003eIf the university fails to meet its fundraising goal, KU still has a plan in place, according to Kansas athletic director Travis Goff.\u003c/p\u003e\u003cp\u003e“To emphasize also that (donor funding is) the primary funding vehicle,” Goff said, “(KU) Athletics if needed can borrow against the project and borrow against future revenues that the project will drive that allows us to invest in an even higher level to see this through. The final maybe comment to that is what we’ve built today achieves approximately 70% of a new facility. We have work to do to tackle the east and kind of of that connectivity to the south (to) finish this whole vision.” \u003c/p\u003e\u003cp\u003eHere are the financial components going into the project and how the university plans to raise the remainder. \u003c/p\u003e\u003ch3\u003eGovernment spending\u003c/h3\u003e\u003cp\u003eThough the university said it used no state general fund dollars to finance the project, $85 million in government spending will be used. \u003c/p\u003e\u003cp\u003eThat funding includes a $50 million grant from the Kansas Department of Commerce and $35 million in federal COVID-19 relief dollars. The government funds will be focused on the portions of the project aimed at economic development, such as the convention center and multi-use spaces, rather than the new stadium itself. \u003c/p\u003e\u003cp\u003eLast year, Kansas lawmakers allocated $75 million to the Kansas Department of Commerce to create the University Challenge Grant Program using federal COVID-19 relief dollars. The program provides matching funds to Kansas colleges pursuing economic development funds. \u003c/p\u003e\u003cp\u003eIn February the agency announced recipients, including $50 million for the University of Kansas. \u003c/p\u003e\u003cp\u003eThe Legislature also allocated $35 million to the university last year from the $1.2 billion sent to the state through the American Rescue Plan Act. The American Rescue Plan ACT was a COVID-19 relief package signed by President Joe Biden. The funding for KU was earmarked for economic development.\u003c/p\u003e\u003cp\u003eAt an event announcing the project’s timeline, KU chancellor Douglas Girod said the two pots of money allocated by the Legislature last year were important “to really kick off this program.” \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278286668; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003eDemocratic Gov. Laura Kelly presented the project as an extension of her administration’s focus on economic development and job growth, bringing 720 jobs to Lawrence and the potential for national and regional conventions. \u003c/p\u003e\u003cp\u003e“These new and improved facilities will benefit not only KU, by increasing student enrollment and attracting new visitors to campus, but also the surrounding community and our entire state,” Kelly said. “More talented students graduating from KU means more talented people entering the Kansas workforce.”\u003c/p\u003e\u003ch3\u003eFundraising\u003c/h3\u003e\u003cp\u003eThus far, the University has raised $165 million of its $300 million funding goal, officials said. \u003c/p\u003e\u003cp\u003eAround $125 million of that fundraising has come since the project was announced last year. David Booth, a KU alumnus and donor, \u003ca href=\"https://www2.kusports.com/news/2017/sep/23/donor-david-booth-explains-his-50m-gift-ku-footbal/\"\u003eannounced in 2017\u003c/a\u003e he would give the university $50 million for the new stadium. The donation was spread out into $10 million installments per year. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278286303; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003eKU officials said the university was still working to raise the additional $135 million to reach their goal. \u003c/p\u003e\u003cp\u003e“The total goal from a fundraising perspective is $300 million, of which about 250 is allocated for this project remaining and 50 is focused on Allen Fieldhouse renovations that are underway,” Goff said. “We’re not going to just hit 300 — we’re going to surpass it. So, that’s (what) it’s going to take, and we have great confidence in our momentum and fundraising perspective of the way our supporters have stepped up.”\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278283188",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Katie Bernard and Shreyas Laddha\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:cbernard@kcstar.com\"\u003ecbernard@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:sladdha@kcstar.com\"\u003esladdha@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "About $85 million for KU’s “Gateway” project, which includes football stadium renovations, will come from government spending. But there are several components.",
+      "lead_media": {
+        "id": "278286293",
+        "url": "https://www.kansascity.com/latest-news/edgnr0/picture278286293",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "KCM_KUSTADIUM081523TL0199F",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1692142302,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692142302,
+        "thumbnail": "https://www.kansascity.com/latest-news/edgnr0/picture278286293/alternates/FREE_1140/KCM_KUSTADIUM081523TL0199F",
+        "href": "/web/v1/content/278286293",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "tljungblad@kcstar.com",
+        "dateline": "",
+        "caption": "Kansas Gov. Laura Kelly shakes hands with KU athletic director Travis Goff and chancellor Douglas Girod, right, after Kelly addressed the crowd regarding plans for renovations to David Booth Kansas Memorial Stadium and a campus Gateway Project in Lawrence on Wednesday, Aug. 15, 2023.",
+        "photographer": "Tammy Ljungblad",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278272203",
+      "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278272203.html",
+      "asset_type": "videoIngest",
+      "brightcove_id": "",
+      "state": "published",
+      "title": "Chiefs rookie describes how it felt to experience NFL stage for first time",
+      "publication": "kansascity",
+      "layout_option": "",
+      "home": "/web/v1/sections/2694",
+      "home_section": {
+        "name": "Chiefs",
+        "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/"
+      },
+      "modified_date": 1692130517,
+      "allow_index": true,
+      "allow_follow": false,
+      "meta_title": "Chiefs rookie describes how it felt to experience NFL stage for first time",
+      "originating_url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278272203.html",
+      "published_date": 1692130212,
+      "leadtext": [
+        {
+          "text": "Kansas City Chiefs rookie wide receiver Rashee Rice explained how it felt to play at the NFL level for the first time during a press conference after a training camp practice at Missouri Western State University in St. Joseph, Mo."
+        }
+      ],
+      "thumbnail": "https://img.connatix.com/7c32e158-9d90-4e92-bf4d-607c67759e55/1_th.jpg",
+      "href": "/web/v1/content/278272203",
+      "access_tags": [
+        "matbasic",
+        "matsport"
+      ],
+      "additional_sections": [
+        "2694",
+        "2415"
+      ],
+      "topic_tags": [],
+      "credit": "",
+      "lead_media": {
+        "id": "278272203",
+        "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278272203.html",
+        "asset_type": "videoIngest",
+        "brightcove_id": "",
+        "state": "published",
+        "title": "Chiefs rookie describes how it felt to experience NFL stage for first time",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2694",
+        "modified_date": 1692130517,
+        "allow_index": true,
+        "allow_follow": false,
+        "meta_title": "Chiefs rookie describes how it felt to experience NFL stage for first time",
+        "originating_url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278272203.html",
+        "published_date": 1692130212,
+        "leadtext": [
+          {
+            "text": "Kansas City Chiefs rookie wide receiver Rashee Rice explained how it felt to play at the NFL level for the first time during a press conference after a training camp practice at Missouri Western State University in St. Joseph, Mo."
+          }
+        ],
+        "thumbnail": "https://img.connatix.com/7c32e158-9d90-4e92-bf4d-607c67759e55/1_th.jpg",
+        "href": "/web/v1/content/278272203",
+        "access_tags": [
+          "matbasic",
+          "matsport"
+        ],
+        "additional_sections": [
+          "2694",
+          "2415"
+        ],
+        "topic_tags": [],
+        "credit": "",
+        "summary": "",
+        "content": "",
+        "brightcove_thumbnail": "https://img.connatix.com/7c32e158-9d90-4e92-bf4d-607c67759e55/1_th.jpg",
+        "photographer": "Nick Wagner",
+        "allow_ads": true,
+        "ads": [
+          {
+            "publication": "kansascity",
+            "tag": "https://pubads.g.doubleclick.net/gampad/ads?ciu_szs=300x250\u0026correlator=%5Btimestamp%5D\u0026cust_params=sect%3Dkansas_city_chiefs%26id%3D278272203%26eid%3D278272203%26vidlength%3Dshort%26pl%3D\u0026description_url=%5Breferrer_url%5D\u0026env=vp\u0026gdfp_req=1\u0026hl=en\u0026impl=s\u0026iu=%2F7675%2FKCM.site_kansascity%2FSports%2FFootball%2FPro%2FNFL\u0026output=vast\u0026sz=400x300\u0026unviewed_position_start=1\u0026url=%5Breferrer_url%5D\u0026vidlength=short\u0026vpos=preroll",
+            "lang": "en",
+            "sz": "400x300",
+            "vpos": "preroll",
+            "cust_params": "sect=kansas_city_chiefs\u0026id=278272203\u0026eid=278272203\u0026vidlength=short\u0026pl="
+          },
+          {
+            "publication": "bnd",
+            "tag": "https://pubads.g.doubleclick.net/gampad/ads?ciu_szs=300x250\u0026correlator=%5Btimestamp%5D\u0026cust_params=sect%3Dchiefs%26id%3D278272203%26eid%3D278272203%26vidlength%3Dshort%26pl%3D\u0026description_url=%5Breferrer_url%5D\u0026env=vp\u0026gdfp_req=1\u0026hl=en\u0026impl=s\u0026iu=%2F7675%2FBND.site_bnd%2FSports%2FFootball%2FPro%2FNFL\u0026output=vast\u0026sz=400x300\u0026unviewed_position_start=1\u0026url=%5Breferrer_url%5D\u0026vidlength=short\u0026vpos=preroll",
+            "lang": "en",
+            "sz": "400x300",
+            "vpos": "preroll",
+            "cust_params": "sect=chiefs\u0026id=278272203\u0026eid=278272203\u0026vidlength=short\u0026pl="
+          }
+        ],
+        "kicker": "",
+        "allow_comments": false,
+        "videoCMSID": "7c32e158-9d90-4e92-bf4d-607c67759e55"
+      },
+      "summary": "",
+      "content": "",
+      "brightcove_thumbnail": "https://img.connatix.com/7c32e158-9d90-4e92-bf4d-607c67759e55/1_th.jpg",
+      "photographer": "Nick Wagner",
+      "allow_ads": true,
+      "ads": [
+        {
+          "publication": "bnd",
+          "tag": "https://pubads.g.doubleclick.net/gampad/ads?ciu_szs=300x250\u0026correlator=%5Btimestamp%5D\u0026cust_params=sect%3Dchiefs%26id%3D278272203%26eid%3D278272203%26vidlength%3Dshort%26pl%3D\u0026description_url=%5Breferrer_url%5D\u0026env=vp\u0026gdfp_req=1\u0026hl=en\u0026impl=s\u0026iu=%2F7675%2FBND.site_bnd%2FSports%2FFootball%2FPro%2FNFL\u0026output=vast\u0026sz=400x300\u0026unviewed_position_start=1\u0026url=%5Breferrer_url%5D\u0026vidlength=short\u0026vpos=preroll",
+          "lang": "en",
+          "sz": "400x300",
+          "vpos": "preroll",
+          "cust_params": "sect=chiefs\u0026id=278272203\u0026eid=278272203\u0026vidlength=short\u0026pl="
+        },
+        {
+          "publication": "kansascity",
+          "tag": "https://pubads.g.doubleclick.net/gampad/ads?ciu_szs=300x250\u0026correlator=%5Btimestamp%5D\u0026cust_params=sect%3Dkansas_city_chiefs%26id%3D278272203%26eid%3D278272203%26vidlength%3Dshort%26pl%3D\u0026description_url=%5Breferrer_url%5D\u0026env=vp\u0026gdfp_req=1\u0026hl=en\u0026impl=s\u0026iu=%2F7675%2FKCM.site_kansascity%2FSports%2FFootball%2FPro%2FNFL\u0026output=vast\u0026sz=400x300\u0026unviewed_position_start=1\u0026url=%5Breferrer_url%5D\u0026vidlength=short\u0026vpos=preroll",
+          "lang": "en",
+          "sz": "400x300",
+          "vpos": "preroll",
+          "cust_params": "sect=kansas_city_chiefs\u0026id=278272203\u0026eid=278272203\u0026vidlength=short\u0026pl="
+        }
+      ],
+      "kicker": "",
+      "allow_comments": false,
+      "videoCMSID": "7c32e158-9d90-4e92-bf4d-607c67759e55"
+    },
+    {
+      "id": "278271948",
+      "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278271948.html",
+      "asset_type": "videoIngest",
+      "brightcove_id": "",
+      "state": "published",
+      "title": "Chiefs starting linebacker comments on Chris Jones’ absence",
+      "publication": "kansascity",
+      "layout_option": "",
+      "home": "/web/v1/sections/2694",
+      "home_section": {
+        "name": "Chiefs",
+        "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/"
+      },
+      "modified_date": 1692130517,
+      "allow_index": true,
+      "allow_follow": false,
+      "meta_title": "Chiefs starting linebacker comments on Chris Jones' absence",
+      "originating_url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278271948.html",
+      "published_date": 1692130103,
+      "leadtext": [
+        {
+          "text": "Kansas City Chiefs linebacker Nick Bolton shares his thoughts on playing without defensive tackle Chris Jones during a press conference after Tuesday's training camp practice at Missouri Western State University in St. Joseph, Mo. "
+        }
+      ],
+      "thumbnail": "https://img.connatix.com/0cb8fa89-ea3b-4044-ad70-5a2aa311e7b0/1_th.jpg",
+      "href": "/web/v1/content/278271948",
+      "access_tags": [
+        "matbasic",
+        "matsport"
+      ],
+      "additional_sections": [
+        "2694",
+        "2415"
+      ],
+      "topic_tags": [],
+      "credit": "",
+      "lead_media": {
+        "id": "278271948",
+        "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278271948.html",
+        "asset_type": "videoIngest",
+        "brightcove_id": "",
+        "state": "published",
+        "title": "Chiefs starting linebacker comments on Chris Jones’ absence",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2694",
+        "modified_date": 1692130517,
+        "allow_index": true,
+        "allow_follow": false,
+        "meta_title": "Chiefs starting linebacker comments on Chris Jones' absence",
+        "originating_url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278271948.html",
+        "published_date": 1692130103,
+        "leadtext": [
+          {
+            "text": "Kansas City Chiefs linebacker Nick Bolton shares his thoughts on playing without defensive tackle Chris Jones during a press conference after Tuesday's training camp practice at Missouri Western State University in St. Joseph, Mo. "
+          }
+        ],
+        "thumbnail": "https://img.connatix.com/0cb8fa89-ea3b-4044-ad70-5a2aa311e7b0/1_th.jpg",
+        "href": "/web/v1/content/278271948",
+        "access_tags": [
+          "matbasic",
+          "matsport"
+        ],
+        "additional_sections": [
+          "2694",
+          "2415"
+        ],
+        "topic_tags": [],
+        "credit": "",
+        "summary": "",
+        "content": "",
+        "brightcove_thumbnail": "https://img.connatix.com/0cb8fa89-ea3b-4044-ad70-5a2aa311e7b0/1_th.jpg",
+        "photographer": "Nick Wagner",
+        "allow_ads": true,
+        "ads": [
+          {
+            "publication": "bnd",
+            "tag": "https://pubads.g.doubleclick.net/gampad/ads?ciu_szs=300x250\u0026correlator=%5Btimestamp%5D\u0026cust_params=sect%3Dchiefs%26id%3D278271948%26eid%3D278271948%26vidlength%3Dshort%26pl%3D\u0026description_url=%5Breferrer_url%5D\u0026env=vp\u0026gdfp_req=1\u0026hl=en\u0026impl=s\u0026iu=%2F7675%2FBND.site_bnd%2FSports%2FFootball%2FPro%2FNFL\u0026output=vast\u0026sz=400x300\u0026unviewed_position_start=1\u0026url=%5Breferrer_url%5D\u0026vidlength=short\u0026vpos=preroll",
+            "lang": "en",
+            "sz": "400x300",
+            "vpos": "preroll",
+            "cust_params": "sect=chiefs\u0026id=278271948\u0026eid=278271948\u0026vidlength=short\u0026pl="
+          },
+          {
+            "publication": "kansascity",
+            "tag": "https://pubads.g.doubleclick.net/gampad/ads?ciu_szs=300x250\u0026correlator=%5Btimestamp%5D\u0026cust_params=sect%3Dkansas_city_chiefs%26id%3D278271948%26eid%3D278271948%26vidlength%3Dshort%26pl%3D\u0026description_url=%5Breferrer_url%5D\u0026env=vp\u0026gdfp_req=1\u0026hl=en\u0026impl=s\u0026iu=%2F7675%2FKCM.site_kansascity%2FSports%2FFootball%2FPro%2FNFL\u0026output=vast\u0026sz=400x300\u0026unviewed_position_start=1\u0026url=%5Breferrer_url%5D\u0026vidlength=short\u0026vpos=preroll",
+            "lang": "en",
+            "sz": "400x300",
+            "vpos": "preroll",
+            "cust_params": "sect=kansas_city_chiefs\u0026id=278271948\u0026eid=278271948\u0026vidlength=short\u0026pl="
+          }
+        ],
+        "kicker": "",
+        "allow_comments": false,
+        "videoCMSID": "0cb8fa89-ea3b-4044-ad70-5a2aa311e7b0"
+      },
+      "summary": "",
+      "content": "",
+      "brightcove_thumbnail": "https://img.connatix.com/0cb8fa89-ea3b-4044-ad70-5a2aa311e7b0/1_th.jpg",
+      "photographer": "Nick Wagner",
+      "allow_ads": true,
+      "ads": [
+        {
+          "publication": "kansascity",
+          "tag": "https://pubads.g.doubleclick.net/gampad/ads?ciu_szs=300x250\u0026correlator=%5Btimestamp%5D\u0026cust_params=sect%3Dkansas_city_chiefs%26id%3D278271948%26eid%3D278271948%26vidlength%3Dshort%26pl%3D\u0026description_url=%5Breferrer_url%5D\u0026env=vp\u0026gdfp_req=1\u0026hl=en\u0026impl=s\u0026iu=%2F7675%2FKCM.site_kansascity%2FSports%2FFootball%2FPro%2FNFL\u0026output=vast\u0026sz=400x300\u0026unviewed_position_start=1\u0026url=%5Breferrer_url%5D\u0026vidlength=short\u0026vpos=preroll",
+          "lang": "en",
+          "sz": "400x300",
+          "vpos": "preroll",
+          "cust_params": "sect=kansas_city_chiefs\u0026id=278271948\u0026eid=278271948\u0026vidlength=short\u0026pl="
+        },
+        {
+          "publication": "bnd",
+          "tag": "https://pubads.g.doubleclick.net/gampad/ads?ciu_szs=300x250\u0026correlator=%5Btimestamp%5D\u0026cust_params=sect%3Dchiefs%26id%3D278271948%26eid%3D278271948%26vidlength%3Dshort%26pl%3D\u0026description_url=%5Breferrer_url%5D\u0026env=vp\u0026gdfp_req=1\u0026hl=en\u0026impl=s\u0026iu=%2F7675%2FBND.site_bnd%2FSports%2FFootball%2FPro%2FNFL\u0026output=vast\u0026sz=400x300\u0026unviewed_position_start=1\u0026url=%5Breferrer_url%5D\u0026vidlength=short\u0026vpos=preroll",
+          "lang": "en",
+          "sz": "400x300",
+          "vpos": "preroll",
+          "cust_params": "sect=chiefs\u0026id=278271948\u0026eid=278271948\u0026vidlength=short\u0026pl="
+        }
+      ],
+      "kicker": "",
+      "allow_comments": false,
+      "videoCMSID": "0cb8fa89-ea3b-4044-ad70-5a2aa311e7b0"
+    },
+    {
+      "id": "278266863",
+      "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278266863.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Three wide receivers, including Justyn Ross, injured at KC Chiefs’ training camp",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2694",
+      "home_section": {
+        "name": "Chiefs",
+        "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/"
+      },
+      "modified_date": 1692119992,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Kansas City Chiefs WR Justyn Ross hurt at training camp: NFL",
+      "originating_url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278266863.html",
+      "meta_description": "Three Kansas City Chiefs wide receivers Justyn Ross, Nikko Remigio and Ihmir Smith-Marsette were injured at training camp on Tuesday.",
+      "published_date": 1692116746,
+      "thumbnail": "https://www.kansascity.com/latest-news/7cpnym/picture278171062/alternates/FREE_1140/KCM_ChiefsCamp_081123_EJC_0%20(6)",
+      "authors": [
+        {
+          "name": "Jesse Newell ",
+          "email": "jnewell@kcstar.com"
+        },
+        {
+          "name": "Pete Grathoff",
+          "email": "pgrathoff@kcstar.com"
+        }
+      ],
+      "keywords": "Kansas City Chiefs, Justyn Ross, injury, Ihmir Smith-Marsette, wide receiver",
+      "access_tags": [
+        "matbasic",
+        "matsport"
+      ],
+      "additional_sections": [
+        "2694",
+        "2414",
+        "2415",
+        "84653",
+        "2662"
+      ],
+      "credit": "",
+      "dateline": "St. Joseph",
+      "summary": "Three Kansas City Chiefs wide receivers Justyn Ross, Nikko Remigio and Ihmir Smith-Marsette were injured at training camp on Tuesday.",
+      "content": "\u003cp\u003eTuesday was a rough day for Chiefs wide receivers.\u003c/p\u003e\u003cp\u003eDuring a training-camp session in St. Joseph, three wideouts left early because of injury.\u003c/p\u003e\u003cp\u003eIhmir Smith-Marsette, Justyn Ross and Nikko Remigio all left practice up the hill before the workout ended.\u003c/p\u003e\u003cp\u003eChiefs coach Andy Reid later provided updates. Ross left with a knee/hamstring injury and was being checked out after practice by trainers. Reid said Remigio had a dislocated shoulder, while Smith-Marsette left with an injured groin.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278267493% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278267638% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278267868% --\u003e\u003c/p\u003e\u003cp\u003eRemigio led the Chiefs with four catches and 71 receiving yards in Sunday’s preseason loss to the Saints.\u003c/p\u003e\u003cp\u003eRoss caught two passes for 29 yards with a touchdown against New Orleans.\u003c/p\u003e\u003cp\u003eSmith-Marsette had a catch for 2 yards on Sunday.\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278266863",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Jesse Newell  and Pete Grathoff\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:jnewell@kcstar.com\"\u003ejnewell@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:pgrathoff@kcstar.com\"\u003epgrathoff@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "Three Chiefs wide receivers sought medical attention during training camp on Tuesday.",
+      "lead_media": {
+        "id": "278171062",
+        "url": "https://www.kansascity.com/latest-news/7cpnym/picture278171062",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "KCM_ChiefsCamp_081123_EJC_0 (6)",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1691772867,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1691772867,
+        "thumbnail": "https://www.kansascity.com/latest-news/7cpnym/picture278171062/alternates/FREE_1140/KCM_ChiefsCamp_081123_EJC_0%20(6)",
+        "href": "/web/v1/content/278171062",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "ecuriel@kcstar.com",
+        "dateline": "",
+        "caption": "Kansas City Chiefs wide receiver Justyn Ross (8) warms up during practice at Chiefs training camp on Friday, Aug. 11, 2023, in St. Joseph, Mo.",
+        "photographer": "Emily Curiel",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278270663",
+      "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278270663.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Another great effort by Kansas City Chiefs WR Nikko Remigio, but it ends with injury",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2694",
+      "home_section": {
+        "name": "Chiefs",
+        "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/"
+      },
+      "modified_date": 1692130441,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Kansas City Chiefs WR Nikko Remigio injured at training camp",
+      "originating_url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278270663.html",
+      "meta_description": "Kansas City Chiefs wide receiver Nikko Regimio has turned in a solid training camp. Now the aspiring NFL WR has a shoulder injury at camp.",
+      "published_date": 1692125403,
+      "thumbnail": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/ymfs7a/picture278269823/alternates/FREE_1140/KCM_ChiefsCamp_20230815_nw_(2)%20(3)",
+      "authors": [
+        {
+          "name": "Blair Kerkhoff",
+          "email": "bkerkhoff@kcstar.com"
+        }
+      ],
+      "keywords": "kansas city chiefs, nikko remigio, wide receiver, rashee rice, training camp",
+      "access_tags": [
+        "matbasic",
+        "matsport"
+      ],
+      "additional_sections": [
+        "2694",
+        "2737",
+        "2414",
+        "95238",
+        "2415",
+        "94902",
+        "84653",
+        "2662"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Kansas City Chiefs wide receiver Nikko Regimio has turned in a solid training camp. Now the aspiring NFL WR has a shoulder injury at camp.",
+      "content": "\u003cp\u003ePicking up where he left off Sunday as a good-hands wide receiver, Nikko Remigio laid out for a deep pass down the sideline. He slipped behind cornerback Dicaprio Bootle and got his hands on the ball before sprawling to the turf.\u003c/p\u003e\u003cp\u003eBut unlike Sunday, when Remigio led the Chiefs with four receptions for 71 yards in Kansas City’s preseason opener against the New Orleans Saints, he didn’t jump up and return to the huddle. Remigio stayed down, which quickly attracted the attention of the Chiefs’ medical staff.\u003c/p\u003e\u003cp\u003eRick Burkholder, vice president of sports medicine and performance, was among those who escorted Remigio to the injury tent, where he received treatment before leaving practice for good.\u003c/p\u003e\u003cp\u003eRemigio suffered a dislocated left shoulder, head coach Andy Reid said.\u003c/p\u003e\u003cp\u003eRemigio was one of three wide receivers injured in Tuesday’s practice, along with Justyn Ross (leg) and Ihmir Smith-Marsette (groin).\u003c/p\u003e\u003cp\u003eReid later provided updates on all three. Ross left with a knee/hamstring injury and was being checked out after practice by the team’s trainers. Reid said Smith-Marsette left with an injured groin.\u003c/p\u003e\u003cp\u003eAs for Remigio, “The shoulder’s back in,” Reid said. “We’ll just see how this thing goes.”\u003c/p\u003e\u003cp\u003eRemigio has become something of a training camp darling after going undrafted this spring. He spent five years in college, the first four at California and a fifth at Fresno State. The 5-foot-9 Remigio is coming off is best college season: 74 receptions and six touchdowns; he also rushed for two touchdowns.\u003c/p\u003e\u003cp\u003eHe’s had a solid training camp, playing mostly with the twos and threes, and is attempting to break through at a deep position group.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278271948% --\u003e\u003c/p\u003e\u003cp\u003e“Nikko Remigio, that’s my boy,” said rookie wide receiver Rashee Rice. “He’s been killing it. For him to go undrafted, I don’t really understand why. But he’s been showing everybody why he should have been drafted.”\u003c/p\u003e\u003cp\u003eIn Sunday’s game, Remigio made the most of his 18 offensive snaps. He caught two of the three longest passes thrown by Chiefs quarterbacks, a 24-yarder from Shane Buechele and a 22-yarder from Chris Oladokun.\u003c/p\u003e\u003cp\u003eHe also returned a kickoff and a punt.\u003c/p\u003e\u003cp\u003e“He had a nice game,” Reid said. “Did some really good thing specials teams-wise and in the throwing game.”\u003c/p\u003e\u003cp\u003eOne more thing: As Remigio looks to heal up and make a name for himself in the NFL, he asks that you say his name correctly. He even took to Twitter on Monday with a pronunciation guide.\u003c/p\u003e\u003cp\u003e“knee-CO ruh-me-HEE-o” he tweeted.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278272763% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278270663",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Blair Kerkhoff\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:bkerkhoff@kcstar.com\"\u003ebkerkhoff@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "Wide receiver Nikko Regimio has turned in a solid training camp. Now he’s dealing with an injury.",
+      "lead_media": {
+        "id": "278269823",
+        "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/ymfs7a/picture278269823",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "KCM_ChiefsCamp_20230815_nw_(2) (3)",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2694",
+        "modified_date": 1692119481,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692119481,
+        "thumbnail": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/ymfs7a/picture278269823/alternates/FREE_1140/KCM_ChiefsCamp_20230815_nw_(2)%20(3)",
+        "href": "/web/v1/content/278269823",
+        "access_tags": [
+          "matbasic",
+          "matsport"
+        ],
+        "additional_sections": [
+          "2694",
+          "2415"
+        ],
+        "credit": "nwagner@kcstar.com",
+        "dateline": "",
+        "caption": "Kansas City Chiefs wide receiver Nikko Remigio (27) makes a diving catch as Chiefs defensive back Dicaprio Bootle (30) defends during a Chiefs training camp practice on Tuesday, Aug. 15, 2023, in St. Joseph, Mo. Remigio left the practice after the play.",
+        "photographer": "Nick Wagner",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278277953",
+      "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278277953.html",
+      "asset_type": "videoIngest",
+      "brightcove_id": "",
+      "state": "published",
+      "title": "How new Chiefs tackles performed in first game",
+      "publication": "kansascity",
+      "layout_option": "",
+      "home": "/web/v1/sections/2694",
+      "home_section": {
+        "name": "Chiefs",
+        "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/"
+      },
+      "modified_date": 1692130424,
+      "allow_index": true,
+      "allow_follow": false,
+      "meta_title": "How new Kansas City Chiefs tackles performed in first game",
+      "originating_url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278277953.html",
+      "published_date": 1692129726,
+      "leadtext": [
+        {
+          "text": "Kansas City Star reporter Jesse Newell and Brett Taveau — longtime high school offensive coordinator and author of Chiefs book \"Unpacking Greatness\" — take a deeper look at how new tackles Donovan Smith and Jawaan Taylor did in their first game with KC: a 26-24 preseason loss to the New Orleans Saints."
+        }
+      ],
+      "thumbnail": "https://img.connatix.com/277204da-4dbb-46dd-b9cd-f78f332a6de8/1_th.jpg",
+      "href": "/web/v1/content/278277953",
+      "access_tags": [
+        "matbasic",
+        "matsport"
+      ],
+      "additional_sections": [
+        "2694",
+        "2415"
+      ],
+      "topic_tags": [],
+      "credit": "",
+      "lead_media": {
+        "id": "278277953",
+        "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278277953.html",
+        "asset_type": "videoIngest",
+        "brightcove_id": "",
+        "state": "published",
+        "title": "How new Chiefs tackles performed in first game",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2694",
+        "modified_date": 1692130424,
+        "allow_index": true,
+        "allow_follow": false,
+        "meta_title": "How new Kansas City Chiefs tackles performed in first game",
+        "originating_url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278277953.html",
+        "published_date": 1692129726,
+        "leadtext": [
+          {
+            "text": "Kansas City Star reporter Jesse Newell and Brett Taveau — longtime high school offensive coordinator and author of Chiefs book \"Unpacking Greatness\" — take a deeper look at how new tackles Donovan Smith and Jawaan Taylor did in their first game with KC: a 26-24 preseason loss to the New Orleans Saints."
+          }
+        ],
+        "thumbnail": "https://img.connatix.com/277204da-4dbb-46dd-b9cd-f78f332a6de8/1_th.jpg",
+        "href": "/web/v1/content/278277953",
+        "access_tags": [
+          "matbasic",
+          "matsport"
+        ],
+        "additional_sections": [
+          "2694",
+          "2415"
+        ],
+        "topic_tags": [],
+        "credit": "",
+        "summary": "",
+        "content": "",
+        "brightcove_thumbnail": "https://img.connatix.com/277204da-4dbb-46dd-b9cd-f78f332a6de8/1_th.jpg",
+        "photographer": "Jesse Newell",
+        "allow_ads": true,
+        "ads": [
+          {
+            "publication": "kansascity",
+            "tag": "https://pubads.g.doubleclick.net/gampad/ads?ciu_szs=300x250\u0026correlator=%5Btimestamp%5D\u0026cust_params=sect%3Dkansas_city_chiefs%26id%3D278277953%26eid%3D278277953%26vidlength%3Dshort%26pl%3D\u0026description_url=%5Breferrer_url%5D\u0026env=vp\u0026gdfp_req=1\u0026hl=en\u0026impl=s\u0026iu=%2F7675%2FKCM.site_kansascity%2FSports%2FFootball%2FPro%2FNFL\u0026output=vast\u0026sz=400x300\u0026unviewed_position_start=1\u0026url=%5Breferrer_url%5D\u0026vidlength=short\u0026vpos=preroll",
+            "lang": "en",
+            "sz": "400x300",
+            "vpos": "preroll",
+            "cust_params": "sect=kansas_city_chiefs\u0026id=278277953\u0026eid=278277953\u0026vidlength=short\u0026pl="
+          },
+          {
+            "publication": "bnd",
+            "tag": "https://pubads.g.doubleclick.net/gampad/ads?ciu_szs=300x250\u0026correlator=%5Btimestamp%5D\u0026cust_params=sect%3Dchiefs%26id%3D278277953%26eid%3D278277953%26vidlength%3Dshort%26pl%3D\u0026description_url=%5Breferrer_url%5D\u0026env=vp\u0026gdfp_req=1\u0026hl=en\u0026impl=s\u0026iu=%2F7675%2FBND.site_bnd%2FSports%2FFootball%2FPro%2FNFL\u0026output=vast\u0026sz=400x300\u0026unviewed_position_start=1\u0026url=%5Breferrer_url%5D\u0026vidlength=short\u0026vpos=preroll",
+            "lang": "en",
+            "sz": "400x300",
+            "vpos": "preroll",
+            "cust_params": "sect=chiefs\u0026id=278277953\u0026eid=278277953\u0026vidlength=short\u0026pl="
+          }
+        ],
+        "kicker": "",
+        "allow_comments": false,
+        "videoCMSID": "277204da-4dbb-46dd-b9cd-f78f332a6de8"
+      },
+      "summary": "",
+      "content": "",
+      "brightcove_thumbnail": "https://img.connatix.com/277204da-4dbb-46dd-b9cd-f78f332a6de8/1_th.jpg",
+      "photographer": "Jesse Newell",
+      "allow_ads": true,
+      "ads": [
+        {
+          "publication": "kansascity",
+          "tag": "https://pubads.g.doubleclick.net/gampad/ads?ciu_szs=300x250\u0026correlator=%5Btimestamp%5D\u0026cust_params=sect%3Dkansas_city_chiefs%26id%3D278277953%26eid%3D278277953%26vidlength%3Dshort%26pl%3D\u0026description_url=%5Breferrer_url%5D\u0026env=vp\u0026gdfp_req=1\u0026hl=en\u0026impl=s\u0026iu=%2F7675%2FKCM.site_kansascity%2FSports%2FFootball%2FPro%2FNFL\u0026output=vast\u0026sz=400x300\u0026unviewed_position_start=1\u0026url=%5Breferrer_url%5D\u0026vidlength=short\u0026vpos=preroll",
+          "lang": "en",
+          "sz": "400x300",
+          "vpos": "preroll",
+          "cust_params": "sect=kansas_city_chiefs\u0026id=278277953\u0026eid=278277953\u0026vidlength=short\u0026pl="
+        },
+        {
+          "publication": "bnd",
+          "tag": "https://pubads.g.doubleclick.net/gampad/ads?ciu_szs=300x250\u0026correlator=%5Btimestamp%5D\u0026cust_params=sect%3Dchiefs%26id%3D278277953%26eid%3D278277953%26vidlength%3Dshort%26pl%3D\u0026description_url=%5Breferrer_url%5D\u0026env=vp\u0026gdfp_req=1\u0026hl=en\u0026impl=s\u0026iu=%2F7675%2FBND.site_bnd%2FSports%2FFootball%2FPro%2FNFL\u0026output=vast\u0026sz=400x300\u0026unviewed_position_start=1\u0026url=%5Breferrer_url%5D\u0026vidlength=short\u0026vpos=preroll",
+          "lang": "en",
+          "sz": "400x300",
+          "vpos": "preroll",
+          "cust_params": "sect=chiefs\u0026id=278277953\u0026eid=278277953\u0026vidlength=short\u0026pl="
+        }
+      ],
+      "kicker": "",
+      "allow_comments": false,
+      "videoCMSID": "277204da-4dbb-46dd-b9cd-f78f332a6de8"
+    },
+    {
+      "id": "278265143",
+      "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278265143.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Arrowhead isn’t the highest-ranked NFL stadium on this tailgating list. Here’s why",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2694",
+      "home_section": {
+        "name": "Chiefs",
+        "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/"
+      },
+      "modified_date": 1692130158,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "KC Chiefs stadium ranked 5th best RV-tailgating experience",
+      "originating_url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278265143.html",
+      "meta_description": "Arrowhead Stadium is known for having one of the best tailgating experiences before NFL games. National site RVTrader ranked KC 5th overall.",
+      "published_date": 1692124138,
+      "thumbnail": "https://www.kansascity.com/latest-news/hy7i6x/picture271805992/alternates/FREE_1140/IMG_5591.jpg",
+      "authors": [
+        {
+          "name": "Joseph Hernandez",
+          "email": "jhernandez@kcstar.com"
+        }
+      ],
+      "keywords": "chiefs, tailgate, arrowhead, experience, rv, trailer, kansas city",
+      "access_tags": [
+        "matbasic",
+        "matsport"
+      ],
+      "additional_sections": [
+        "2694",
+        "2533",
+        "93024",
+        "2415",
+        "2598"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Arrowhead Stadium is known for having one of the best tailgating experiences before NFL games. National site RVTrader ranked KC 5th overall.",
+      "content": "\u003cp\u003eNothing bonds fans at GEHA Field at Arrowhead Stadium like grilling hot dogs and hamburgers, along with barbecue goodies, before a Chiefs game. \u003c/p\u003e\u003cp\u003eIt’s one of the many traditions that make \u003ca href=\"https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article267121166.html\" target=\"_self\" rel=\"Follow\"\u003eArrowhead one of the best stadiums in the NFL\u003c/a\u003e.\u003c/p\u003e\u003cp\u003eA recent national study backs up the claim. RVTrader, an online site dedicated to RV lifestyle, ranked \u003ca href=\"https://www.rvtrader.com/blog/2022/09/06/10-best-nfl-stadiums-for-rv-tailgating/\" target=\"_self\" rel=\"Follow\"\u003eArrowhead as the fifth-best stadium\u003c/a\u003e for RV tailgating in the NFL.\u003c/p\u003e\u003cp\u003eHaving parking spots large enough to accommodate RVs is one of the factors that influenced Arrowhead’s ranking.\u003c/p\u003e\u003cp\u003eRVTrader warned \u003ca href=\"https://www.thormotorcoach.com/motorhomes/class-a-motorhomes\" target=\"_self\" rel=\"Follow\"\u003eClass A\u003c/a\u003e or \u003ca href=\"https://www.rvtrader.com/Class-C/rvs-for-sale?type=Class%20C%7C198069\u0026modelkeyword=1\u0026cmp=blog_post_22Q3\" target=\"_self\" rel=\"Follow\"\u003eClass C\u003c/a\u003e motorhome owners that they may have to park in another section if the RV takes up more than two spaces. You will also have to buy an oversized parking pass, \u003ca href=\"https://www.chiefs.com/stadium/parking/faqs\" target=\"_self\" rel=\"Follow\"\u003ewhich costs $120 before fees\u003c/a\u003e.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:257865868; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003eRVTrader said you can see fans starting their tailgating as soon as the parking lot gate opens four and a half hours before kickoff. \u003c/p\u003e\u003cp\u003eBefore 2022’s home-opening game against the Los Angeles Chargers, \u003ca href=\"https://www.kansascity.com/sports/spt-columns-blogs/for-petes-sake/article265864171.html\" target=\"_self\" rel=\"Follow\"\u003efans were tailgating at 10:30 a.m.\u003c/a\u003e for a game that didn’t start until 7:15 p.m.\u003c/p\u003e\u003cp\u003eArrowhead ranked behind the stadiums of the Houston Texans, Las Vegas Raiders, New England Patriots and Buffalo Bills. \u003c/p\u003e\u003cp\u003eStart preparing your tailgate for the 2023 season with by looking at \u003ca href=\"https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article268297462.html\" target=\"_self\" rel=\"Follow\"\u003etips from expert Arrowhead tailgaters\u003c/a\u003e.\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278265143",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Joseph Hernandez\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:jhernandez@kcstar.com\"\u003ejhernandez@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "Arrowhead has plenty of space for RVs. But it costs fans extra, which was one of the factors that determined its ranking in this report.",
+      "lead_media": {
+        "id": "271805992",
+        "url": "https://www.kansascity.com/latest-news/hy7i6x/picture271805992",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "IMG_5591.jpg",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1675027244,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1675027244,
+        "thumbnail": "https://www.kansascity.com/latest-news/hy7i6x/picture271805992/alternates/FREE_1140/IMG_5591.jpg",
+        "href": "/web/v1/content/271805992",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "",
+        "dateline": "",
+        "caption": "One tailgate party on Sunday centered on “Vandy Reid,” a custom van with its own Instagram account and fan following.",
+        "photographer": "Jenna Thompson - The Kansas City Star",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278277113",
+      "url": "https://www.kansas.com/sports/college/big-12/kansas-state/article278277113.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Kansas State coach Jerome Tang lands well-traveled basketball transfer Ques Glover",
+      "publication": "kansas",
+      "layout_option": "none",
+      "home": "/web/v1/sections/3318",
+      "home_section": {
+        "name": "Kansas State University",
+        "url": "https://www.kansas.com/sports/college/big-12/kansas-state/"
+      },
+      "modified_date": 1692130127,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "K-State Wildcats add Samford basketball transfer Ques Glover",
+      "originating_url": "https://www.kansas.com/sports/college/big-12/kansas-state/article278277113.html",
+      "meta_description": "Jerome Tang has found another basketball player for the Kansas State roster. His name is Ques Glover, a transfer from Florida and Samford.",
+      "published_date": 1692130127,
+      "thumbnail": "https://www.kansas.com/latest-news/wic9h0/picture278277263/alternates/FREE_1140/usatsi_15603915.jpg",
+      "authors": [
+        {
+          "name": "Kellis Robinett",
+          "email": "krobinett@wichitaeagle.com"
+        }
+      ],
+      "keywords": "Kansas State, K-State, Wildcats, Samford, Florida",
+      "access_tags": [
+        "matbasic"
+      ],
+      "additional_sections": [
+        "3318",
+        "3035",
+        "3315"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Jerome Tang has found another basketball player for the Kansas State roster. His name is Ques Glover, a transfer from Florida and Samford.",
+      "content": "\u003cp\u003eRecruiting never stops for Jerome Tang, even when he is in Israel on a summer trip with the Kansas State men’s basketball team.\u003c/p\u003e\u003cp\u003eQues Glover, a 5-foot-11 and 182-pound graduate transfer who previously played at Florida and Samford, has announced that he will continue his college hoops career with the Wildcats.\u003c/p\u003e\u003cp\u003eHis decision is big news for the K-State basketball roster, which had been stuck on 11 scholarship players for several months. Some were beginning to wonder if it was too late in the recruiting calendar to land any new players before the start of the fall semester. But that was never much of a concern for Tang, and he proved why on Tuesday.\u003c/p\u003e\u003cp\u003eGlover averaged 14.7 points, 2.5 rebounds and 2.1 assists as a Samford guard last season. Before that, he averaged 19.2 points as a junior. That production came after he started out his college basketball career at Florida and played sparingly while appearing in 51 games for the Gators.\u003c/p\u003e\u003cp\u003eK-State coaches have been looking for an extra guard with experience to add to a backcourt that already features Cam Carter and Tylor Perry. Glover will most likely be used as a complementary player behind them.\u003c/p\u003e\u003cp\u003eMany different schools tried to recruit Glover when he announced that he was looking for a new home after he finished up the 2022-23 season at Samford. He originally committed to BYU but later backed out of that arrangement to explore his options.\u003c/p\u003e\u003cp\u003eIn the past few weeks, that brought new attention from schools like Indiana and Illinois. He considered them but decided to commit to K-State.\u003c/p\u003e\u003cp\u003eMost, if not all, of Glover’s recruitment with K-State happened via phone and Zoom. Glover did not make a recruiting visit to Manhattan and the Wildcats have been overseas on a foreign tour for the past week.\u003c/p\u003e\u003cp\u003eK-State \u003ca href=\"https://www.kansas.com/sports/college/big-12/kansas-state/article278266428.html\" target=\"_blank\" rel=\"Follow\"\u003edefeated Israel Select 94-87 during an exhibition game\u003c/a\u003e on Tuesday. That was good news for the Wildcats, but landing Glover was arguably an even better development.\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278277113",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Kellis Robinett\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:krobinett@wichitaeagle.com\"\u003ekrobinett@wichitaeagle.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "Jerome Tang has added a new transfer to the Kansas State basketball roster.",
+      "lead_media": {
+        "id": "278277263",
+        "url": "https://www.kansas.com/latest-news/wic9h0/picture278277263",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "usatsi_15603915.jpg",
+        "publication": "kansas",
+        "layout_option": "",
+        "home": "/web/v1/sections/3035",
+        "modified_date": 1692129674,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692128131,
+        "thumbnail": "https://www.kansas.com/latest-news/wic9h0/picture278277263/alternates/FREE_1140/usatsi_15603915.jpg",
+        "href": "/web/v1/content/278277263",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3035"
+        ],
+        "credit": "USA TODAY Sports",
+        "dateline": "",
+        "caption": "Ques Glover will finish his college basketball career at Kansas State after starting out at Florida and Samford.",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "Wichita",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278263503",
+      "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278263503.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Chiefs injuries piling up. Here’s latest on Jody Fortson, L’Jarius Sneed, Justyn Ross",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2694",
+      "home_section": {
+        "name": "Chiefs",
+        "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/"
+      },
+      "modified_date": 1692126298,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Chiefs’ Reid update on injured players: Ross, Fortson, Sneed",
+      "originating_url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278263503.html",
+      "meta_description": "The Kansas City Chiefs placed tight end Jody Fortson on injured reserve \u0026 had 3 receivers leave training camp practice early with ailments.",
+      "published_date": 1692125999,
+      "thumbnail": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/2lj0te/picture278267263/alternates/FREE_1140/KCM_ChiefsCamp_20230815_nw_%20(2)",
+      "authors": [
+        {
+          "name": "Jesse Newell",
+          "email": "jnewell@kcstar.com"
+        }
+      ],
+      "keywords": "Kansas City Chiefs, injury, Justyn Ross, Jody Fortson, training camp",
+      "access_tags": [
+        "matbasic",
+        "matsport"
+      ],
+      "additional_sections": [
+        "2694",
+        "2414",
+        "95238",
+        "2415",
+        "94902",
+        "84653",
+        "2662"
+      ],
+      "credit": "",
+      "dateline": "St. Joseph",
+      "summary": "The Kansas City Chiefs placed tight end Jody Fortson on injured reserve \u0026 had 3 receivers leave training camp practice early with ailments.",
+      "content": "\u003cp\u003eKansas City Chiefs coach Andy Reid begins every training camp news conference with an injury update, typically taking a few seconds to review the status of players who weren’t on the practice field.\u003c/p\u003e\u003cp\u003eThat ended up being a more significant undertaking Tuesday, as Reid spoke about eight players recently affected.\u003c/p\u003e\u003cp\u003eMost notably: Reid announced that the Chiefs were placing tight end Jody Fortson on season-ending injured reserve after Fortson had a procedure done on his \u003ca href=\"https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article277748483.html\" target=\"_blank\" rel=\"Follow\"\u003eshoulder, which he injured early in training camp\u003c/a\u003e.\u003c/p\u003e\u003cp\u003eFortson, 27, was entering his third season with the Chiefs. The 6-foot-4 tight end had been a red-zone weapon in the past, catching 14 passes for 155 yards with four touchdowns the last two seasons combined.\u003c/p\u003e\u003cp\u003eThe Chiefs also waived cornerback Anthony Witherstone with an injury settlement after he sprained a toe in \u003ca href=\"https://www.kansascity.com/sports/spt-columns-blogs/sam-mcdowell/article278211187.html\" target=\"_blank\" rel=\"Follow\"\u003eSunday’s preseason loss to the Saints\u003c/a\u003e. In Fortson and Witherstone’s place, the Chiefs added linebacker Olakunle Fatukasi and cornerback Duron Lowe to Tuesday’s roster.\u003c/p\u003e\u003cp\u003eReid had other injuries to discuss, too, as three receivers left practice early Tuesday: Justyn Ross, Nikko Remigio and Ihmir Smith-Marsette.\u003c/p\u003e\u003cp\u003eReid said Ross left with a knee/hamstring injury and would be further checked out by trainers. Ross was seen walking around after the injury before he departed practice.\u003c/p\u003e\u003cp\u003e“We’ll just have to see how it is,” Reid said.\u003c/p\u003e\u003cp\u003e\u003ca href=\"https://www.kansascity.com/sports/nfl/kansas-city-chiefs/article278270663.html\" target=\"_blank\" rel=\"Follow\"\u003eRemigio, who led the Chiefs with four catches for 71 yards Sunday, dislocated his shoulder\u003c/a\u003e during a diving catch Tuesday. Smith-Marsette, meanwhile, left the workout with a groin injury, Reid said.\u003c/p\u003e\u003cp\u003eThe Chiefs were still awaiting more information on seventh-round cornerback Nic Jones, who fractured fingers during Sunday’s game against the Saints. Jones was set to see a hand specialist Tuesday, with Reid hoping to learn more about Jones’ status in the next 24 hours.\u003c/p\u003e\u003cp\u003eReid sounded optimistic that a pair of defensive veterans could be returning soon. That included safety Mike Edwards, whose ankle swelled up after he was stepped on during the Saints game. Reid said precautionary ankle X-rays showed no further damage.\u003c/p\u003e\u003cp\u003eCornerback L’Jarius Sneed, who has sat out most of training camp with a lingering knee injury, also should be fine, Reid said.\u003c/p\u003e\u003cp\u003e“We’re taking that slow,” Reid said of Sneed’s knee. “But we’ll get him back here sooner than later.”\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278263503",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Jesse Newell\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:jnewell@kcstar.com\"\u003ejnewell@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "The Chiefs lost a top red-zone threat for the season.",
+      "lead_media": {
+        "id": "278267263",
+        "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/2lj0te/picture278267263",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "KCM_ChiefsCamp_20230815_nw_ (2)",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2694",
+        "modified_date": 1692116012,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692116012,
+        "thumbnail": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/2lj0te/picture278267263/alternates/FREE_1140/KCM_ChiefsCamp_20230815_nw_%20(2)",
+        "href": "/web/v1/content/278267263",
+        "access_tags": [
+          "matbasic",
+          "matsport"
+        ],
+        "additional_sections": [
+          "2694",
+          "2415"
+        ],
+        "credit": "nwagner@kcstar.com",
+        "dateline": "",
+        "caption": "Kansas City Chiefs head coach Andy Reid talks with offensive coordinator Matt Nagy during a Chiefs training camp practice on Tuesday, Aug. 15, 2023, in St. Joseph, Mo.",
+        "photographer": "Nick Wagner",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278272498",
+      "url": "https://www.kansascity.com/sports/mlb/kansas-city-royals/article278272498.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "How special was Bobby Witt Jr.’s inside-the-park home run? We looked at the numbers",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2687",
+      "home_section": {
+        "name": "Royals",
+        "url": "https://www.kansascity.com/sports/mlb/kansas-city-royals/"
+      },
+      "modified_date": 1692123747,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Bobby Witt Jr. inside-the-park home run set KC Royals record",
+      "originating_url": "https://www.kansascity.com/sports/mlb/kansas-city-royals/article278272498.html",
+      "meta_description": "Kansas City Royals shortstop Bobby Witt Jr. proved again why speed thrills. The KC Royals star shortstop had an inside-the-park HR Monday.",
+      "published_date": 1692123734,
+      "thumbnail": "https://www.kansascity.com/latest-news/dvhpxa/picture278273418/alternates/FREE_1140/USATSI_21203637.jpg",
+      "authors": [
+        {
+          "name": "Jaylon Thompson",
+          "email": "jathompson@kcstar.com"
+        }
+      ],
+      "keywords": "Bobby Witt Jr., Kansas City Royals, speed, inside-the-park, home run",
+      "access_tags": [
+        "matbasic",
+        "matsport"
+      ],
+      "additional_sections": [
+        "2687",
+        "2415",
+        "84653",
+        "2738",
+        "2662"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Kansas City Royals shortstop Bobby Witt Jr. proved again why speed thrills. The KC Royals star shortstop had an inside-the-park HR Monday.",
+      "content": "\u003cp\u003eKansas City Royals shortstop Bobby Witt Jr. has \u003ca href=\"https://www.kansascity.com/sports/mlb/kansas-city-royals/article277983368.html\" target=\"_self\" rel=\"Follow\"\u003ecreated a lot of highlights\u003c/a\u003e this season. \u003c/p\u003e\u003cp\u003eWitt has displayed his five-tool ability multiple times at Kauffman Stadium. There was his \u003ca href=\"https://www.kansascity.com/sports/mlb/kansas-city-royals/article277747158.html\" target=\"_self\" rel=\"Follow\"\u003ewalk-off grand slam against the Minnesota Twins\u003c/a\u003e. He also \u003ca href=\"https://www.kansascity.com/sports/mlb/kansas-city-royals/article275844156.html\" target=\"_self\" rel=\"Follow\"\u003enearly hit for the cycle\u003c/a\u003e against the Washington Nationals. \u003c/p\u003e\u003cp\u003eOn Monday night, Witt elevated his game to the next level. Witt\u003ca href=\"https://www.kansascity.com/sports/mlb/kansas-city-royals/article278253208.html\" target=\"_self\" rel=\"Follow\"\u003e hit an inside-the-park home run \u003c/a\u003eagainst the Seattle Mariners. In the fifth inning, he hit a 97 mph fastball into the right-field gap off Mariners starter Logan Gilbert. \u003c/p\u003e\u003cp\u003eThe baseball got past Mariners outfielder Dominic Canzone. He appeared to misjudge the line drive — or perhaps lost it in the lights — as the ball rolled all the way to the wall.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278254123% --\u003e\u003c/p\u003e\u003cp\u003eWitt was off to the races. He went home-to-home in 14.3 seconds to record his 22nd home run of the season. \u003c/p\u003e\u003cp\u003eHow special was the feat? \u003c/p\u003e\u003cp\u003eWitt turned in the second inside-the-park home run in all of MLB this season. The last Royals player to do it was Whit Merrifield in 2019 against the Detroit Tigers. \u003c/p\u003e\u003cp\u003eWitt also turned in the fourth-fastest home-to-home time in the Statcast Era (since 2015), \u003ca href=\"https://twitter.com/SlangsOnSports/status/1691263404894212096\" target=\"_self\" rel=\"Follow\"\u003eper MLB.com researcher Sarah Slangs\u003c/a\u003e. It was the fastest inside-the-park home run since August of 2017.\u003c/p\u003e\u003cp\u003eHe trails Dee Strange-Gordon and Byron Buxton (twice) on the list. Strange-Gordon raced home in 14.2 seconds in 2015. Meanwhile, Buxton did it on two separate occasions. He turned in 14.1 seconds in 2016 and 13.9 seconds in 2017. \u003c/p\u003e\u003cp\u003e“I guess the baseball gods were on my side,” Witt said. “Just with the first two ABs (at-bats), I didn’t really hit them hard — just put them in a good spot to get a hit out of them. The lights helped me out a little bit, I think.”\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278272473% --\u003e\u003c/p\u003e\u003cp\u003eWitt ranks in the 100th percentile for sprint speed — placing him at the top of MLB. He has a 30.4 ft/sec sprint speed and 190 competitive runs, per Baseball Savant. He averages 4.14 seconds from home plate to first base this season. \u003c/p\u003e\u003cp\u003eThe Royals have three of the top four sprint speeds in MLB. Royals outfielder Dairon Blanco and \u003ca href=\"https://www.kansascity.com/sports/mlb/kansas-city-royals/article278251093.html\" target=\"_self\" rel=\"Follow\"\u003enew acquisition Bubba Thompson\u003c/a\u003e each have 30.4 ft/sec sprint speeds as well. They trail Cincinnati Reds superstar Elly De La Cruz (30.5 ft/sec) on the list. \u003c/p\u003e\u003cp\u003e\u003cspan id=\"docs-internal-guid-6ab0e422-7fff-06cc-7359-63762b0d35cb\"\u003e“I saw the ball go back and I was definitely pushing for him to go all the way around the bases,” Blanco \u003ca href=\"https://www.kansascity.com/sports/mlb/kansas-city-royals/article278255853.html\" target=\"_self\" rel=\"Follow\"\u003esaid after his walk-off bunt\u003c/a\u003e. “I knew he could do it.”\u003c/span\u003e\u003c/p\u003e\u003cp\u003eThe Royals value speed in their lineup. Witt leads the team with 34 steals. Meanwhile, Royals third baseman Maikel Garcia has 18 and Blanco has 14. \u003c/p\u003e\u003cp\u003e“It’s fun to watch him run,” Royals manager Matt Quatraro said.\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278272498",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Jaylon Thompson\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:jathompson@kcstar.com\"\u003ejathompson@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "The Kansas City Royals were treated to something special on Monday night. ",
+      "lead_media": {
+        "id": "278273418",
+        "url": "https://www.kansascity.com/latest-news/dvhpxa/picture278273418",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "USATSI_21203637.jpg",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1692123617,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692123617,
+        "thumbnail": "https://www.kansascity.com/latest-news/dvhpxa/picture278273418/alternates/FREE_1140/USATSI_21203637.jpg",
+        "href": "/web/v1/content/278273418",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "USA TODAY Sports",
+        "dateline": "",
+        "caption": "Kansas City Royals shortstop Bobby Witt Jr. (7) is congratulated by teammates after hitting an inside-the-park home run during the fifth inning against the Seattle Mariners at Kauffman Stadium on Aug. 14, 2023.",
+        "photographer": "Jay Biggerstaff",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278235583",
+      "url": "https://www.kansascity.com/sports/spt-columns-blogs/for-petes-sake/article278235583.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Former NFL defensive end believes Chiefs’ Achilles heel could be holding penalties",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/6607",
+      "home_section": {
+        "name": "For Pete's Sake",
+        "url": "https://www.kansascity.com/sports/spt-columns-blogs/for-petes-sake/"
+      },
+      "modified_date": 1692118176,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Donovan Smith’s penalty woes may cost Chiefs, says NFL analyst",
+      "originating_url": "https://www.kansascity.com/sports/spt-columns-blogs/for-petes-sake/article278235583.html",
+      "meta_description": "Kansas City Chiefs left tackle Donovan Smith’s trouble with holding penalties could be costly to the NFL team says ESPN’s Marcus Spears.",
+      "published_date": 1692118176,
+      "thumbnail": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/agj1dk/picture275753371/alternates/FREE_1140/KCM_CHIEFSNEWELL052423TL021",
+      "authors": [
+        {
+          "name": "Pete Grathoff",
+          "email": "pgrathoff@kcstar.com"
+        }
+      ],
+      "keywords": "Kansas City Chiefs, Donovan Smith, tackle, Marcus Spears, penalties",
+      "access_tags": [
+        "matbasic",
+        "matsport"
+      ],
+      "additional_sections": [
+        "6607",
+        "2694",
+        "2415",
+        "84653",
+        "2662"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Kansas City Chiefs left tackle Donovan Smith’s trouble with holding penalties could be costly to the NFL team says ESPN’s Marcus Spears.",
+      "content": "\u003cp\u003eThe Chiefs are the defending Super Bowl champions and have the league’s best player in Patrick Mahomes, so yeah, expectations are high for the 2023 season.\u003c/p\u003e\u003cp\u003eESPN’s Marcus Spears and Dan Orlovsky on Monday debated the outlook for the Chiefs this season, and were asked to say if KC would be better, worse or the same.\u003c/p\u003e\u003cp\u003eOrlovksy thinks the Chiefs will be better, while Spears said about the same.\u003c/p\u003e\u003cp\u003eSpears, the \u003ca href=\"https://www.pro-football-reference.com/players/S/SpeaMa21.htm\" target=\"_blank\" rel=\"Follow\"\u003eformer Cowboys defensive end\u003c/a\u003e, expressed his concern about the Chiefs’ new tackles, \u003ca href=\"https://www.chiefs.com/team/players-roster/donovan-smith/\" target=\"_blank\" rel=\"Follow\"\u003eDonovan Smith\u003c/a\u003e and \u003ca href=\"https://www.chiefs.com/team/players-roster/jawaan-taylor/\" target=\"_blank\" rel=\"Follow\"\u003eJawaan Taylor\u003c/a\u003e.\u003c/p\u003e\u003cp\u003e“You just said there’s a question at the left tackle spot,” Spears said. “First of all, Donovan Smith has played a lot of football, but Donovan Smith has held a lot in football. And the one thing that could disrupt this offense is penalties. And we know that when you’re ushering in two new tackles starting in the system. And you’re right, we’ve seen Patrick Mahomes and Andy Reid overcome a lot. \u003c/p\u003e\u003cp\u003e“The one thing we haven’t seen them overcome is bad offensive line play. It’s been an issue here before in this franchise as we’ve seen and I’m not just pointing to the Super Bowl (LV). You can point back to when they were struggling a little bit early in the season. That unit wasn’t playing great throughout that stretch. ... That offensive line was playing into a lot of what that offensive struggle was for this team.” \u003c/p\u003e\u003cp\u003eSpears and Orlovsky both noted the importance of the Chiefs reaching a deal with defensive tackle Chris Jones. He’s missed all of training camp while holding out for a new contract.\u003c/p\u003e\u003cp\u003eBut Spears reiterated that the offensive line will be the key to the Chiefs’ hopes this season.\u003c/p\u003e\u003cp\u003e“They are not going to win the Super Bowl on defense, they are going to win it because of Patrick Mahomes and this unit that they put around him from a protection standpoint,” Spears said. “I’m not even worried about the wide receivers because Travis Kelce is there. I don’t care who is playing wide receiver as long as Travis Kelce and Patrick Mahomes are on the field. \u003c/p\u003e\u003cp\u003e“But ultimately, if we are sitting here saying, ‘Dang man, did you see what has happened to Kansas City? Or Kansas City didn’t get back to the Super Bowl or back to the AFC Championship,’ I think we will squarely point to protection for Patrick Mahomes from those tackles spots. I don’t think it’s gonna be an issue, but I can’t say they’re gonna be better leading into the season trying to put two new guys in that position.”\u003c/p\u003e\u003ch3\u003ePenalty numbers\u003c/h3\u003e\u003cp\u003eSpears is particularly concerned about Smith, who was the second-most penalized player in the NFL last season. He was flagged for \u003ca href=\"https://www.footballdb.com/stats/penalties-player.html?yr=2022\u0026tm=\" target=\"_blank\" rel=\"Follow\"\u003eholding seven times\u003c/a\u003e, the most of any player, per the Football Database. That was in 13 games.\u003c/p\u003e\u003cp\u003eHowever, in the 2021 season, Smith played all 17 games and was called for holding just three times. Taylor, however, was called eight times for holding that year.\u003c/p\u003e\u003cp\u003e“Patrick Mahomes’ ability to run and improv in the playoffs are a big reason why the Kansas City Chiefs have so much success in winning Super Bowls,” Spears said. “I get concerned when a play goes for seven seconds, and there’s a tackle on the field that is susceptible to holding defensive lineman, and he’s gonna play a lot of really good outside rushers in the AFC this year. That’s my only issue.”\u003c/p\u003e\u003cp\u003eHere is that \u003ca href=\"https://www.youtube.com/watch?v=kftVVUIQ1Xw\" target=\"_blank\" rel=\"Follow\"\u003eESPN discussion\u003c/a\u003e.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278268853% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278235583",
+      "allow_ads": true,
+      "allow_stn_player": false,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Pete Grathoff\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:pgrathoff@kcstar.com\"\u003epgrathoff@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "New Chiefs left tackle Donovan Smith was called for the most offensive holding calls in 202, and a former NFL player says that could hamstring KC.",
+      "lead_media": {
+        "id": "275753371",
+        "url": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/agj1dk/picture275753371",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "KCM_CHIEFSNEWELL052423TL021",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2694",
+        "modified_date": 1684956634,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1684956634,
+        "thumbnail": "https://www.kansascity.com/sports/nfl/kansas-city-chiefs/agj1dk/picture275753371/alternates/FREE_1140/KCM_CHIEFSNEWELL052423TL021",
+        "href": "/web/v1/content/275753371",
+        "access_tags": [
+          "matbasic",
+          "matsport"
+        ],
+        "additional_sections": [
+          "2694",
+          "2415"
+        ],
+        "credit": "tljungblad@kcstar.com",
+        "dateline": "",
+        "caption": "Chiefs quarterback Patrick Mahomes (15), tackles Donovan Smith,(79) and Darian Kinnard (75) during OTAs on Wednesday, May 24, 2023, at the Chiefs Training facility in Kansas City.",
+        "photographer": "Tammy Ljungblad",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": [
+        {
+          "name": "mcc-timely-ta"
+        }
+      ]
+    },
+    {
+      "id": "278249443",
+      "url": "https://www.kansascity.com/sports/article278249443.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Does Messi’s arrival in MLS put pressure on Sporting Kansas City to enhance roster?",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2662",
+      "home_section": {
+        "name": "Sports",
+        "url": "https://www.kansascity.com/sports/"
+      },
+      "modified_date": 1692115469,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Lionel Messi in MLS and the status of Sporting KC’s roster",
+      "originating_url": "https://www.kansascity.com/sports/article278249443.html",
+      "meta_description": "Let’s talk about Messi’s effect on Sporting KC and Major League Soccer, as well as the KC Current’s search for a permanent head coach.",
+      "published_date": 1692111600,
+      "thumbnail": "https://www.miamiherald.com/latest-news/ha8i8k/picture278192307/alternates/FREE_1140/207_Inter_Miami_vs_Charlotte_FC_DS.jpg",
+      "authors": [
+        {
+          "name": "Daniel Sperry ",
+          "email": ""
+        }
+      ],
+      "keywords": "messi, sporting kc, soccer, kc current, mls",
+      "access_tags": [
+        "matbasic",
+        "matsport"
+      ],
+      "additional_sections": [
+        "2662",
+        "2691",
+        "2415",
+        "84653",
+        "2690"
+      ],
+      "credit": "Special to The Star",
+      "dateline": "",
+      "summary": "Let’s talk about Messi’s effect on Sporting KC and Major League Soccer, as well as the KC Current’s search for a permanent head coach.",
+      "content": "\u003cp\u003eThe arrival of Lionel Messi to Major League Soccer has delivered a significant number of eyeballs.\u003c/p\u003e\u003cp\u003eSince Messi joined Inter Miami last month, the team’s owner, Jorge Mas, claims the number of subscribers to MLS Season Pass on Apple TV has doubled.\u003c/p\u003e\u003cp\u003eThe Messi effect has been undeniable during the Leagues Cup: Inter Miami, MLS’ worst team through more than half the season, has reached the semifinals. It helps that stars Jordi Alba and Sergio Busquets have joined their former Barcelona teammate in South Beach. \u003c/p\u003e\u003cp\u003eMessi could write another thank-you note to the host of players who have missed their mark in defending him.\u003c/p\u003e\u003cp\u003eBut none of that affects Sporting Kansas City directly ... at the moment. In the longer run, you’ll likely see some sort of change in the league’s roster rules, perhaps as soon as next year. It’s rumored to have been a major topic of discussion at the MLS owners’ meetings during the All-Star break.\u003c/p\u003e\u003cp\u003eChanges in the rules governing roster construction would seem to be the most likely way the Messi effect could touch Sporting KC. Ownership would likely have to spend even more on the roster to keep up. Before Messi’s debut, Sporting’s \u003ca href=\"https://www.kansascity.com/sports/soccer/sporting-kc/article277541543.html\" target=\"_self\" rel=\"Follow\"\u003ePeter Vermes predicted\u003c/a\u003e the Argentine soccer star’s arrival would force other clubs to “up the ante.”\u003c/p\u003e\u003cp\u003e“Everybody loves saying, ‘Let’s spend money,’ and I’m sure that’s not what the owners want to hear all the time,” Vermes said. “But I just think that’s the cost of doing business as the league continues to evolve.”\u003c/p\u003e\u003cp\u003eSo in short, yes. Messi’s arrival will undoubtedly pressure mid-market teams to find new ways to be competitive with those who can, and will, spend big. Whether this means increasing spending and/or finding more efficiencies in their approach to roster-building, Sporting KC and other teams face a new challenge.\u003c/p\u003e\u003cp\u003e\u003ci\u003eNow on to some of your questions about both Sporting KC and the KC Current, as fielded via social media:\u003c/i\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278249823% --\u003e\u003c/p\u003e\u003cp\u003eThe Current have certainly investigated a few names for the full-time role. But they’re in their stretch run and are the healthiest they’ve been in months.\u003c/p\u003e\u003cp\u003eThey’ll likely continue to let Caroline Sjöblom handle the reins through the rest of the season and into the playoffs, if they can make that push.\u003c/p\u003e\u003cp\u003eThe Current have lost just three matches across all competitions since June. Defensively, they’ve become sound, conceding just four goals in their last six matches. And they are putting the ball into the back of the net. \u003c/p\u003e\u003cp\u003eAs for what happens after the season? It depends on how this team performs down the stretch. If they make the postseason or narrowly miss out, Sjöblom will get some consideration for the role. \u003c/p\u003e\u003cp\u003eDon’t be surprised if Vlatko Andonovski is also in the mix. The World Cup cycle is complete, the USWNT coach is a proud Kansas City resident and Current owners Chris and Angie Long like to swing for the fences.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278250013% --\u003e\u003c/p\u003e\u003cp\u003eIn response to the first question, here’s what I would like see changed: the rule requiring a team that wants to use three U-22 initiative slots to have one of their three designated player spots filled by a player whose salary is under the max budget charge.\u003c/p\u003e\u003cp\u003eIt hampers what a team can pay one of its DPs. And if that team chooses to pay the full DP slot, it’s unable to capitalize on a young player signing that, hypothetically, could turn into financial profit down the road. \u003c/p\u003e\u003cp\u003eRegarding the second question, Sporting certainly is not out of contention. Sure, the teams ahead have games in hand, but they will face some heavier fixture congestion ahead that Sporting won’t. And Sporting is just three points off the playoff line.\u003c/p\u003e\u003cp\u003eHaving dropped the most points in the league from a winning position, they’re arguably farther down the table than their quality has shown to be at times. Then again, at some point we may have to agree that this is who they are: a team that can’t close out victories.\u003c/p\u003e\u003cp\u003eIf Sporting doesn’t come out of the Leagues Cup break strong, it won’t be long before they’re out of contention. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278250278% --\u003e\u003c/p\u003e\u003cp\u003eInterim Current head coach Caroline Sjöblom told reporters on Monday that next week is the soonest Lauren and Stine Ballisager could get their visas. It will probably be two to three match-weeks before they get integrated into a match-day squad.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278250348% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278250368% --\u003e\u003c/p\u003e\u003cp\u003eA lot of players’ contract situations will be in limbo next season. Thirteen players are either out of contract or have an option for next year. Alan Pulido’s contract expiration has gotten the most attention, but Gadi Kinda is also out of contract at the end of this season.\u003c/p\u003e\u003cp\u003eJohnny Russell is no longer a DP but has been for a while, and his contract has an option for 2024. Among other regulars whose continued presence would require picking up an option: Jake Davis, Remi Walter and Willy Agada.\u003c/p\u003e\u003cp\u003eIn short, barring a total collapse down the stretch, a massive roster overhaul would be surprising. But Sporting has ways out if club leadership elects to hit the reset button.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278250553% --\u003e\u003c/p\u003e\u003cp\u003eThe Current certainly have the ability to make a run. But they can ill afford another slip-up. \u003c/p\u003e\u003cp\u003eThe good news is that they’re just six points out of a playoff spot. The bad: they’re in last place in the regular-season standings. That means there are six teams between them and a postseason spot. The other difficulty is the road ahead: Of their seven remaining regular-season games, just three are at home.\u003c/p\u003e\u003cp\u003eThey will have road trips to San Diego, Houston, Washington and Gotham. All of those teams currently occupy playoff spots. The Current gained momentum in the Challenge Cup, but now they must go on a scorched-earth tear through their final seven games in order to make the playoffs.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278250643% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278250723% --\u003e\u003c/p\u003e\u003cp\u003eVermes has said the club and Pulido are still in negotiations. At the moment, despite reports from various outlets in Mexico that Pulido and Sporting have reached agreement on an extension, that is still Sporting’s answer about the situation.\u003c/p\u003e\u003cp\u003eMany of those reporting an agreement between the two also floated narratives that Chivas and Cruz Azul had made offers to Sporting to acquire Pulido during the summer window. Vermes has repeatedly refuted those reports, saying no club had contacted Sporting about Pulido.\u003c/p\u003e\u003cp\u003eThere’s undoubtedly some optimism around the club that Pulido will suit up in a Sporting kit again next season. But until Pulido signs on the dotted line, that is a hope — not a reality.\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278249443",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Daniel Sperry \u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eSpecial to The Star\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Let’s talk about Messi’s effect on Major League Soccer, as well as the KC Current’s search for a permanent head coach.",
+      "lead_media": {
+        "id": "278192307",
+        "url": "https://www.miamiherald.com/latest-news/ha8i8k/picture278192307",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "207_Inter_Miami_vs_Charlotte_FC_DS.jpg",
+        "publication": "miamiherald",
+        "layout_option": "",
+        "home": "/web/v1/sections/3180",
+        "modified_date": 1692054095,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1691822921,
+        "thumbnail": "https://www.miamiherald.com/latest-news/ha8i8k/picture278192307/alternates/FREE_1140/207_Inter_Miami_vs_Charlotte_FC_DS.jpg",
+        "href": "/web/v1/content/278192307",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "3180"
+        ],
+        "credit": "dsantiago@miamiherald.com",
+        "dateline": "",
+        "caption": "Inter Miami forward Lionel Messi waves to his fans during the second half of a Leagues Cup quarterfinal match against the Charlotte FC at DRV PNK Stadium on Friday, Aug. 11, 2023, in Fort Lauderdale, Fla.",
+        "photographer": "David Santiago",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278253208",
+      "url": "https://www.kansascity.com/sports/mlb/kansas-city-royals/article278253208.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Brady Singer dazzles, then Kansas City Royals survive roller-coaster ride vs. Mariners",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/2687",
+      "home_section": {
+        "name": "Royals",
+        "url": "https://www.kansascity.com/sports/mlb/kansas-city-royals/"
+      },
+      "modified_date": 1692114957,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Kansas City Royals vs. Seattle Mariners: MLB Game recap",
+      "originating_url": "https://www.kansascity.com/sports/mlb/kansas-city-royals/article278253208.html",
+      "meta_description": "The Kansas City Royals began a four-game series against the Seattle Mariners at Kauffman Stadium on Monday night.",
+      "published_date": 1692070325,
+      "thumbnail": "https://www.kansascity.com/latest-news/oxkr8c/picture278255808/alternates/FREE_1140/USATSI_21203983.jpg",
+      "authors": [
+        {
+          "name": "Jaylon Thompson",
+          "email": "jathompson@kcstar.com"
+        }
+      ],
+      "keywords": "Brady Singer, Salvador Perez, Kansas City Royals, MLB, seattle mariners",
+      "access_tags": [
+        "matbasic",
+        "matsport"
+      ],
+      "additional_sections": [
+        "2687",
+        "2415",
+        "84653",
+        "2738",
+        "2662"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "The Kansas City Royals began a four-game series against the Seattle Mariners at Kauffman Stadium on Monday night.",
+      "content": "\u003cp\u003eKansas City Royals pitcher Brady Singer had a night to remember. \u003c/p\u003e\u003cp\u003eSinger, 27, hit all the right notes in his start against the Seattle Mariners on Monday night at Kauffman Stadium. The performance drew comparisons to his\u003ca href=\"https://www.kansascity.com/sports/mlb/kansas-city-royals/article245636090.html\" target=\"_self\" rel=\"Follow\"\u003e 2020 outing against the now Cleveland Guardians\u003c/a\u003e. \u003c/p\u003e\u003cp\u003eSinger chased perfection early by retiring the first 14 batters he faced. Then, he remained in a groove after issuing a walk to Mariners outfielder Cade Marlowe. \u003c/p\u003e\u003cp\u003eWith the crowd behind him, Singer took a no-hit bid into the seventh inning before Mariners outfielder Dominic Canzone broke it up with a two-out single. \u003c/p\u003e\u003cp\u003eThe Royals went on to survive a furious Seattle rally against the KC bullpen to win the series opener 7-6.\u003c/p\u003e\u003cp\u003e“I knew (of the no-hitter), but you never think it was going to happen,” Singer said. “I was just going out there and making pitches. ... I was trying to stay in the zone as much as I can, not worry about that, and get quick outs.” \u003c/p\u003e\u003cp\u003eSinger was dominant with a \u003ca href=\"https://www.kansascity.com/sports/mlb/kansas-city-royals/article277945768.html\" target=\"_self\" rel=\"Follow\"\u003esuperb three-pitch arsenal\u003c/a\u003e. His sinker danced across the plate, while his slider glided from each corner. \u003c/p\u003e\u003cp\u003eAfter the Mariners came back to take a ninth-inning lead, \u003ca href=\"https://www.kansascity.com/sports/mlb/kansas-city-royals/article278255853.html\" target=\"_blank\" rel=\"Follow\"\u003ethe Royals scored two runs in the bottom of the ninth to win the game\u003c/a\u003e. Royals captain Salvador Perez hit a sacrifice fly that scored Bobby Witt Jr., and outfielder Dairon Blanco won it with a bunt single.\u003c/p\u003e\u003cp\u003e“I had the heads-up instinct that if we had first and third with less than two outs, I was going to bunt,” Blanco said through an interpreter. “The situation came up. I got it done and we won the ballgame.” \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:277940118; alt=\"undefined\"% --\u003e\u003c/p\u003e\u003cp\u003eSinger threw 106 pitches in 7 1/3 innings. He allowed two hits and two earned runs and struck out eight. Singer also generated 16 called strikes and 13 whiffs against a potent Mariners lineup.\u003c/p\u003e\u003cp\u003e“Everything felt good,” Singer said. “I was able to stay in the strike zone with all my pitches. The sinker was doing good and I was able to work up in the zone. Like I said in the last outing, working up in the zone is working out for me.” \u003c/p\u003e\u003cp\u003eThe Royals provided ample early run support. Perez hit a three-run homer over the center-field wall in the first inning. It was his 19th home run and gave KC a 3-0 lead. \u003c/p\u003e\u003cp\u003eRoyals shortstop Witt Jr. hit an inside-the-park home run as part of a four-hit game. He has remained hot after recently becoming the \u003ca href=\"https://www.kansascity.com/sports/mlb/kansas-city-royals/article277983368.html\" target=\"_self\" rel=\"Follow\"\u003efirst major-league player with at least 20 home runs and 30 stolen bases \u003c/a\u003ein his first two big-league seasons. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278254618% --\u003e\u003c/p\u003e\u003cp\u003eThe Mariners would not go quietly. They scored four runs in the eighth inning after Singer had departed the game. Mariners star Julio Rodriguez hit a three-run double to cut into the Royals’ lead and third baseman Eugenio Suarez added an RBI single.\u003c/p\u003e\u003cp\u003eThe Mariners continued their onslaught in the ninth. Second baseman Jose Rojas drove home Teoscar Hernandez to tie the game and Rodriguez knocked in the go-ahead run.\u003c/p\u003e\u003cp\u003eBut the Royals wouldn’t send the announced crowd of 11,878 home disappointed. They improved to 39-81 with the wild victory.\u003c/p\u003e\u003cp\u003e“Just the different swings and emotions in that game ...” Royals manager Matt Quatraro said. “For the guys to come right back (was good).”\u003c/p\u003e\u003ch3\u003eMore Royals news \u003c/h3\u003e\u003cp\u003e\u003cb\u003eRoster move: \u003c/b\u003e\u003ca href=\"https://www.kansascity.com/sports/mlb/kansas-city-royals/article278251093.html\"\u003eRoyals option Edward Olivares to Triple-A, claim Bubba Thompson from Rangers\u003c/a\u003e.\u003c/p\u003e\u003cp\u003e\u003cb\u003eFully endorsed: \u003c/b\u003e\u003ca href=\"https://www.kansascity.com/sports/spt-columns-blogs/for-petes-sake/article278060057.html\"\u003eBobby Witt Jr. signs endorsement deal with CommunityAmerica Credit Union\u003c/a\u003e.\u003c/p\u003e\u003cp\u003e\u003cspan id=\"docs-internal-guid-8cb8dabe-7fff-1200-7dcd-a7fd890934d4\"\u003e\u003ci style=\"\"\u003eHere are more notables from Monday’s game:\u003c/i\u003e\u003c/span\u003e\u003c/p\u003e\u003ch3\u003eBobby Witt Jr. thrills with inside-park HR \u003c/h3\u003e\u003cp\u003eRoyals shortstop Bobby Witt Jr. thrilled fans with an inside-the-park home run in the fifth inning. \u003c/p\u003e\u003cp\u003eWitt, \u003ca href=\"https://www.kansascity.com/sports/mlb/kansas-city-royals/article278114472.html\" target=\"_self\" rel=\"Follow\"\u003ewho recently had a jersey sent to Cooperstown\u003c/a\u003e, hit a 97 mph fastball into the right-field gap. Mariners outfielder Dominic Canzone misjudged the line drive and the ball rolled all the way to the wall. Witt raced around the bases and received the green light from third-base coach Vance Wilson. \u003c/p\u003e\u003cp\u003e“I guess the baseball gods were on my side,” Witt said. “Just with the first two ABs (at-bats), I didn’t really hit them hard — just put them in a good spot to get a hit out of them. The lights helped me out a little bit, I think.”\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278254123% --\u003e\u003c/p\u003e\u003cp\u003eWitt slid headfirst into home. He raced around the bases in 14.3 seconds for his 22nd home run of the season. It was the fourth-fastest home-to-home time of the Statcast era (since 2015). \u003c/p\u003e\u003cp\u003e“I thought he caught it,” Witt said. “Then I saw him and I was picking up Vance to see what we were doing. I was just running as fast as I can. Then I saw him sending me and dove.” \u003c/p\u003e\u003cp\u003eThe breathtaking sequence gave the Royals a 4-0 lead. \u003c/p\u003e\u003cp\u003eIt was the first inside-the-park homer of Witt’s career. He also became the first Royals player with an inside-the-park home run since Whit Merrifield in 2019.\u003c/p\u003e\u003cp\u003e“It’s fun to watch him run,” Quatraro said. \u003c/p\u003e\u003ch3\u003eMaikel Garcia sets new Royals rookie mark \u003c/h3\u003e\u003cp\u003eThe Royals welcomed third baseman \u003ca href=\"https://www.kansascity.com/sports/mlb/kansas-city-royals/article278251093.html\" target=\"_self\" rel=\"Follow\"\u003eMaikel Garcia back to the lineup\u003c/a\u003e Monday night. \u003c/p\u003e\u003cp\u003eGarcia, who had \u003ca href=\"https://www.kansascity.com/sports/mlb/kansas-city-royals/article278188332.html\" target=\"_self\" rel=\"Follow\"\u003emissed one game due to left upper-body discomfort\u003c/a\u003e, was back in his usual leadoff role against the Mariners. \u003c/p\u003e\u003cp\u003eHe was also chasing franchise history. \u003c/p\u003e\u003cp\u003eIn the first inning, Garcia extended his hitting streak to 16 games — the longest hitting streak by a Royals rookie. Garcia eclipsed former Royals standouts David DeJesus and Mike Moustakas. \u003c/p\u003e\u003cp\u003eGarcia finished 2 for 4 with a RBI and run scored Monday. His hitting streak is currently the longest active streak in the majors.\u003c/p\u003e\u003cp\u003e\u003cb\u003eWhat’s next: \u003c/b\u003eThe Royals continue their four-game series against the Mariners on Tuesday. Jordan Lyles will start for KC, while Emerson Hancock will start for Seattle.\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278253208",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Jaylon Thompson\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:jathompson@kcstar.com\"\u003ejathompson@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "Good things seem to happen when KC’s Dairon Blanco bunts the baseball.",
+      "lead_media": {
+        "id": "278255808",
+        "url": "https://www.kansascity.com/latest-news/oxkr8c/picture278255808",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "USATSI_21203983.jpg",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1692076417,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692076417,
+        "thumbnail": "https://www.kansascity.com/latest-news/oxkr8c/picture278255808/alternates/FREE_1140/USATSI_21203983.jpg",
+        "href": "/web/v1/content/278255808",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "USA TODAY Sports",
+        "dateline": "",
+        "caption": "Royals left fielder Dairon Blanco, right, celebrates with catcher Salvador Perez after dropping a walk-off bunt against the Seattle Mariners Monday night at Kauffman Stadium.",
+        "photographer": "Jay Biggerstaff",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": []
+    },
+    {
+      "id": "278260243",
+      "url": "https://www.kansascity.com/sports/spt-columns-blogs/for-petes-sake/article278260243.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Ángel Hernández dealt legal setback one day after blown call in Royals-Mariners game",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/6607",
+      "home_section": {
+        "name": "For Pete's Sake",
+        "url": "https://www.kansascity.com/sports/spt-columns-blogs/for-petes-sake/"
+      },
+      "modified_date": 1692112038,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Ángel Hernández dealt legal setback one day after blown call ",
+      "originating_url": "https://www.kansascity.com/sports/spt-columns-blogs/for-petes-sake/article278260243.html",
+      "meta_description": "Replay review overturned a call by umpire Angel Hernandez on a stolen base attempt and Kansas City Royals, Seattle Mariners fans ripped him.",
+      "published_date": 1692112038,
+      "thumbnail": "https://www.kansascity.com/latest-news/w4uy3b/picture278264033/alternates/FREE_1140/Angelbehindtheplate.jpg",
+      "authors": [
+        {
+          "name": "Pete Grathoff",
+          "email": "pgrathoff@kcstar.com"
+        }
+      ],
+      "keywords": "Angel Hernandez, Replay Review, overturned call, Kansas City Royals, Seattle Mariners",
+      "access_tags": [
+        "matbasic",
+        "matsport"
+      ],
+      "additional_sections": [
+        "6607",
+        "2415",
+        "84653",
+        "2687",
+        "2662"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Replay review overturned a call by umpire Angel Hernandez on a stolen base attempt and Kansas City Royals, Seattle Mariners fans ripped him.",
+      "content": "\u003cp\u003eMajor League Baseball umpire Ángel Hernández received some bad news Tuesday.\u003c/p\u003e\u003cp\u003eESPN reported a federal appeals court in Manhattan\u003ca href=\"https://www.espn.com/mlb/story/_/id/38196498/appeals-court-rejects-angel-hernandez-lawsuit-vs-mlb\" target=\"_blank\" rel=\"Follow\"\u003e declined to revive Hernández’s lawsuit\u003c/a\u003e that accused Major League Baseball of racial discrimination. A U.S. District Court had dismissed the suit in 2021.\u003c/p\u003e\u003cp\u003eThat original suit said MLB “manipulated its internal umpiring metrics to \u003ca href=\"https://www.kansascity.com/sports/spt-columns-blogs/for-petes-sake/article262345937.html\" target=\"_blank\" rel=\"Follow\"\u003edisadvantage minorities\u003c/a\u003e, thereby excluding them from becoming crew chiefs.”\u003c/p\u003e\u003cp\u003eUnfortunately for Hernández, there are external umpiring metrics that show the struggles he’s had at his job. For example, Hernández was the\u003ca href=\"https://twitter.com/UmpireAuditor/status/1690695696339398656\" target=\"_blank\" rel=\"Follow\"\u003e lowest rated plate umpire\u003c/a\u003e in Saturday’s games, according to Umpire Auditor. \u003c/p\u003e\u003cp\u003eHernández missed most of the \u003ca href=\"https://www.si.com/fannation/mlb/fastball/news/umpire-angel-hernandez-misses-more-calls-behind-home-plate-in-yankees-marlins-game\" target=\"_blank\" rel=\"Follow\"\u003e2023 season after having back surgery\u003c/a\u003e, according to Sports Illustrated. He will be back behind the plate Wednesday when the Royals play the Mariners at Kauffman Stadium.\u003c/p\u003e\u003cp\u003eTuesday’s legal ruling comes one day after Hernández missed a call during the Royals’ \u003ca href=\"https://www.kansascity.com/sports/mlb/kansas-city-royals/article278255853.html\" target=\"_blank\" rel=\"Follow\"\u003ebonkers 7-6 victory\u003c/a\u003e over Seattle. Royals outfielder Drew Waters was originally called safe on a stolen base attempt, but the Mariners challenged and \u003ca href=\"https://twitter.com/mlbreplays/status/1691281899937738752\" target=\"_blank\" rel=\"Follow\"\u003ethe call was overturned\u003c/a\u003e.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278263708% --\u003e\u003c/p\u003e\u003cp\u003eWhile clearly hoping for different outcomes from the review, Royals and Mariners fans were united on one point: their disgust with Hernández.\u003c/p\u003e\u003cp\u003eHere is some of what they were saying about the missed call at second base.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278263753% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278263773% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278264213% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278263808% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278263833% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278263838% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278263893% --\u003e\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278264253% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278260243",
+      "allow_ads": true,
+      "allow_stn_player": false,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Pete Grathoff\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:pgrathoff@kcstar.com\"\u003epgrathoff@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "Umpire Ángel Hernández was dealt a legal setback Tuesday, one day after missing a call in Royals’ win over Mariners.",
+      "lead_media": {
+        "id": "278264033",
+        "url": "https://www.kansascity.com/latest-news/w4uy3b/picture278264033",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "Angelbehindtheplate.jpg",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1692111491,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692111491,
+        "thumbnail": "https://www.kansascity.com/latest-news/w4uy3b/picture278264033/alternates/FREE_1140/Angelbehindtheplate.jpg",
+        "href": "/web/v1/content/278264033",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "USA TODAY Sports",
+        "dateline": "",
+        "caption": "Umpire Angel Hernandez (5) works at third base during a game between the Texas Rangers and the Houston Astros at Globe Life Field.",
+        "photographer": "Raymond Carlin III",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": [
+        {
+          "name": "mcc-breaking-ta"
+        }
+      ]
+    },
+    {
+      "id": "278252998",
+      "url": "https://www.kansascity.com/sports/spt-columns-blogs/for-petes-sake/article278252998.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Former Royals infielder Nicky Lopez sets a second MLB record with Atlanta Braves",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/6607",
+      "home_section": {
+        "name": "For Pete's Sake",
+        "url": "https://www.kansascity.com/sports/spt-columns-blogs/for-petes-sake/"
+      },
+      "modified_date": 1692109932,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Nicky Lopez: Two starts for Atlanta Braves, two MLB records",
+      "originating_url": "https://www.kansascity.com/sports/spt-columns-blogs/for-petes-sake/article278252998.html",
+      "meta_description": "Former Kansas City Royals infielder Nicky Lopez made his second start for the Atlanta Braves and set another Major League Baseball record.",
+      "published_date": 1692109932,
+      "thumbnail": "https://www.kansascity.com/latest-news/ahr0no/picture278262083/alternates/FREE_1140/NickTake2.jpg",
+      "authors": [
+        {
+          "name": "Pete Grathoff",
+          "email": "pgrathoff@kcstar.com"
+        }
+      ],
+      "keywords": "Nicky Lopez, Kansas City Royals, Atlanta Braves, record",
+      "access_tags": [
+        "matbasic",
+        "matsport"
+      ],
+      "additional_sections": [
+        "6607",
+        "2415",
+        "84653",
+        "2687",
+        "2662"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Former Kansas City Royals infielder Nicky Lopez made his second start for the Atlanta Braves and set another Major League Baseball record.",
+      "content": "\u003cp\u003eThe Atlanta Braves have a pair of MVP candidates in first baseman Matt Olson and right fielder Ronald Acuña.\u003c/p\u003e\u003cp\u003eBut neither of those two leads the team in average or on-base plus slugging percentage among players who have started at least one game. \u003ca href=\"https://www.mlb.com/braves/stats/ops?playerPool=ALL\" target=\"_blank\" rel=\"Follow\"\u003eAtlanta’s team leader\u003c/a\u003e in those categories is Nicky Lopez, the former Royals infielder. \u003c/p\u003e\u003cp\u003eThere’s an obvious caveat: Lopez has appeared in just three games with the Braves. But that doesn’t take away from what he has done since joining Atlanta.\u003c/p\u003e\u003cp\u003eLopez made his second start for the Braves on Monday and went three for four with three RBIs in Atlanta’s 11-3 win over the Yankees.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278262023% --\u003e\u003c/p\u003e\u003cp\u003eIn two starts for the Braves since being traded by the Royals last month, Lopez is batting .700 (7 for 10) with eight RBIs, five runs scored and a 1.800 OPS. \u003c/p\u003e\u003cp\u003eLopez had a \u003ca href=\"https://www.kansascity.com/sports/spt-columns-blogs/for-petes-sake/article278206707.html\" target=\"_blank\" rel=\"Follow\"\u003estat line unseen in MLB history\u003c/a\u003e in his first start on Saturday. He set another record Monday.\u003c/p\u003e\u003cp\u003eOpta Sports said\u003ca href=\"https://twitter.com/OptaSTATS/status/1691277142150012928?s=20\" target=\"_blank\" rel=\"Follow\"\u003e Lopez is the first player\u003c/a\u003e with seven or more hits and eight or more RBIs in his first two starts with a team since RBIs became an official stat in 1920.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278261328% --\u003e\u003c/p\u003e\u003cp\u003eAfter Monday’s game, Lopez was interviewed on the MLB Network. Jon Morosi jokingly asked Lopez if he’s told Acuña and Olson he’s now leading the team.\u003c/p\u003e\u003cp\u003e“\u003ca href=\"https://twitter.com/MLBNetwork/status/1691287438843322368?s=20\" target=\"_blank\" rel=\"Follow\"\u003eNo, I have not\u003c/a\u003e,” Lopez said with a smile. “I credit a lot of it to watching them hit in the cages, just trying to pick the brains of everyone I can here. I’ve learned so much since I’ve been here and who better to learn from than two MVP candidates, so it’s been awesome.”\u003c/p\u003e\u003cp\u003eToronto’s Whit Merrifield, a former Royals teammate, tweeted \u003ca href=\"https://twitter.com/WhitMerrifield/status/1691247223013613569?s=20\" target=\"_blank\" rel=\"Follow\"\u003ea short message\u003c/a\u003e about Lopez.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278261928% --\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278252998",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Pete Grathoff\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:pgrathoff@kcstar.com\"\u003epgrathoff@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "Nicky Lopez, the former Royals infielder, is on a hot streak with Atlanta, and he’s making MLB history.",
+      "lead_media": {
+        "id": "278262083",
+        "url": "https://www.kansascity.com/latest-news/ahr0no/picture278262083",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "NickTake2.jpg",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1692108347,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692108347,
+        "thumbnail": "https://www.kansascity.com/latest-news/ahr0no/picture278262083/alternates/FREE_1140/NickTake2.jpg",
+        "href": "/web/v1/content/278262083",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "USA TODAY Sports",
+        "dateline": "",
+        "caption": "Atlanta Braves second baseman Nicky Lopez (15) celebrates with teammates after scoring a run against the New York Yankees in the second inning at Truist Park.",
+        "photographer": "Brett Davis",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": [
+        {
+          "name": "mcc-timely-ta"
+        }
+      ]
+    },
+    {
+      "id": "278253013",
+      "url": "https://www.kansascity.com/sports/spt-columns-blogs/for-petes-sake/article278253013.html",
+      "asset_type": "story",
+      "state": "published",
+      "title": "Chargers star has zero interest in watching TV show about ‘my rival’ Patrick Mahomes",
+      "publication": "kansascity",
+      "layout_option": "none",
+      "home": "/web/v1/sections/6607",
+      "home_section": {
+        "name": "For Pete's Sake",
+        "url": "https://www.kansascity.com/sports/spt-columns-blogs/for-petes-sake/"
+      },
+      "modified_date": 1692107033,
+      "allow_index": true,
+      "allow_follow": true,
+      "meta_title": "Joey Bosa has no interest in watching Patrick Mahomes’ TV show",
+      "originating_url": "https://www.kansascity.com/sports/spt-columns-blogs/for-petes-sake/article278253013.html",
+      "meta_description": "Los Angeles Chargers Joey Bosa said there are better things to watch than Netflix’s “Quarterback” with Kansas City Chiefs’ Patrick Mahomes.",
+      "published_date": 1692107033,
+      "thumbnail": "https://www.kansascity.com/latest-news/4vnqt3/picture278253623/alternates/FREE_1140/BOSAandPatrickM.jpg",
+      "authors": [
+        {
+          "name": "Pete Grathoff",
+          "email": "pgrathoff@kcstar.com"
+        }
+      ],
+      "keywords": "Patrick Mahomes, Joey Bosa, Kansas City Chiefs, Los Angeles Chargers, Quarterabck",
+      "access_tags": [
+        "matbasic",
+        "matsport"
+      ],
+      "additional_sections": [
+        "6607",
+        "2694",
+        "2415",
+        "84653",
+        "2662"
+      ],
+      "credit": "",
+      "dateline": "",
+      "summary": "Los Angeles Chargers Joey Bosa said there are better things to watch than Netflix’s “Quarterback” with Kansas City Chiefs’ Patrick Mahomes.",
+      "content": "\u003cp\u003eShortly after the docuseries “Quarterback” was released, it became the \u003ca href=\"https://twitter.com/EquitySports/status/1681404723025575936?s=20\" target=\"_blank\" rel=\"Follow\"\u003emost-streamed show on Netflix\u003c/a\u003e.\u003c/p\u003e\u003cp\u003e“Quarterback” followed the Chiefs’ Patrick Mahomes, Vikings’ Kirk Cousins and Eagles’ Marcus Mariota through the 2022 season, and football fans have enjoyed many scenes inside the players’ homes and the mic’d-up moments on the field.\u003c/p\u003e\u003cp\u003eBut one NFL player has absolutely no interest in watching the show: Chargers defensive end Joey Bosa.\u003c/p\u003e\u003cp\u003eWhile on “The Doug Gottlieb Show,” Bosa was asked about the docuseries.\u003c/p\u003e\u003cp\u003e“I’m not going to watch that. \u003ca href=\"https://twitter.com/FoxSportsRadio/status/1691185424423682048\" target=\"_blank\" rel=\"Follow\"\u003eAre you kidding me\u003c/a\u003e?” Bosa said. “I’m going to watch that documentary on Mahomes? For what? What are you crazy? There’s 8 billion shows on TV, you think I’m going to go home and watch?\u003c/p\u003e\u003cp\u003e“Nothing against Mahomes, but I’m going to watch my rival, see how great he is?”\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278253488% --\u003e\u003c/p\u003e\u003cp\u003eTo be fair, Bosa has probably seen plenty of Mahomes highlights just by watching film of the Chiefs. Mahomes has a \u003ca href=\"https://www.pro-football-reference.com/players/M/MahoPa00/splits/\" target=\"_blank\" rel=\"Follow\"\u003e7-2 career record\u003c/a\u003e against the Chargers and has yet to lose on the road against the Chiefs’ AFC West rival.\u003c/p\u003e\u003cp\u003eBosa has 2 1/2 sacks and 12 quarterback hits in seven career games started by Mahomes.\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278253013",
+      "allow_ads": true,
+      "allow_stn_player": false,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Pete Grathoff\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_email\"\u003e\u003ca href=\"mailto:pgrathoff@kcstar.com\"\u003epgrathoff@kcstar.com\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\n",
+      "template_type": "",
+      "story_teaser": "The docuseries “Quarterback” with the Chiefs’ Patrick Mahomes has been a big hit for Netflix, but one person who won’t watch is Chargers defensive end Joey Bosa.",
+      "lead_media": {
+        "id": "278253623",
+        "url": "https://www.kansascity.com/latest-news/4vnqt3/picture278253623",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "BOSAandPatrickM.jpg",
+        "publication": "kansascity",
+        "layout_option": "",
+        "home": "/web/v1/sections/2415",
+        "modified_date": 1692062742,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692062742,
+        "thumbnail": "https://www.kansascity.com/latest-news/4vnqt3/picture278253623/alternates/FREE_1140/BOSAandPatrickM.jpg",
+        "href": "/web/v1/content/278253623",
+        "access_tags": [
+          "matbasic"
+        ],
+        "additional_sections": [
+          "2415"
+        ],
+        "credit": "USA TODAY Sports",
+        "dateline": "",
+        "caption": "Kansas City Chiefs quarterback Patrick Mahomes (15) meets with Los Angeles Chargers linebacker Joey Bosa (97) following a game at GEHA Field at Arrowhead Stadium.",
+        "photographer": "Jay Biggerstaff",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "KansasCity",
+      "allow_comments": true,
+      "disable_amp": false,
+      "topic_tags": [
+        {
+          "name": "mcc-timely-ta"
+        }
+      ]
+    }
+  ]
+}

--- a/data/thestreet.json
+++ b/data/thestreet.json
@@ -1,0 +1,1677 @@
+{
+  "items": [
+    {
+      "id": "278314883",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278314883.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "You may want to avoid this one airline for your Labor Day travels",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692217387,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.thestreet.com/travel/which-airline-not-take-for-labor-day-flight",
+      "meta_description": "A new report looks at the airlines most and least likely to face delays over Labor Day weekend.",
+      "published_date": 1692215378,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/u5dpg5/picture263361128/alternates/FREE_1140/spirit-jetblue-frontier.jpg",
+      "authors": [
+        {
+          "name": "Veronika Bondarenko",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87307"
+      ],
+      "credit": "TheStreet",
+      "dateline": "",
+      "summary": "A new report looks at the airlines most and least likely to face delays over Labor Day weekend.",
+      "content": "\u003cp\u003eAs the airport chaos seen over Fourth of July, Memorial Day and even the past 2\u003ca href=\"https://www.thestreet.com/travel/southwest-airlines-explanation-for-holiday-disruptions-is-underwhelming\"\u003e022-2023 holiday season \u003c/a\u003econtinues to show, the dates around federal days off have become a particularly risky time to travel.\u003c/p\u003e\u003cp\u003eWhile delays and cancelations are \u003ca href=\"https://www.thestreet.com/travel/southwest-airlines-explanation-for-holiday-disruptions-is-underwhelming\"\u003ealready high\u003c/a\u003e amid the explosion in travel demand seen after the pandemic, the risk\u003ca href=\"https://www.thestreet.com/lifestyle/travel/airline-cancels-thousands-of-flights-as-4th-of-july-looms-it-could-get-worse\"\u003e goes up exponentially \u003c/a\u003eduring high-traffic periods. Data from plane tracker website FlightAware shows that more than 3,000 flights were delayed or canceled on Fourth of July this year.\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eDon't Miss: \u003ca href=\"https://www.thestreet.com/travel/has-faa-extended-nyc-flight-limits\"\u003eThe government just stepped in to help airlines amid staffing crisis\u003c/a\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003eAccording to the latest Bureau of Transportation Statistics data \u003ca href=\"https://www.price4limo.com/labor-day-flight-delays.html\"\u003ecrunched by\u003c/a\u003e transportation company Price4Limo, JetBlue \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/JBLU\"\u003eJBLU\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=JBLU\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e is the airline statistically most likely to have a delay or cancelation during the upcoming holiday weekend.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278092072; alt=\"47a2aab0-8954-4da1-a811-eb27a331eb07\"% --\u003e\u003c/p\u003e\u003ch2\u003eWhile delays are high, some airports fare better than others on the holiday weekend\u003c/h2\u003e\u003cp\u003eLooking at data on Labor Days from 2017 to 2022, the report found that approximately 20% of departing JetBlue flights faced some sort of delay on that weekend. Across airports and airlines, the average number of flights to not depart on time was 13%.\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eMore Travel:\u003c/strong\u003e\u003c/p\u003e\u003cul\u003e\u003cli\u003e\u003ca href=\"https://www.thestreet.com/travel/a-new-travel-term-is-taking-over-the-internet-and-reaching-airlines-and-hotels\"\u003e\u003cstrong\u003eA new travel term is taking over the internet (and reaching airlines and hotels)\u003c/strong\u003e\u003c/a\u003e\u003c/li\u003e\u003cli\u003e\u003ca href=\"https://www.thestreet.com/topics/stock/top-rated-equity-airlines\"\u003e\u003cstrong\u003eThe 10 best airline stocks to buy now\u003c/strong\u003e\u003c/a\u003e\u003c/li\u003e\u003cli\u003e\u003ca href=\"https://www.thestreet.com/investing/airlines-see-a-new-kind-of-traveler-at-the-front-of-the-plane\"\u003e\u003cstrong\u003eAirlines see a new kind of traveler at the front of the plane\u003c/strong\u003e\u003c/a\u003e\u003c/li\u003e\u003c/ul\u003e\u003cp\u003eWhen it comes to airports, Daniel K. Inouye International Airport in Honolulu, Minneapolis-St. Paul International Airport and Seattle-Tacoma International Airport topped the good list with the most on-time Labor Day departures.\u003c/p\u003e\u003cp\u003ePuerto Rico's Luis Muñoz Martín International Airport and Newark Liberty International Airport, meanwhile, landed at the bottom. While only 7% of flights leaving Daniel K. Inouye International Airport on Fourth of July over the last five years faced delays, that number shot up to 18% for Newark.\u003c/p\u003e\u003cp\u003eAirlines with the lowest Labor Day delay rates include Hawaiian Airlines, Delta \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/DAL\"\u003eDAL\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=DAL\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e and Alaska Airlines \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/ALK\"\u003eALK\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=ALK\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e. \u003c/p\u003e\u003cp\u003eHawaii is a good place not just for its sunny beaches, but also for the efficiency of its airports and airlines. The state's main airline had the lowest delay rate in the country with only 6% of departing flights not leaving on time. \u003c/p\u003e\u003cp\u003eLow-cost carrier Spirit Airlines \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/SAVE\"\u003eSAVE\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=SAVE\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e had the highest rates of canceled flights in the country. Hawaiian Airlines also had the lowest cancelation rates in the nation.\u003c/p\u003e\u003ch2\u003eAirports with 'streamlined passenger flow, contingency plans' generally fare better\u003c/h2\u003e\u003cp\u003e\"From our findings, airports that fare better during peak times like these often have robust infrastructure, efficient staff training, and streamlined passenger flow management,\" Maddie Weirman of Price4Limo's creative team told TheStreet. \"Moreover, some airports have better contingency plans in place to deal with unexpected challenges, such as weather disruptions or technical issues.\"\u003c/p\u003e\u003cp\u003eTo better prepare for potential delays or other unforeseen problems, the authors of the study advise giving yourself more time by arriving earlier at the airport than usual. While \"chancing it\" and arriving just before check-in closes might have been good enough in the past, the long lines \u003ca href=\"https://www.thestreet.com/travel/these-are-the-worst-days-and-times-to-go-through-airport-customs\"\u003eseen at many airports\u003c/a\u003e even during non-holiday periods make one much more likely to miss a flight.\u003c/p\u003e\u003cp\u003eOther suggestions include checking the airline's website or app for real-time updates and going over TSA guidelines before packing to ensure you do not set off an alarm and get delayed at security.\u003c/p\u003e\u003cp\u003e\u003cem\u003e\u003ca href=\"https://www.price4limo.com/labor-day-flight-delays.html\"\u003eSEE HOW THE AIRPORTS AND AIRLINES YOU PLAN ON TAKING FARE HERE.\u003c/a\u003e\u003c/em\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Arena Media Brands, LLC THESTREET is a registered trademark of TheStreet, Inc.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278314883",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Veronika Bondarenko\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eTheStreet\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "A new report looks at the airlines most and least likely to face delays over Labor Day weekend.",
+      "lead_media": {
+        "id": "263361128",
+        "url": "https://www.mcclatchy-wires.com/incoming/u5dpg5/picture263361128",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "spirit-jetblue-frontier.jpg",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692217333,
+        "expires": 1693424978,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1657563892,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/u5dpg5/picture263361128/alternates/FREE_1140/spirit-jetblue-frontier.jpg",
+        "href": "/web/v1/content/263361128",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "The Street",
+      "copyright": "The Street",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278313138",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278313138.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Morningstar’s view of Buffett’s homebuilder stocks",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692215105,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.thestreet.com/stocks/buffett-buying-stocks-morningstar-view",
+      "meta_description": "The S\u0026P 500 index has climbed 15% year to date, but has slid 3.4% since July 31.",
+      "published_date": 1692213115,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/d4utef/picture275547051/alternates/FREE_1140/d9c234dc-59f4-4591-9807-07511d4227d1",
+      "authors": [
+        {
+          "name": "Dan Weil",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87307"
+      ],
+      "credit": "TheStreet",
+      "dateline": "",
+      "summary": "The S\u0026P 500 index has climbed 15% year to date, but has slid 3.4% since July 31.",
+      "content": "\u003cp\u003eCall it the Warren Buffett effect. \u003c/p\u003e\u003cp\u003eHomebuilder stocks rose Tuesday, after news that the investment icon's Berkshire Hathaway \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/BRK.B\"\u003eBRK.B\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=BRK.B\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/BRK.A\"\u003eBRK.A\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=BRK.A\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e \u003ca href=\"https://www.reuters.com/business/berkshire-invests-three-homebuilders-2023-08-14/\"\u003ebought shares of\u003c/a\u003e D.R. Horton \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/DHI\"\u003eDHI\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=DHI\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e, Lennar \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/LEN\"\u003eLEN\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=LEN\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e and NVR \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/NVR\"\u003eNVR\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=NVR\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e in the second quarter.\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eDON’T MISS: \u003c/strong\u003e\u003ca href=\"https://www.thestreet.com/investing/stocks/d-r-horton-shares-leap-after-warren-buffett-reveals-homebuilder-stake\"\u003e\u003cstrong\u003eD.R. Horton shares higher\u003c/strong\u003e\u003c/a\u003e\u003cstrong\u003e after Warren Buffett discloses stake in homebuilder\u003c/strong\u003e\u003c/p\u003e\u003cp\u003eThat led Morningstar to publish \u003ca href=\"https://www.morningstar.com/stocks/warren-buffetts-berkshire-hathaway-bought-us-housing-stocks-should-you\"\u003eits analyses of three\u003c/a\u003e major homebuilder stocks.\u003c/p\u003e\u003ch2\u003eD.R. Horton\u003c/h2\u003e\u003cp\u003eMorningstar moat (durable competitive advantage): none. Morningstar fair value estimate: $120. Wednesday stock quote: $125.\u003c/p\u003e\u003cp\u003e“D.R. Horton is the largest U.S. homebuilder, with an extensive geographic footprint, wide product breadth, and affordable price point,” wrote Morningstar analyst Brian Bernard. \u003c/p\u003e\u003cp\u003e“Management is focused on expanding the business while generating steady returns on invested capital and positive cash flows throughout the housing cycle.”\u003c/p\u003e\u003cp\u003eWhen it comes to pricing, “D.R. Horton has always been one of the more affordable homebuilders, at least compared with public peers,” Bernard said. “And the firm has clearly benefited from its pricing actions.”\u003c/p\u003e\u003cp\u003eIn D.R. Horton’s latest quarter, new orders surged 37% year over year, with orders up by a double-digit percentage across all regions, he noted. That came as the new-order average selling price declined 8% year over year to about $381,000.\u003c/p\u003e\u003ch2\u003eLennar\u003c/h2\u003e\u003cp\u003eMorningstar moat: none. Morningstar fair value estimate: $133. Wednesday stock quote: $124.40.\u003c/p\u003e\u003cp\u003e“We expect first-time buyers will be a key driver of future housing demand, and Lennar is well positioned to capture these potential buyers with its increased mix of entry-level homes,” Bernard said. \u003c/p\u003e\u003cp\u003e“Lennar controls an ample land supply, which affords it the ability to meet future demand while focusing on improving cash flows and maintaining a strong balance sheet.”\u003c/p\u003e\u003cp\u003eBut “the company has shifted to a lighter land acquisition strategy,” he said. “It seeks to reduce the amount of capital tied up in land by purchasing smaller land parcels and relying more on options to acquire land on a just-in-time basis.”\u003c/p\u003e\u003cp\u003eLike D.R. Horton, Lennar benefited from charging lower home prices in its latest quarter, he said. Its average selling price for new orders fell 11% to $457,000. And new orders gained 0.5%, after a 10% decline in the prior quarter.\u003c/p\u003e\u003ch2\u003eToll Brothers\u003c/h2\u003e\u003cp\u003e\u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/TOL\"\u003eTOL\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=TOL\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e\u003c/p\u003e\u003cp\u003eMorningstar moat: none. Morningstar fair value: $76. Wednesday stock quote: $81.20.\u003c/p\u003e\u003cp\u003e“Toll Brothers prides itself on controlling an ample supply of some of the best land in the industry,” Bernard said. “Its premier land inventory and luxurious, customizable designs allow the company to charge average selling prices that lead its publicly traded industry peers.” \u003c/p\u003e\u003cp\u003eAs a result, “we think Toll Brothers will capitalize on what we see as favorable long-term housing demand dynamics,” he said.\u003c/p\u003e\u003cp\u003eCaution: “[While] we think Toll Brothers can achieve positive economic profits in a healthy market, we expect competition and the company's more capital-intensive land acquisition strategy to restrain those profits,” Bernard said. \u003c/p\u003e\u003cp\u003eTo be sure, “management is focused on moving to a lighter land strategy and has made substantial progress.”\u003c/p\u003e\u003cp\u003eMeanwhile, Toll Brothers reported “good” earnings in the latest quarter, with key performance metrics all exceeding management’s guidance, Bernard said. \u003c/p\u003e\u003cp\u003e\u003cstrong\u003eNote to investors: \u003c/strong\u003eOf the three stocks, only Lennar trades below Morningstar’s fair value estimate. \u003c/p\u003e\u003cp\u003e\u003cem\u003eThe author of this story owns shares of Berkshire Hathaway.\u003c/em\u003e\u003c/p\u003e\u003cp\u003e\u003cstrong\u003e\u003cem\u003eGet investment guidance from trusted portfolio managers without the management fees. Sign up for \u003ca href=\"https://subscriptions.thestreet.com/action-alerts-plus?placement=editorialv1\"\u003eAction Alerts PLUS\u003c/a\u003e now.\u003c/em\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Arena Media Brands, LLC THESTREET is a registered trademark of TheStreet, Inc.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278313138",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Dan Weil\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eTheStreet\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "The S\u0026P 500 index has climbed 15% year to date, but has slid 3.4% since July 31.",
+      "lead_media": {
+        "id": "275547051",
+        "url": "https://www.mcclatchy-wires.com/incoming/d4utef/picture275547051",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "d9c234dc-59f4-4591-9807-07511d4227d1",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692215057,
+        "expires": 1693422715,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1684422937,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/d4utef/picture275547051/alternates/FREE_1140/d9c234dc-59f4-4591-9807-07511d4227d1",
+        "href": "/web/v1/content/275547051",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "The Street",
+      "copyright": "The Street",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278313133",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278313133.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Kroger, Costco, and Walmart rival Aldi buys 400 grocery stores",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692215103,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.thestreet.com/retailers/kroger-costco-and-walmart-rival-makes-big-low-cost-grocery-move",
+      "meta_description": "The already crowded low-cost grocery market just got a little bit more crowded which should be good for consumers.",
+      "published_date": 1692213360,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/mvmiy9/picture274736861/alternates/FREE_1140/622a560e-0344-49a7-a082-a688195fc7a4",
+      "authors": [
+        {
+          "name": "Daniel Kline",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87307"
+      ],
+      "credit": "TheStreet",
+      "dateline": "",
+      "summary": "The already crowded low-cost grocery market just got a little bit more crowded which should be good for consumers.",
+      "content": "\u003cp\u003eThe uncertain nature of the United States economy has forced more people into looking for bargains. That might be because people have lost their jobs, fear losing their jobs, or just because caution makes sense when bad economic times are either here or could be on the horizon.\u003c/p\u003e\u003cp\u003eThere's also the matter of inflation and lingering supply chain problems driving prices higher. Yes, those numbers have begun to come down, which even Walmart WMT CEO Doug McMillon has acknowledged, but prices are still higher than they were before the covid pandemic.\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eDON'T MISS: \u003ca href=\"https://www.thestreet.com/retailers/walmart-shares-a-warning-for-customers\"\u003eWalmart shares a warning for customers\u003c/a\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003eHigher prices everywhere have driven some customers away from traditional grocery chains to lower-cost options. That's something Walmart CFO John David Rainey addressed during the chain's \u003ca href=\"https://www.fool.com/earnings/call-transcripts/2023/05/18/walmart-wmt-q1-2024-earnings-call-transcript/\"\u003efirst-quarter earnings call\u003c/a\u003e.\u003c/p\u003e\u003cp\u003e\"Share gains in grocery continued, including from higher-income households, as our strong price gaps resonate with customers who are increasingly prioritizing value and convenience,\" he said.\u003c/p\u003e\u003cp\u003eCostco has also been open on its earnings calls about how while inflation has decreased, pricing pressure remains. That has forced both chains to take lower margins in order to hold onto (or even gain) market share.\u003c/p\u003e\u003cp\u003eit's a difficult time for any player in the grocery space, but lower-cost options like Costco \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/COST\"\u003eCOST\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=COST\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e, Walmart, and through sheer buying power, Kroger \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/KR\"\u003eKR\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=KR\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e (although it's not a traditional low-cost player) have an advantage. It's a case where bigger has proven better and larger chains can leverage their size to get better prices which they can pass on to their customers.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:270008697; alt=\"0b04fc83-da87-4fa4-9029-d507424ba775\"% --\u003e\u003c/p\u003e\u003ch2\u003eAldi becomes a bigger grocery player\u003c/h2\u003e\u003cp\u003eAldi, a German grocery chain, has been building its presence in the United States, specifically the Southeast, and now has over 2,000 American stores. The chain is based on offering low prices and has been recognized as the number one grocery chain in price according to the dunnhumby Retailer Preference Index Report for the past six years.\u003c/p\u003e\u003cp\u003eThe chain competes with Walmart, Costco, Kroger, as well as regional giant Publix. Now, it has made a major move to accelerate its growth. The company has reached an agreement to buy Winn-Dixie and Harveys Supermarket as part of a larger divestiture of their parent company Southeastern Grocers to various entities.  \u003c/p\u003e\u003cp\u003e“Like Aldi, Winn-Dixie and Harveys Supermarket have long histories and many loyal customers in the Southeast and we look forward to serving them in the years to come,” said Aldi CEO Jason Hart said in a press release.  \u003c/p\u003e\u003cp\u003eThe company plans to operate the stores and add 120 new Aldi locations in the coming year. Some of the locations, which are spread across Alabama, Florida, Georgia, Louisiana, and Mississippi, will be rebranded with the Aldi name. \u003c/p\u003e\u003cp\u003e“Aldi will operate Winn-Dixie and Harveys Supermarket stores with the same level of care and focus on quality and service, as we also evaluate which locations will convert to the Aldi format to better support the neighborhoods we’ll now have the privilege of serving,” added Hart. “For those stores we do not convert, our intention is that these continue to operate as Winn-Dixie and Harveys Supermarket stores.”\u003c/p\u003e\u003cp\u003eThe sale is expected to close in the first half of 2024 and is subject to regulatory approval.  \u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Arena Media Brands, LLC THESTREET is a registered trademark of TheStreet, Inc.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278313133",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Daniel Kline\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eTheStreet\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "The already crowded low-cost grocery market just got a little bit more crowded which should be good for consumers.",
+      "lead_media": {
+        "id": "274736861",
+        "url": "https://www.mcclatchy-wires.com/incoming/mvmiy9/picture274736861",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "622a560e-0344-49a7-a082-a688195fc7a4",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692215053,
+        "expires": 1693422960,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1682522083,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/mvmiy9/picture274736861/alternates/FREE_1140/622a560e-0344-49a7-a082-a688195fc7a4",
+        "href": "/web/v1/content/274736861",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "caption": "People believe inflation is higher than it is.Image source: Jeremy Hogan/SOPA Images/LightRocket via Getty Images",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "The Street",
+      "copyright": "The Street",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278312278",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278312278.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Wayfair, Mattress Firm face bankruptcy risk",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692213844,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.thestreet.com/retailers/these-two-big-name-retailers-face-a-major-bankruptcy-risk",
+      "meta_description": "It has been an awful year for a number of retailers, and more of your favorite brands might be in their final days.",
+      "published_date": 1692212400,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/suiw3f/picture261515297/alternates/FREE_1140/retail-sale_2.jpg",
+      "authors": [
+        {
+          "name": "Daniel Kline",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87307"
+      ],
+      "credit": "TheStreet",
+      "dateline": "",
+      "summary": "It has been an awful year for a number of retailers, and more of your favorite brands might be in their final days.",
+      "content": "\u003cp\u003eBed Bath \u0026 Beyond seemed as if it'd remain a cornerstone of brick-and-mortar retail for decades to come. \u003c/p\u003e\u003cp\u003eThe brand, founded in 1971, sold merchandise that people like to touch and see before they buy. \u003c/p\u003e\u003cp\u003eSheets, bedding and bath towels aren't immune from online disruption, but physical retailers have an advantage when it comes to items that touch people's skin. Nonetheless, the company had been stumbling for years and was liquidated earlier this year. (The former Overstock.com has bought and taken on its name.) \u003c/p\u003e\u003cp\u003e\u003cstrong\u003eDON'T MISS: \u003ca href=\"https://www.thestreet.com/retailers/beloved-retailer-closes-its-doors-for-now\"\u003eBeloved retailer closes its doors (for now)\u003c/a\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003eBed Bath \u0026 Beyond wasn't the only big retail name we lost this year. Christmas Tree Shops, which it once owned, closed its doors for good on Aug. 12. While it was not a national player, the brand had a cult-like following in New England where it began. But that was not enough to save it. \u003c/p\u003e\u003cp\u003eNot every Chapter 11 has turned into a Chapter 7 liquidation. David's Bridal was saved at the last minute and will continue operating most of its stores. That's a major relief for thousands of brides who had ordered but not received their wedding dresses.\u003c/p\u003e\u003cp\u003eTwo other big-name retailers run a real risk of filing for bankruptcy, according to a leading index that tracks the short- and long-term health of public and privately held retailers.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:274116940; alt=\"52b27290-213f-438c-a1be-d35c4623a2dd\"% --\u003e\u003c/p\u003e\u003ch2\u003eWatch these two major retailers\u003c/h2\u003e\u003cp\u003eRapid Ratings uses two metrics to track the health of retail companies. The Financial Health Rating index uses a 0-100 scale that looks at a company's short-term estimated probability of default. The Core Health Score is a longer-term view of a company's overall health.\u003c/p\u003e\u003cp\u003eHaving an FHR or a CHR under 40 shows that a company is at high risk for default while a score under 20 is a major red flag.\u003c/p\u003e\u003cp\u003eIn a May reading of those numbers, only Mattress Firm had both numbers under 20 (a 19 in each case) while Wayfair \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/W\"\u003eW\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=W\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e had an FHR of 19 and a CHS of 29.  \u003c/p\u003e\u003cp\u003e“Financial corporate health is a good deal like physical health. Healthy companies are in the best position to withstand a shock,” Rapid Ratings Chief Executive James Gellert told \u003ca href=\"https://www.forbes.com/sites/pamdanziger/2023/05/03/more-retail-bankruptcies-are-brewing-after-bed-bath--beyond-and-davids-bridal/?sh=56e00a5a4656\"\u003eForbes\u003c/a\u003e, adding that his company’s ratings are measures of financial health and not credit ratings.\u003c/p\u003e\u003cp\u003eMattress Firm had filed for an IPO but has pulled the offering, citing the current economic environment. \u003c/p\u003e\u003cp\u003eIt's important to note that Rapid Ratings has access only to the financial information companies share publicly. Both these retailers could have financial moves planned that are not yet publicly known. \u003c/p\u003e\u003cp\u003e Neither Wayfair nor Mattress Firm immediately returned a request to comment.\u003c/p\u003e\u003ch2\u003eMore bankruptcies are likely to come\u003c/h2\u003e\u003cp\u003eThe end of cheap credit and easy access to venture capital for any company calling itself a high-growth technology-driven business has put a lot of digital-native companies at risk. \u003c/p\u003e\u003cp\u003e\u003ca href=\"https://www.retaildive.com/news/digitally-native-retailers-risk-of-bankruptcy-wayfair-real-real/643978/\"\u003eRetailDive\u003c/a\u003e in March reported a list of 11 digital-native companies that were at risk for bankruptcy. That list included digital stalwarts like Boxed and RealReal. \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/REAL\"\u003eREAL\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=REAL\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e (Boxed \u003ca href=\"https://www.reuters.com/business/retail-consumer/e-commerce-firm-boxed-inc-files-bankruptcy-eyes-software-unit-sale-2023-04-03/\"\u003efiled Chapter 11\u003c/a\u003e in April.)\u003c/p\u003e\u003cp\u003eWayfair was on that list as well.\u003c/p\u003e\u003cp\u003e\"Take Wayfair for example. The retailer, by design, sells a broad range of offerings in an effort to attract a wide consumer base. The problem is, so does Overstock. And Amazon. And Target. And Walmart. And a large swath of other major retailers,\" the website noted. \u003c/p\u003e\u003cp\u003eA Chapter 11 filing, again, does not mean the end; it gives a company breathing room and an opportunity to reorganize. And as we saw with Bed Bath \u0026 Beyond, even liquidation does not mean the brand name will disappear. \u003c/p\u003e\u003cp\u003eBankruptcy risk is an assessment based on known financial data. A company that's having short-term issues could well end up avoiding such a filing.   \u003c/p\u003e\u003cp\u003e\u003cstrong\u003e\u003cem\u003eSign up for \u003ca href=\"https://subscriptions.thestreet.com/real-money-pro?placement=editorialv3\"\u003eReal Money Pro\u003c/a\u003e to learn the ins and outs of the trading floor from Doug Kass’s Daily Diary.\u003c/em\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Arena Media Brands, LLC THESTREET is a registered trademark of TheStreet, Inc.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278312278",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Daniel Kline\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eTheStreet\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "It has been an awful year for a number of retailers, and more of your favorite brands might be in their final days.",
+      "lead_media": {
+        "id": "261515297",
+        "url": "https://www.mcclatchy-wires.com/incoming/suiw3f/picture261515297",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "retail-sale_2.jpg",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692213793,
+        "expires": 1693422000,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1652791044,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/suiw3f/picture261515297/alternates/FREE_1140/retail-sale_2.jpg",
+        "href": "/web/v1/content/261515297",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "The Street",
+      "copyright": "The Street",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278311483",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278311483.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Their bags are packed but they’re not ready to go.",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692213003,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.thestreet.com/lifestyle/travel/airlines-get-a-green-light-on-using-afghan-airspace-but-flights-are-few-and-far-between",
+      "meta_description": "Their bags are packed but they’re not ready to go.",
+      "published_date": 1692210743,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/y2ikuu/picture278311193/alternates/FREE_1140/55b0b4c6-c853-401a-bfea-19feff60f5b3",
+      "authors": [
+        {
+          "name": "Brian O’Connell",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87307"
+      ],
+      "credit": "TheStreet",
+      "dateline": "",
+      "summary": "Their bags are packed but they’re not ready to go.",
+      "content": "\u003cp\u003eUncle Sam has taken the brakes off on banning U.S. airlines from Afghan airspace, greenlighting commercial flights to the country for the first time in two years, as of July 25, 2023.\u003c/p\u003e\u003cp\u003eDue to improved procedures implemented by the Taliban authorities, the U.S. Federal Aviation Administration stated \"US civil aviation operations in the Kabul FIR (OAKX) may resume at altitudes at or above FL320 (32,000 feet) due to diminished risks ... at those altitudes\".\u003c/p\u003e\u003cp\u003eThe response from American air carrier personnel? “Thanks, but no thanks.”\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eDON’T MISS: \u003ca href=\"https://www.thestreet.com/topics/stock/top-rated-equity-airlines\"\u003eThe 10 Best Airline Stocks to Buy Now\u003c/a\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e“There’s no ATC (air traffic control) service across the entire country, there’s a seemingly endless list of surface-to-air weaponry they might start shooting at you if you fly too low, and if you have to divert then good luck with the Taliban,” stated the OPSGroup, a membership organization representing pilots, dispatcher, scheduler, and controllers, \u003ca href=\"https://abcnews.go.com/Business/wireStory/fly-taliban-held-afghanistan-new-faa-rules-planes-102301964\"\u003eas reported by The Associated Press\u003c/a\u003e.\u003c/p\u003e\u003cp\u003eThat’s an intriguing take from airline professionals whose companies are looking to save costs wherever possible – and Afghanistan is a budget-cutters dream. \u003c/p\u003e\u003cp\u003eMore Travel:\u003c/p\u003e\u003cul\u003e\u003cli\u003e\u003ca href=\"https://www.thestreet.com/travel/a-new-travel-term-is-taking-over-the-internet-and-reaching-airlines-and-hotels\"\u003eA new travel term is taking over the internet (and reaching airlines and hotels)\u003c/a\u003e\u003c/li\u003e\u003cli\u003e\u003ca href=\"https://www.thestreet.com/topics/stock/top-rated-equity-airlines\"\u003eThe 10 best airline stocks to buy now\u003c/a\u003e\u003c/li\u003e\u003cli\u003e\u003ca href=\"https://www.thestreet.com/investing/airlines-see-a-new-kind-of-traveler-at-the-front-of-the-plane\"\u003eAirlines see a new kind of traveler at the front of the plane\u003c/a\u003e\u003c/li\u003e\u003c/ul\u003e\u003cp\u003eFor starters, the central Asia county lies in the direct flight path for commercial airlines looking for flights from and to India from Europe and the U.S. By skirting Afghan airspace, commercial airliners may be acting safely on behalf of flight personnel worried about the possibility of being targeted from Taliban anti-aircraft fire.\u003c/p\u003e\u003cp\u003eYet by bypassing direct routes over Afghanistan, which was taken over by the Taliban two years ago, airlines are giving up a chance to save millions of dollars on added fuel expenses.\u003c/p\u003e\u003cp\u003eThat’s apparently okay with major U.S. and European airlines, like United Airlines and Virgin Atlantic, which both indicated to the Associated Press they would avoid flying directly over Afghan airspace, even at 32,000-feet heights the U.S. military has said is out of reach of Taliban anti-aircraft weaponry. The Taliban reportedly holds an estimated 4,500 shoulder-launched anti-aircraft weapons although it has made no direct threats to use them on commercial airliners recently.\u003c/p\u003e\u003cp\u003eAirlines, however, aren't taking any chances.\u003c/p\u003e\u003cp\u003e“In accordance with current FAA rules, United operates Newark to New Delhi flights over a small section of Afghanistan where air traffic control is provided by other countries,” United Airlines told the AP. “We do not plan to expand our use of Afghan airspace at this time.”\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eGet exclusive access to portfolio managers and their proven investing strategies with \u003c/strong\u003e\u003ca href=\"https://subscriptions.thestreet.com/real-money-pro?placement=editorialv1\"\u003e\u003cstrong\u003eReal Money Pro\u003c/strong\u003e\u003c/a\u003e\u003cstrong\u003e. Get started now\u003c/strong\u003e.\u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Arena Media Brands, LLC THESTREET is a registered trademark of TheStreet, Inc.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278311483",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Brian O\u0026#39;Connell\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eTheStreet\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Their bags are packed but they’re not ready to go.",
+      "lead_media": {
+        "id": "278311193",
+        "url": "https://www.mcclatchy-wires.com/incoming/y2ikuu/picture278311193",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "55b0b4c6-c853-401a-bfea-19feff60f5b3",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692212991,
+        "expires": 1693420343,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692210743,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/y2ikuu/picture278311193/alternates/FREE_1140/55b0b4c6-c853-401a-bfea-19feff60f5b3",
+        "href": "/web/v1/content/278311193",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "The Street",
+      "copyright": "The Street",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278310568",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278310568.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Fed minutes show inflation risk too high, but economy to avoid recession",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692211924,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.thestreet.com/investing/stocks/fed-minutes-show-inflation-risk-too-high-but-economy-to-avoid-recession",
+      "meta_description": "The red-hot U.S. economy is likely to avoid recession this year, minutes of the Fed's last policy meeting suggest, but inflation risks will likely require at least one more rate hike to tame.",
+      "published_date": 1692209918,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/mdlrme/picture271912032/alternates/FREE_1140/8c8b0c11-1f74-4d86-af6a-04970d4d2d9b",
+      "authors": [
+        {
+          "name": "Martin Baccardax",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87307"
+      ],
+      "credit": "TheStreet",
+      "dateline": "",
+      "summary": "The red-hot U.S. economy is likely to avoid recession this year, minutes of the Fed's last policy meeting suggest, but inflation risks will likely require at least one more rate hike to tame.",
+      "content": "\u003cp\u003eFederal Reserve officials hinted at the idea of a 'soft landing' for the U.S. economy, minutes of the central bank's July policy meeting indicated, suggesting a recession will likely be avoided but cautioning on the need for near-term rate hikes.\u003c/p\u003e\u003cp\u003e The minutes, taken from the Fed's policy meeting that ended on July 26, reflect both the central bank's official statement, as well as comments from Chairman Jerome Powell to reporters that followed its decision to lift its benchmark lending rate by a quarter of a percentage point to a twenty-two year high of between 5% and 5.25%.\u003c/p\u003e\u003cp\u003ePolicymakers also noted that inflation pressures remain \"unacceptably high\", adding that more data was needed in order to determine if price pressures are firmly on the patch towards the Fed's 2% target following a two-year low reading for headline CPI of 3% in June.\u003c/p\u003e\u003cp\u003e\"Since the emergence of stress in the banking sector in mid-March, indicators of spending and real activity had come in stronger than anticipated; as a result, the staff no longer judged that the economy would enter a mild recession toward the end of the year,\" the minutes indicated. \u003c/p\u003e\u003cp\u003e\"However, the staff continued to expect that real GDP growth in 2024 and 2025 would run below their estimate of potential output growth, leading to a small increase in the unemployment rate relative to its current level,\" the minutes read. \u003c/p\u003e\u003cp\u003eU.S. stocks were modestly lower following the release of the minutes at 2:00 pm Eastern time, with the Dow Jones Industrial Average down 55 points on the session and the S\u0026P 500 falling 14 points alongside a corresponding rise in Treasury bond yields.\u003c/p\u003e\u003cp\u003eBenchmark 10-year note yields were pegged at 3.254%, nearing the highest levels in fifteen years, while 2-year notes changed hands at 4.982%. The dollar index, which tracks the greenback against a basket of six global currencies, was up 0.23% to 103.401.\u003c/p\u003e\u003cp\u003eThe \u003ca href=\"https://www.cmegroup.com/markets/interest-rates/cme-fedwatch-tool.html\"\u003eCME Group's FedWatch\u003c/a\u003e now indicates an 88.5% chance that the Fed will hold rates steady at its next meeting in September, with bets on a quarter point increase in November rising to around 35.4%. \u003c/p\u003e\u003cp\u003e\"Participants noted the recent reduction in total and core inflation rates,\" the minutes indicated. \"However, they stressed that inflation remained unacceptably high and that further evidence would be required for them to be confident that inflation was clearly on a path toward the Committee’s 2%objective.\" \u003c/p\u003e\u003cp\u003eSolid retail sales for the month of July, which showed the key control group reading -- which feeds into GDP calculations -- surging 1% from the prior month, have added to hopes that consumers are weathering the Federal Reserve's aggressive rate hikes while continuing to leverage the earnings power of an historically tight labor market. \u003c/p\u003e\u003cp\u003eThe spending rush, however, has revived concerns that the Fed may need to lift rates once more between now and the end of the year in order to keep inflation from ticking higher over the autumn months. \u003c/p\u003e\u003cp\u003eFurther signs of a recovery in the housing market added to that concern, with July housing starts rising by a faster-than-expected 3.9%, to an annualized rate of 1.452 million units, even as the Mortgage Bankers' Association said 30-year mortgage rates matched a 2001 high of 7.16% last week. \u003c/p\u003e\u003cul\u003e\u003cli\u003e\u003cstrong\u003e Get investment guidance from trusted portfolio managers without the management fees. Sign up for \u003ca href=\"https://subscriptions.thestreet.com/action-alerts-plus?placement=editorialv1\"\u003eAction Alerts PLUS\u003c/a\u003e now.\u003c/strong\u003e\u003c/li\u003e\u003c/ul\u003e\u003cp\u003e\u003ci\u003eThe Arena Media Brands, LLC THESTREET is a registered trademark of TheStreet, Inc.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278310568",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Martin Baccardax\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eTheStreet\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "The red-hot U.S. economy is likely to avoid recession this year, minutes of the Fed’s last policy meeting suggest, but inflation risks will likely require at least one more rate hike to tame.",
+      "lead_media": {
+        "id": "271912032",
+        "url": "https://www.mcclatchy-wires.com/incoming/mdlrme/picture271912032",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "8c8b0c11-1f74-4d86-af6a-04970d4d2d9b",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692211881,
+        "expires": 1693419518,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1675251416,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/mdlrme/picture271912032/alternates/FREE_1140/8c8b0c11-1f74-4d86-af6a-04970d4d2d9b",
+        "href": "/web/v1/content/271912032",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "The Street",
+      "copyright": "The Street",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278309768",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278309768.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Rebel’s Edge -Analyzing Market News- $DLO, $TGT, $HRB, and Anthony Richardson",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692211021,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.thestreet.com/investing/rebels-edge-august-16",
+      "meta_description": "Jon and Pete Najarian join forces to discuss and debate their favorite topics, including the hottest stock-specific news and sports! Today: $DLO, $TGT, $HRB, and Anthony Richardson",
+      "published_date": 1692209132,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/z6fang/picture278309588/alternates/FREE_1140/5318bf28-7a6a-42ab-a40a-9a72d4809f4e",
+      "authors": [
+        {
+          "name": "Market Rebellion",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87307"
+      ],
+      "credit": "TheStreet",
+      "dateline": "",
+      "summary": "Jon and Pete Najarian join forces to discuss and debate their favorite topics, including the hottest stock-specific news and sports! Today: $DLO, $TGT, $HRB, and Anthony Richardson",
+      "content": "\u003cp\u003eJoin Jon and Pete Najarian on today's episode of Rebel's Edge as they discuss stocks including DLocal spiking 52% after major UOA action, Target slashing its outlook, H\u0026R Block riding a nice bump, and Coherent sliding on rough guidance. Gain a deeper understanding of these stocks as Jon and Pete share their perspectives, potential growth prospects, and market predictions. They also talk about Anthony Richardson starting against the Bears, and Lamar Jackson's dynamic with his OC. Stay on the cutting edge with Rebel's Edge.\u003c/p\u003e\u003cp\u003eLearn more about options trading with Jon and Pete at: \u003ca href=\"https://marketrebellion.com/getstarted/?utm_source=thesteet\u0026utm_campaign=rebelsedge\u0026utm_medium=referral\"\u003ehttps://marketrebellion.com\u003c/a\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Arena Media Brands, LLC THESTREET is a registered trademark of TheStreet, Inc.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278309768",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Market Rebellion\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eTheStreet\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Jon and Pete Najarian join forces to discuss and debate their favorite topics, including the hottest stock-specific news and sports! Today: $DLO, $TGT, $HRB, and Anthony Richardson",
+      "lead_media": {
+        "id": "278309588",
+        "url": "https://www.mcclatchy-wires.com/incoming/z6fang/picture278309588",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "5318bf28-7a6a-42ab-a40a-9a72d4809f4e",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692210987,
+        "expires": 1693418732,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692209132,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/z6fang/picture278309588/alternates/FREE_1140/5318bf28-7a6a-42ab-a40a-9a72d4809f4e",
+        "href": "/web/v1/content/278309588",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "The Street",
+      "copyright": "The Street",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278296458",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278296458.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Madonna makes shocking Las Vegas Strip return",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692207903,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.thestreet.com/travel/huge-star-makes-shocking-las-vegas-strip-return",
+      "meta_description": "One of the biggest acts of all time will make a triumphant Las Vegas return after a major health problem.",
+      "published_date": 1692191708,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/vm33kj/picture270113762/alternates/FREE_1140/4fb0c78c-9141-47f9-ba4b-d712aba82895",
+      "authors": [
+        {
+          "name": "Daniel Kline",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87307"
+      ],
+      "credit": "TheStreet",
+      "dateline": "",
+      "summary": "One of the biggest acts of all time will make a triumphant Las Vegas return after a major health problem.",
+      "content": "\u003cp\u003eEvery big star plays the Las Vegas Strip.\u003c/p\u003e\u003cp\u003eFor some, Las Vegas has become a way to stay active while not touring. Stars like Lady Gaga, Katy Perry, Adele and Garth Brooks remain among the world's biggest stars, and their Las Vegas Strip residencies enable them to play regularly without the hassle of touring.\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eDON'T MISS: \u003ca href=\"https://www.thestreet.com/travel/las-vegas-strip-adding-two-unique-and-very-different-attractions\"\u003eLas Vegas Strip adding two unique (and very different) attractions\u003c/a\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003eThat's also true for acts that have made Las Vegas their home, like Donny Osmond and Wayne Newton, who have residencies at Caesars Entertainment \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/CZR\"\u003eCZR\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=CZR\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e properties. Osmond and Newton are sort of \"only in Las Vegas\" performers, acts that feel right on the Strip but might struggle to find an audience elsewhere.\u003c/p\u003e\u003cp\u003eWhen you visit Las Vegas you can pick from performers ranging from the biggest stars in the business to nostalgia acts like Boys II Men, Kylie Minogue, and pretty much any star from the '80s or '90s. Sin City has also become the electronic dance music capital, with every big name playing both day and night clubs.\u003c/p\u003e\u003cp\u003eIn addition to its residencies, Las Vegas has become a can't-miss tour stop for every major act. Both Taylor Swift and BTS played multiple nights at Allegiant Stadium and pretty much every national tour has to stop on the Strip (or just off the Strip in the case of the stadium).\u003c/p\u003e\u003cp\u003eMadonna had been scheduled in January to bring her tour to Las Vegas, but a bacterial infection nearly killed the iconic performer. \u003c/p\u003e\u003cp\u003eNow, in a surprise announcement, the singer, who has not shared a lot of information about her recovery, will bring her \"Celebration\" tour to T-Mobile Arena for two shows, March 1-2.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:277861353; alt=\"2cf727f0-33bd-4479-be83-15827760aff4\"% --\u003e\u003c/p\u003e\u003ch2\u003eMadonna makes triumphant Las Vegas Strip return   \u003c/h2\u003e\u003cp\u003eActs who made their names in the 1980s and 90s have become a bit of a sweet spot for Las Vegas. U2, perhaps the biggest act from that time period, will open the Sphere \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/SPHR\"\u003eSPHR\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=SPHR\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e, a new concert venue that has lit up the Las Vegas Strip with its exterior displays.\u003c/p\u003e\u003cp\u003eIn addition to U2, \u003ca href=\"https://www.thestreet.com/travel/las-vegas-strip-brings-back-classic-superstar-residency\"\u003eShania Twain will soon return to the Strip\u003c/a\u003e, bringing back her residency, but her return isn't as surprising as Madonna making her way back to T-Mobile Arena so soon after her health crisis.\u003c/p\u003e\u003cp\u003eIn a July Twitter (now X) post Madonna, who is 65, updated her fans on her health.\u003c/p\u003e\u003cp\u003e“My first thought when I woke up in the hospital was my children,” she said. “My second thought was that I did not want to disappoint anyone who bought tickets for my tour. I didn’t want to let down the people who worked tirelessly with me over the last few months to create my show. I didn’t want to disappoint anyone.\"\u003c/p\u003e\u003cp\u003eThat's a noble sentiment from an artist who has been one of the most successful performers of all time. \u003c/p\u003e\u003cp\u003eMadonna last played Las Vegas in 2019 but has not headlined an arena on the Strip since her 2015 \"Rebel Heart\" tour, when she played MGM Resorts International's \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/MGM\"\u003eMGM\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=MGM\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e MGM Grand Garden.   \u003c/p\u003e\u003cp\u003eThe artist, whose last tour was in the guise of her \"Madame X\" persona, is expected to perform her greatest hits on her current tour. \u003c/p\u003e\u003cp\u003eSince people with tickets to her canceled shows from January have priority on tickets to these shows, no on-sale date for any remaining tickets has been announced. \u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Arena Media Brands, LLC THESTREET is a registered trademark of TheStreet, Inc.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278296458",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Daniel Kline\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eTheStreet\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "One of the biggest acts of all time will make a triumphant Las Vegas return after a major health problem.",
+      "lead_media": {
+        "id": "270113762",
+        "url": "https://www.mcclatchy-wires.com/incoming/vm33kj/picture270113762",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "4fb0c78c-9141-47f9-ba4b-d712aba82895",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692192024,
+        "expires": 1693401308,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1671220573,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/vm33kj/picture270113762/alternates/FREE_1140/4fb0c78c-9141-47f9-ba4b-d712aba82895",
+        "href": "/web/v1/content/270113762",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "Image source\u0026colon; Robert Mora\u0026sol;Getty Images",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "The Street",
+      "copyright": "The Street",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278305038",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278305038.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "This is the one thing you need to do to start investing in real estate",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692205145,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.thestreet.com/real-estate/what-do-i-need-to-do-to-start-investing-real-estate",
+      "meta_description": "Ryan Serhant of Million Dollar Listing New York tells TheStreet his best investing advice.",
+      "published_date": 1692204538,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/y6zaa0/picture272143182/alternates/FREE_1140/131b49dc-60ca-4b43-be48-ac4c68ece527",
+      "authors": [
+        {
+          "name": "Veronika Bondarenko",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87307"
+      ],
+      "credit": "TheStreet",
+      "dateline": "",
+      "summary": "Ryan Serhant of Million Dollar Listing New York tells TheStreet his best investing advice.",
+      "content": "\u003cp\u003eWith the housing markets in many states \u003ca href=\"https://www.thestreet.com/housing/vanguard-home-prices-lower-2023\"\u003efinally starting\u003c/a\u003e to slow, many see now as their time to get in on real estate investing.\u003c/p\u003e\u003cp\u003eMany have been anxiously awaiting even the smallest cooldown to do everything from identifying an \u003ca href=\"https://www.thestreet.com/housing/what-is-the-most-desirable-neighborhood-real-estate\"\u003eup-and-coming neighborhood\u003c/a\u003e for rentals or buying a vacation property for the summer season to locking in \u003ca href=\"https://realmoney.thestreet.com/investing/don-t-chase-housing-rally-airbnb-effect-crumbling-16127637\"\u003etheir first mortgage \u003c/a\u003eand finally starting to build equity.\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eDon't Miss: \u003ca href=\"https://www.thestreet.com/investing/real-estate-vs-stock-investing-15106133\"\u003eReal estate vs. stock investing — which is a better investment?\u003c/a\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003eRyan Serhant of Comcast \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/CMCSA\"\u003eCMCSA\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=CMCSA\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e-owned Bravo series \"Million Dollar Listing New York\" told TheStreet that would-be investors should think of their real estate agent as a personal \"investment advisor\" who knows the market and can help find properties that can bring in the most money.\u003c/p\u003e\u003ch2\u003e'They're financially incentivized for you to win on the buy,' Serhant tells TheStreet\u003c/h2\u003e\u003cp\u003e\"Take it slow and do your research right, work with a seasoned professional and treat them as your partner,\" Serhant told TheStreet in an exclusive video interview. \"Maybe they come in on a deal with you, but if they don't, they're financially incentivized for you to win both on the buy and on the potential sell or lease out of the space.\"\u003c/p\u003e\u003cp\u003eAlong with working with a professional, Serhant advises first-time and early investors to not get caught into what may look like a really low price or great opportunity but to take the time to understand the ins and outs of the market.\u003c/p\u003e\u003cp\u003e\"I would move to the opposite direction of any trend and just be really, really, really, really smart,\" Serhant said. \"Do it once, make sure it works, and then continue to go from there. The biggest concern for any real estate investor today is probably regulatory changes and different hurdles.\"\u003c/p\u003e\u003ch2\u003eHere is how a change in regulation can 'immediately change' your investment\u003c/h2\u003e\u003cp\u003eThe above-mentioned hurdles often come down to the laws and regulations that investors coming from another state do not always consider. Serhant says that the strict restrictions on short-term rentals New York City enacted in 2022 are still confusing many wealthy investors coming in from other states and countries.\u003c/p\u003e\u003cp\u003e\"If you're an investor and you're banking on those Airbnb \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/ABNB\"\u003eABNB\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=ABNB\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e rates and that ROI and then Florida enacts some sort of regulatory change that says, nope, no more short term leases in the entire state, ... that immediately changes your investment and it will for everybody else that bought for short-term housing reasons,\" Serhant said.\u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Arena Media Brands, LLC THESTREET is a registered trademark of TheStreet, Inc.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278305038",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Veronika Bondarenko\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eTheStreet\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Ryan Serhant of Million Dollar Listing New York tells TheStreet his best investing advice.",
+      "lead_media": {
+        "id": "272143182",
+        "url": "https://www.mcclatchy-wires.com/incoming/y6zaa0/picture272143182",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "131b49dc-60ca-4b43-be48-ac4c68ece527",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692205122,
+        "expires": 1693414138,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1675617566,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/y6zaa0/picture272143182/alternates/FREE_1140/131b49dc-60ca-4b43-be48-ac4c68ece527",
+        "href": "/web/v1/content/272143182",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "caption": "David McNew/Getty Images",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "The Street",
+      "copyright": "The Street",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278304558",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278304558.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Michael Oher’s ex-teammate and ESPN analyst reacts to accusations against Tuohys",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692204304,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.thestreet.com/sports/michael-ohers-ex-teammate-espn-analyst-reacts-accusations-against-tuohys",
+      "meta_description": "Oher is accusing the Tuohys of tricking him into signing away his name and likeness.",
+      "published_date": 1692203530,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/5wk2sr/picture278304388/alternates/FREE_1140/5aa7ef66-a476-45f1-bcaa-71e999698b54",
+      "authors": [
+        {
+          "name": "Colin Salao",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87307"
+      ],
+      "credit": "TheStreet",
+      "dateline": "",
+      "summary": "Oher is accusing the Tuohys of tricking him into signing away his name and likeness.",
+      "content": "\u003cp\u003eMichael Oher is filing a lawsuit against the Tuohy family, and many aren't sure what to make of the situation nearly 15 years since \"The Blind Side\" was released. \u003c/p\u003e\u003cp\u003eDomonique Foxworth, a sports media personality and former teammate of Oher, spoke on “The Dan Le Batard Show” on Tuesday, August 15 and reacted to the fact of Oher accusing the Tuohy family of tricking him into signing a conservatorship.\u003c/p\u003e\u003cp\u003eFoxworth, who with Oher on the Baltimore Ravens in 2009 when the “The Blind Side” film was released, acknowledged that these are still just accusations and the truth is still unclear, but he could see how Oher’s side could be true.\u003c/p\u003e\u003cp\u003e“It's an interesting story to look back on because I could see how this can happen,” Foxworth said. “You're a young kid, and this family has to the best of your knowledge looked out for you up to this point, and they asked you to sign some papers because we're going to make you an official member of our family. Apparently, that's what Michael believes happened.”\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eDON’T MISS: \u003ca href=\"https://www.thestreet.com/sports/local-service-industry-workers-have-a-lot-to-say-about-the-tuohys\"\u003eLocal service industry workers have a lot to say about the Tuohys\u003c/a\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003eFoxworth, who played in the defensive secondary during his six years in the NFL, admitted that he wasn’t the closest of friends with Oher given that his ex-teammate was on the offensive line. He described Oher as \"low key\" and \"soft-spoken.\"\u003c/p\u003e\u003cp\u003eBut he noticed enough to see that Oher still did have a relationship with the Tuohys, at least during the immediate aftermath of the film.\u003c/p\u003e\u003cp\u003e“The Tuohy family was around often and he did have them involved in his affairs,” Foxworth said. “I remember doing charity events with Michael when they would show up so at that point, they were still in his life in some way.”\u003c/p\u003e\u003cp\u003eFoxworth also said that Oher would “welcome them into the facility from time to time.”\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eMore Sports Business:\u003c/strong\u003e\u003c/p\u003e\u003cul\u003e\u003cli\u003e\u003ca href=\"https://www.thestreet.com/restaurants/inside-chipotle-ambitious-sports-marketing-strategy-formula-1-team\"\u003e\u003cstrong\u003eInside Chipotle’s ambitious sports marketing strategy and its partnership with a Formula 1 team\u003c/strong\u003e\u003c/a\u003e\u003c/li\u003e\u003cli\u003e\u003ca href=\"https://www.thestreet.com/lifestyle/sports/the-saudi-multi-billion-dollar-investment-in-global-sports-explained\"\u003e\u003cstrong\u003eThe Saudi multi-billion dollar investment in global sports explained\u003c/strong\u003e\u003c/a\u003e\u003c/li\u003e\u003cli\u003e\u003ca href=\"https://www.thestreet.com/sports/how-the-pga-tour-saudi-pif-drama-could-spill-into-the-nba\"\u003e\u003cstrong\u003eHow the PGA Tour, Saudi PIF drama could spill into the NBA\u003c/strong\u003e\u003c/a\u003e\u003c/li\u003e\u003c/ul\u003e\u003cp\u003eOher is filing a lawsuit against the Tuohys, alleging they tricked him into signing away his name and legal authority and then earned millions of dollars from his name and likeness from the release of the film. \u003c/p\u003e\u003cp\u003eThe film showed Oher signing some papers soon after he turned 18, but Oher believed they were adoption papers. Had he been legally adopted, he would have been able to retain the authority to his finances. \u003c/p\u003e\u003cp\u003eThe lawsuit says Oher only learned about this in February of this year.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278304383% --\u003e\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eReceive full access to real-time market analysis along with stock, commodities, and options trading recommendations. Sign up for \u003ca href=\"https://subscriptions.thestreet.com/real-money-pro?placement=editorialv2\"\u003eReal Money Pro\u003c/a\u003e now.\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Arena Media Brands, LLC THESTREET is a registered trademark of TheStreet, Inc.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278304558",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Colin Salao\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eTheStreet\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Oher is accusing the Tuohys of tricking him into signing away his name and likeness.",
+      "lead_media": {
+        "id": "278304388",
+        "url": "https://www.mcclatchy-wires.com/incoming/5wk2sr/picture278304388",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "5aa7ef66-a476-45f1-bcaa-71e999698b54",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692204251,
+        "expires": 1693413130,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692203530,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/5wk2sr/picture278304388/alternates/FREE_1140/5aa7ef66-a476-45f1-bcaa-71e999698b54",
+        "href": "/web/v1/content/278304388",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "The Street",
+      "copyright": "The Street",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278304433",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278304433.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Forget Kid Rock: Bud Light faces a new big-name critic",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692204122,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.thestreet.com/restaurants/forget-kid-rock-bud-light-face-a-new-big-name-critic",
+      "meta_description": "The Anheuser-Busch beer brand has seen sales drop by nearly 30% since its controversial marketing program with the transgender influencer Dylan Mulvaney.",
+      "published_date": 1692203513,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/iisf7p/picture275599461/alternates/FREE_1140/e2b1d982-5b95-4784-8492-f114f38eab0e",
+      "authors": [
+        {
+          "name": "Daniel Kline",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87307"
+      ],
+      "credit": "TheStreet",
+      "dateline": "",
+      "summary": "The Anheuser-Busch beer brand has seen sales drop by nearly 30% since its controversial marketing program with the transgender influencer Dylan Mulvaney.",
+      "content": "\u003cp\u003eKid Rock may have started the anti-Bud-Light campaign, but he certainly has not been the only star to make his feelings known. \u003c/p\u003e\u003cp\u003eMost stars have been more subtle than Rock and did not, as he did, choose to shoot up cases of the formerly best-selling beer in the world, but lots of statements have been made.\u003c/p\u003e\u003cp\u003eCountry-music stars Travis Tritt and John Rich (of Big \u0026 Rich fame) have made clear that they won't support the Anheuser-Busch \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/BUD\"\u003eBUD\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=BUD\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e brand anymore. \u003c/p\u003e\u003cp\u003eThat's been a popular opinion for conservatives who took issue with the brand engaging the transgender social-media influencer Dylan Mulvaney for an online marketing campaign.\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eDON'T MISS: \u003ca href=\"https://www.thestreet.com/restaurants/mcdonalds-menu-adds-controversial-new-item\"\u003eMcDonald's menu adds a potentially dangerous item\u003c/a\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003eShowing how strongly you oppose diversity and inclusion has become a sort of right-wing calling card and Anheuser-Busch has not been the only company affected. Target \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/TGT\"\u003eTGT\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=TGT\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e also said in its recent earnings call that its revenue was hurt by boycotts tied to its sales of Pride Month merchandise.  \u003c/p\u003e\u003cp\u003eWalt Disney has also faced its fair share of anti-woke fallout. The entertainment stalwart has been targeted by Florida Gov. Ron DeSantis -- although it's unclear whether those issues have actually caused the slight slowdown at Disney World. \u003c/p\u003e\u003cp\u003eIn a broad sense, the world has become very polarized as even Chick-fil-A, a famously right-leaning company, faced boycotts (albeit mostly unsuccessful ones) when it posted an ad for a vice president of diversity, equity, and inclusion.\u003c/p\u003e\u003cp\u003eNow, the Bud Light saga has taken a new turn as Anheuser-Busch heir Billy Busch has offered to buy the Budweiser brand from its current owners.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:275746316; alt=\"81237ace-a77d-472e-8ecf-35fe21b5d8a1\"% --\u003e\u003c/p\u003e\u003ch2\u003eBusch offers to buy Budweiser\u003c/h2\u003e\u003cp\u003e Speaking on the far-right media personality Tomi Lahren's \u003ca href=\"https://www.youtube.com/watch?v=2eFGP7F_9-c\u0026embeds_referring_euri=https%3A%2F%2Fwww.washingtonexaminer.com%2F\u0026source_ve_path=OTY3MTQ\u0026feature=emb_imp_woyt\"\u003epodcast/YouTube show\u003c/a\u003e, Busch made his offer.  \u003c/p\u003e\u003cp\u003e“If they don’t want that brand any longer, sell it back to the Busch family. Sell it to me. I’ll be the first in line to buy that brand back from you, and we’ll make that brand great again,” he said.\u003c/p\u003e\u003cp\u003eThe Budweiser Brand is owned by Anheuser-Busch Inbev \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/BUD\"\u003eBUD\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=BUD\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e, which is based in Belgium. That has put the beer brand, which has always used a lot of American iconography in its ads, under the ownership of a foreign company. This does not appear to sit well with Busch. \u003c/p\u003e\u003cp\u003eHe says the new owners have not run the company in the same way his family did.\u003c/p\u003e\u003cp\u003e“That culture is completely gone now,” Busch said. “They knew who their drinkers were,\" he added. “...We’ve always cared very, very much about the people in America. What made this company great was America, of course.\"\u003c/p\u003e\u003cp\u003eBusch also says the new owners are listening to the wrong people.\u003c/p\u003e\u003ch2\u003eBusch blames Bud Light's boss  \u003c/h2\u003e\u003cp\u003eIn addition to the Mulvaney fallout, Bud Light also faced a backlash after former Bud Light Vice President Alissa Heinerscheid appeared on the \u003ca href=\"https://ninesliving.com/make-yourself-at-home-podcast-alissa-heinerscheid-bud-light/\"\u003eMake Yourself At Home\u003c/a\u003e podcast and made some comments that struck long-time fans of the brand the wrong way.\u003c/p\u003e\u003cp\u003e“We had this hangover, I mean Bud Light had been kind of a brand of fratty, kind of out-of-touch humor, and it was really important that we had another approach,” she said.\u003c/p\u003e\u003cp\u003eThose remarks were made before the Mulvaney issue broke publicly, and there was little backlash at the time. But after the Mulvaney campaign Heinerscheid's comments were used to illustrate another way the brand had lost touch with its customers.\u003c/p\u003e\u003cp\u003eBusch says the problem goes deeper than that.\u003c/p\u003e\u003cp\u003e“When you are a foreign company and you rely on these woke students that are coming out of these local colleges to do your advertising for you, you’re making a big mistake,” he said. \u003c/p\u003e\u003cp\u003e\u003cstrong\u003e\u003cem\u003eReceive full access to real-time market analysis along with stock, commodities, and options trading recommendations. Sign up for \u003ca href=\"https://subscriptions.thestreet.com/real-money-pro?placement=editorialv2\"\u003eReal Money Pro\u003c/a\u003e now.\u003c/em\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Arena Media Brands, LLC THESTREET is a registered trademark of TheStreet, Inc.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278304433",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Daniel Kline\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eTheStreet\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "The Anheuser-Busch beer brand has seen sales drop by nearly 30% since its controversial marketing program with the transgender influencer Dylan Mulvaney.",
+      "lead_media": {
+        "id": "275599461",
+        "url": "https://www.mcclatchy-wires.com/incoming/iisf7p/picture275599461",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "e2b1d982-5b95-4784-8492-f114f38eab0e",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692204054,
+        "expires": 1693413113,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1684524272,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/iisf7p/picture275599461/alternates/FREE_1140/e2b1d982-5b95-4784-8492-f114f38eab0e",
+        "href": "/web/v1/content/275599461",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "Image source\u0026colon; Shutterstock",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "The Street",
+      "copyright": "The Street",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278300073",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278300073.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Southwest Airlines expands its presence in Nashville",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692198063,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.thestreet.com/travel/southwest-airlines-makes-surprise-move-passengers-will-like",
+      "meta_description": "The airline has done something that rivals including JetBlue, American and United are struggling with.",
+      "published_date": 1692196931,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/aerub4/picture270440357/alternates/FREE_1140/3061730a-0798-4673-b946-ce8cd8edcb99",
+      "authors": [
+        {
+          "name": "Daniel Kline",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87307"
+      ],
+      "credit": "TheStreet",
+      "dateline": "",
+      "summary": "The airline has done something that rivals including JetBlue, American and United are struggling with.",
+      "content": "\u003cp\u003eIt has been a rough few years for the airline industry\u003c/p\u003e\u003cp\u003eFirst, the covid pandemic essentially drove demand to zero, That was devastating in the short term, but it also had a much longer-range effect. \u003c/p\u003e\u003cp\u003e\u003cstrong\u003eDON'T MISS: \u003ca href=\"https://www.thestreet.com/travel/southwest-airlines-making-huge-boarding-process-change\"\u003eSouthwest Airlines making huge boarding process change\u003c/a\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003eAs covid raged and operations diminished, airlines found ways to shed staff to save money. Southwest Airlines \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/LUV\"\u003eLUV\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=LUV\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e did not have any layoffs, but thousands of its pilots took early retirement.\u003c/p\u003e\u003cp\u003eThe same thing happened at pretty much every airline. JetBlue, Delta, American, United Airlines, and really the entire industry lost pilots that they now have no easy way to replace. That's a significant problem as covid has stopped being an active concern and air travel has returned more or less to prepandemic levels.\u003c/p\u003e\u003cp\u003eThe lack of pilots, of course, is not the only problem limiting growth at the airlines. Boeing has fallen behind on its deliveries and the Federal Aviation Administration faces an acute shortage of air-traffic controllers.\u003c/p\u003e\u003cp\u003eThese problems have caused many airlines to cut routes and limit service in certain markets. Many of the above-mentioned airlines have cut as much as 10% of their flights from New York and Washington because the FAA allowed them to do so due to the shortage of air-traffic controllers.\u003c/p\u003e\u003cp\u003eSouthwest, however, despite dealing with its own pilot and aircraft delivery issues, has continued to expand and has added a major new hub.  \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:271064037; alt=\"8abd892f-6bc6-4747-8bd1-1f36b0a1ab56\"% --\u003e\u003c/p\u003e\u003ch2\u003eSouthwest expanding in Nashville\u003c/h2\u003e\u003cp\u003eSouthwest has decided to build its 12th crew base at Nashville International Airport. The airline will open its new crew base with 150 to 250 pilots starting in early 2024 and will grow that to 500 to 600 pilots and 500 to 700 flight attendants going forward. \u003c/p\u003e\u003cp\u003e\"Hundreds of Southwest employees who work in the air and on the ground already consider their hometown to be in middle Tennessee, with our presence in Nashville remaining a key factor to our success, future growth, and the reliability of our network,\" Southwest Chief Operating Officer Andrew Watterson said.\u003c/p\u003e\u003cp\u003eA crew base is a hub where crew members live and from where they can start their workdays. It's common in the airline industry for pilots and flight attendants to live in places other than their base cities. That adds a layer of potential problems as those staff members need to fly to get to their assignments.\u003c/p\u003e\u003cp\u003eSouthwest has been flying out of Nashville since 1986 and it's now the largest carrier at the airport. Adding a crew base in the city is part of the airline's broad plan to avoid delays and eliminate systemwide failures like the holiday meltdown that left tens of thousands of passengers stranded last December.\u003c/p\u003e\u003cp\u003e\u003cstrong\u003e\u003ca href=\"https://aap.thestreet.com/story/16130473/1/we-re-moving-this-bullpen-name-up-to-the-portfolio.html?placement=editorialMCD\"\u003eHere’s why we just bought shares in this fast-food chain! (It’s not what you think)\u003c/a\u003e\u003c/strong\u003e\u003c/p\u003e\u003ch2\u003eSouthwest has fixed its pilot shortage (for now)\u003c/h2\u003e\u003cp\u003eSouthwest Air has been dealing with a pilot shortage and increased competition when it comes to hiring pilots. Watterson addressed the matter during the company's \u003ca href=\"https://www.fool.com/earnings/call-transcripts/2023/07/27/southwest-airlines-luv-q2-2023-earnings-call-trans/\"\u003esecond-quarter-earnings call\u003c/a\u003e.\u003c/p\u003e\u003cp\u003e\"It's definitely a hot pilot market. And, I guess, hot employee market as well. You have to work extra to hire people and to keep people. And so, it's a record year from our pilot hiring,\" he said.\u003c/p\u003e\u003cp\u003eThat does not tell the full story as keeping pilots has been a challenge, but the problems have not hurt Southwest's plans so far.\u003c/p\u003e\u003cp\u003e\"It's also a record year for pilot attrition, but it's a modest number that is not sufficient to actually change our plan. So, our amount of flying we have this year and the next is not at all affected by this, kind of, a little bit uptick in attrition this year,\" he added.\u003c/p\u003e\u003cp\u003eSouthwest is currently negotiating a new contract with its pilots union while other airlines have reached new deals.  \u003c/p\u003e\u003cp\u003e\"We do see pilots as a kind of a job hop around the industry, trying to maximize their personal gain, what airline appeals them the best. And I don't begrudge that to them because it's once you start with the main line, it becomes ... a lifelong commitment\" because of the seniority system, he said. \u003c/p\u003e\u003cp\u003eWatterson also says those issues might be settling down.\u003c/p\u003e\u003cp\u003e\"We do see some people who come and leave right away, but it's -- I think it kind of spiked here in the second quarter and now it's kind of even starting to tail off a little bit,\" the COO added. \u003c/p\u003e\u003cp\u003e\u003cstrong\u003e\u003cem\u003eGet exclusive access to portfolio managers and their proven investing strategies with \u003ca href=\"https://subscriptions.thestreet.com/real-money-pro?placement=editorialv1\"\u003eReal Money Pro\u003c/a\u003e. Get started now.\u003c/em\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Arena Media Brands, LLC THESTREET is a registered trademark of TheStreet, Inc.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278300073",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Daniel Kline\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eTheStreet\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "The airline has done something that rivals including JetBlue, American and United are struggling with.",
+      "lead_media": {
+        "id": "270440357",
+        "url": "https://www.mcclatchy-wires.com/incoming/aerub4/picture270440357",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "3061730a-0798-4673-b946-ce8cd8edcb99",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692197993,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1671978000,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/aerub4/picture270440357/alternates/FREE_1140/3061730a-0798-4673-b946-ce8cd8edcb99",
+        "href": "/web/v1/content/270440357",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "caption": "Robert Alexander/Getty Images",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "The Street",
+      "copyright": "The Street",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278298133",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278298133.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "A private jet came close to colliding with a Southwest plane",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692195661,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.thestreet.com/travel/private-jet-near-collision-southwest-plane",
+      "meta_description": "The National Transportation Safety Board is currently investigating a \"runway incursion and overflight\" between a private jet and Southwest plane.",
+      "published_date": 1692194759,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/opq2gt/picture258877663/alternates/FREE_1140/southwest_072221.jpg",
+      "authors": [
+        {
+          "name": "Veronika Bondarenko",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87307"
+      ],
+      "credit": "TheStreet",
+      "dateline": "",
+      "summary": "The National Transportation Safety Board is currently investigating a \"runway incursion and overflight\" between a private jet and Southwest plane.",
+      "content": "\u003cp\u003ePlane collisions are incredibly rare, but still the source of many people's \u003ca href=\"https://www.thestreet.com/travel/how-to-get-over-fear-of-flying\"\u003eflying fears\u003c/a\u003e. One air safety study \u003ca href=\"https://bea.aero/etudes/abordageseng/midair.htm\"\u003econducted over decades\u003c/a\u003e showed there's an average of one-and-a-half in-air plane crashes a year.\u003c/p\u003e\u003cp\u003eEvery plane is closely monitored from the ground by a\u003ca href=\"https://www.thestreet.com/travel/planes-collide-following-near-miss-at-jfk\"\u003e team of air traffic\u003c/a\u003e controllers, so most dangerous situations can be spotted well in advance and averted by one or either of the planes' pilots. Runway crashes are \u003ca href=\"https://www.thestreet.com/travel/planes-collide-following-near-miss-at-jfk\"\u003emore common\u003c/a\u003e but still very rare.\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eDon't Miss: \u003ca href=\"https://www.thestreet.com/travel/planes-collide-following-near-miss-at-jfk\"\u003ePlanes collide following near miss at same airport earlier this week\u003c/a\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003eEven so, some close calls do occur and make for splashy news stories. On August 11, a private Cessna Citation jet narrowly avoided crashing into a Southwest Airlines \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/LUV\"\u003eLUV\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=LUV\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e plane when preparing to land at San Diego International Airport.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278298073; alt=\"21657110-eb02-4799-b01e-aa654ceeb2a3\"% --\u003e\u003c/p\u003e\u003ch2\u003ePrivate jet cleared to land in same runway space as Southwest plane\u003c/h2\u003e\u003cp\u003eThe National Transportation Safety Board (NTSB) is currently investigating the incident. They \u003ca href=\"https://twitter.com/NTSB_Newsroom/status/1690462206473682945?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E1690462206473682945%7Ctwgr%5E4cabb69f45dadd5a78f5a8b107efdc75c08ef56e%7Ctwcon%5Es1_\u0026ref_url=https%3A%2F%2Fwww.nbcsandiego.com%2Fnews%2Flocal%2Ffaa-investigating-close-call-between-southwest-jet-and-cessna-at-san-diego-international-airport%2F3284372%2F\"\u003ewrote on Twitter \u003c/a\u003ethat a \"runway incursion and overflight\" occurred when \"a Cessna 560X was cleared to land on Runway 27 and conflicted with a Southwest Airlines Boeing \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/BA\"\u003eBA\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=BA\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e 737.\"\u003c/p\u003e\u003cp\u003eNTSB Chair Jennifer Homendy later told CNN that the Cessna came \"within 100 feet” of the Southwest passenger plane and narrowly missed a collision. Southwest's Flight 2493 was preparing to leave San Diego's airport for San Jose.\u003c/p\u003e\u003cp\u003eThe collision was averted when an air traffic controller spotted the Southwest plane in the spot where the private jet was supposed to land and called off instructions to descend. Still, Homendy said the fact that the two planes came so close is a \"big concern for [her] and the agency.\"\u003c/p\u003e\u003ch2\u003e'I worry about potential tragedy,' says NTSB chair\u003c/h2\u003e\u003cp\u003e\"I worry about potential tragedy,\" she told CNN. In this case, no injuries occurred.\u003c/p\u003e\u003cp\u003eThe Federal Aviation Authority is also reviewing to see where the wires got crossed.\u003c/p\u003e\u003cp\u003e\"The controller had previously cleared the Citation to land on Runway 27 and then instructed Southwest Flight 2493 to taxi onto that runway and wait for instructions to depart,\" the preliminary report says. \"The facility's automated surface surveillance system alerted the controller about the developing situation.\"\u003c/p\u003e\u003cp\u003eAudio captured from the incident also reveals that the pilot of the Cessna had repeatedly double-checked whether it was safe to land.\u003c/p\u003e\u003cp\u003e“Verify Four Hotel Victor is still clear to land?” the pilot is heard asking.\u003c/p\u003e\u003cp\u003e“Citation Four Hotel Victor go around, fly the published missed approach,” responds the air traffic controller in the tower.\u003c/p\u003e\u003cp\u003eAt the end of July, an in-air collision was averted when the \u003ca href=\"https://www.thestreet.com/travel/mid-sky-horror-two-planes-nearly-collided-mid-air-injuries-reported\"\u003epilot of an Allegiant Air flight\u003c/a\u003e flying into Kentucky's Lexington from Fort Lauderdale \"received an automated alert about another aircraft at the same altitude\" and immediately \"took evasive action\" to avoid crashing into a private Gulfstream jet.\u003c/p\u003e\u003cp\u003eThe sudden swerve sent two flight attendants flying backward (one was later treated for injuries) and gave a huge shock to the passengers aboard.\u003c/p\u003e\u003cp\u003e\"It honestly felt like a roller coaster, like when you come down from the highest point, and then you take a big hill,\" one of the passengers on the flight told news outlets upon landing.\u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Arena Media Brands, LLC THESTREET is a registered trademark of TheStreet, Inc.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278298133",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Veronika Bondarenko\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eTheStreet\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "The National Transportation Safety Board is currently investigating a “runway incursion and overflight” between a private jet and Southwest plane.",
+      "lead_media": {
+        "id": "258877663",
+        "url": "https://www.mcclatchy-wires.com/incoming/opq2gt/picture258877663",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "southwest_072221.jpg",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692195644,
+        "expires": 1693404359,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1646066062,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/opq2gt/picture258877663/alternates/FREE_1140/southwest_072221.jpg",
+        "href": "/web/v1/content/258877663",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "caption": "Image source: Shutterstock",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "The Street",
+      "copyright": "The Street",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278297748",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278297748.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Celebrity Cruise Line sailing more ships from Florida",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692194463,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.thestreet.com/travel/royal-caribbean-makes-a-major-celebrity-cruise-change",
+      "meta_description": "The cruise company has done something that matches recent efforts by MSC and Carnival Cruise Line.",
+      "published_date": 1692193072,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/5yp4gq/picture258723638/alternates/FREE_1140/royal_carribean_ship_1.jpg",
+      "authors": [
+        {
+          "name": "Daniel Kline",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87307"
+      ],
+      "credit": "TheStreet",
+      "dateline": "",
+      "summary": "The cruise company has done something that matches recent efforts by MSC and Carnival Cruise Line.",
+      "content": "\u003cp\u003eCruising has long been a global travel option with ships leaving from Europe, Australia, Singapore, Israel, and a number of other spots around the world. Royal Caribbean even recently shared that it plans to return a ship to China for the first time since the covid pandemic in the coming months.\u003c/p\u003e\u003cp\u003eBut, while there are cruises that originate all over the world, it’s fair to call Florida the industry’s home base, specifically three ports on the state’s east coast – Miami, Fort Lauderdale, and Port Canaveral. In fact, Port Canaveral recently passed Miami as the busiest cruise port in the world, but all three east coast Florida ports are bustling.\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eDON’T MISS: \u003ca href=\"https://www.thestreet.com/restaurants/royal-caribbean-considers-pricing-change-passengers-would-hate\"\u003eRoyal Caribbean considers big dining change passengers won't like\u003c/a\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003eBoth Royal Caribbean and Carnival have generally based their newest ships in either Miami or Port Canaveral. Wonder of the Seas, Royal Caribbean’s flagship and Carnival Celebration, that cruise line’s newest (and largest) ship has sailed (mostly) out of Miami and Port Canaveral. \u003c/p\u003e\u003cp\u003eMSC has also been stepping up its commitment to Florida sailing multiple ships out of Miami and Port Canaveral. Like its rivals, that includes one of its newest ships, MSC Seascape, sailing out of Miami.\u003c/p\u003e\u003cp\u003eThat trend will continue as the next two Royal Caribbean ships, the soon-to-be largest ship in the world Icon of the Seas, and the next Oasis-class ship, Utopia of the Seas will sail out of Miami and Port Canaveral respectively. Utopia will actually sail 3-4 day itineraries out of Port Canaveral, taking over from Allure of the Seas, the first ship in that celebrated class to sail short itineraries while Icon will be used for weeklong sailings out of Miami.\u003c/p\u003e\u003cp\u003eThat’s a massive commitment from the cruise line to put its newest hardware into those ports while also sailing multiple ships from each of the east coast Florida ports. Now, Royal Caribbean is making a similar commitment to Florida with its higher-end Celebrity brand.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:270498257; alt=\"26b0e466-5c17-49b4-879f-0e45217b6035\"% --\u003e\u003c/p\u003e\u003ch2\u003eCelebrity cruise line brings more ships to Florida\u003c/h2\u003e\u003cp\u003eCelebrity has generally rotated one or more of its ships through Miami, Port Canaveral, and Fort Lauderdale (Port Everglades). Now, for the winter 2024-2025 season, the Royal Caribbean-owned brand intends to base four of its ships in Florida for an extended period. \u003c/p\u003e\u003cp\u003eTwo ships – Celebrity Apex and Summit – will sail out of Fort Lauderdale’s Port Everglades. From October 23, 2024, to March 8, 2025, Apex will sail 6-7-night itineraries making stops in destinations including St. Maarten, San Juan, Grand Cayman, and Mexico, as well as select sailings to \u003cem\u003ePerfect Day at CocoCay\u003c/em\u003e\u003cem\u003e.\u003c/em\u003e Summit, the smaller and older of the two ships, will sail 5-9 night itineraries from February 25, 2025, to April 10, 2025 the Western and Eastern Caribbean.\u003c/p\u003e\u003cp\u003eCelebrity will also bring a ship to Port Canaveral for the first time as Celebrity Equinox will call the port home from November 21, 2024, to April 19, 2025. During this time, the ship will sail 20 new itineraries (most lasting 7 nights) with stops in Caribbean destinations including the Bahamas, Belize, Grand Cayman, Mexico, San Juan, and St. Maarten. Equinox will also have two March sailings, March 1 and March 15, 2025 that will visits Royal Caribbean Perfect Day at Coco Cay private island.\u003c/p\u003e\u003cp\u003eAnd, while Royal Caribbean’s largest commitment has been to Florida’s east coast ports, it is not ignoring the west coast. The cruise line will bring more sailing on Celebrity Constellation to the port in Tampa Bay.\u003c/p\u003e\u003cp\u003e“The new program expands the brand’s offerings with four new itineraries and a total of 14 sailings for the season from January 2, 2025, to April 6, 2025. These itineraries will visit destinations like Belize, Honduras, Key West, Mexico, and New Orleans during Mardi Gras, scheduled for March 1, 2025,” the cruise line shared.\u003c/p\u003e\u003cp\u003eThese changes essentially reposition some of Celebrity’s ships from sailing in Europe – including the Edge Class Apex – to Florida. The cruise line’s newest ship, Celebrity Ascent, will call Miami its home port when it begins sailing in December. \u003c/p\u003e\u003cp\u003e\u003cstrong\u003eGet exclusive access to portfolio managers and their proven investing strategies with \u003ca href=\"https://subscriptions.thestreet.com/real-money-pro?placement=editorialv1\"\u003eReal Money Pro\u003c/a\u003e. Get started now.\u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Arena Media Brands, LLC THESTREET is a registered trademark of TheStreet, Inc.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278297748",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Daniel Kline\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eTheStreet\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "The cruise company has done something that matches recent efforts by MSC and Carnival Cruise Line.",
+      "lead_media": {
+        "id": "258723638",
+        "url": "https://www.mcclatchy-wires.com/incoming/5yp4gq/picture258723638",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "royal_carribean_ship_1.jpg",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692194414,
+        "expires": 1693402672,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1645663020,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/5yp4gq/picture258723638/alternates/FREE_1140/royal_carribean_ship_1.jpg",
+        "href": "/web/v1/content/258723638",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "caption": "Image source: Royal Caribbean.",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "The Street",
+      "copyright": "The Street",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278294053",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278294053.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Target surges on Q2 earnings beat as markets ignore cautious outlook",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692183425,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.thestreet.com/investing/stocks/target-surges-on-q2-earnings-beat-as-markets-ignore-cautious-outlook",
+      "meta_description": "Target slashed its 2023 profit forecast, even after beating Street earnings estimates over the second quarter, suggesting consumers will face significant spending pressures over the back half of the year.",
+      "published_date": 1692182614,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/wf95br/picture270475867/alternates/FREE_1140/746da4af-1fcc-4f1c-9c0d-77588b560863",
+      "authors": [
+        {
+          "name": "Martin Baccardax",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87307"
+      ],
+      "credit": "TheStreet",
+      "dateline": "",
+      "summary": "Target slashed its 2023 profit forecast, even after beating Street earnings estimates over the second quarter, suggesting consumers will face significant spending pressures over the back half of the year.",
+      "content": "\u003cp\u003eTarget \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/TGT\"\u003eTGT\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=TGT\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e posted stronger-than-expected second quarter earnings Wednesday, but slashed its full-year profit forecast amid a pullback in discretionary spending from American consumers that continue to face significant inflation pressures.\u003c/p\u003e\u003cp\u003eTarget said adjusted earnings for the three months ended in June were pegged at $1.80 a share, more than six times the level for the same period last year and well ahead of the Wall Street consensus forecast of $1.39 per share.\u003c/p\u003e\u003cp\u003eGroup revenue, Target said, fell 5% to $24.77 billion, missing analysts' estimates of a $25.18 billion tally. Target said same-store sales fell 5.4% compared to last year, as well, missing the Refinitiv forecast of 3.2% decline. Digital sales were also down 10.5%, the biggest decline since the group began gathering separate data for online sales.\u003c/p\u003e\u003cp\u003eTarget was able to improve its overall profit margins, which rose by 0.7% to 27%, thanks to lower markdowns as inventories fell by 17%. \u003c/p\u003e\u003cp\u003eLooking into the current quarter, Target said it sees adjusted earnings of between $7 and $8 per share, well shy of its prior forecast of between $7.75 and $7.85 per share, with comparable sales in a \"wide range\" of mid-single digit decline for the remainder of the year.\u003c/p\u003e\u003cp\u003e\"As we move into the Fall, the team is gearing up for the biggest seasons of the year, with a focus on continuing to serve our guests with newness throughout our assortment,\" said CEO Brian Cornell. \"At the same time, we continue to take a cautious approach to planning our business, and have therefore adjusted our financial guidance in anticipation of continued near-term challenges on the topline.'\u003c/p\u003e\u003cp\u003e\"This approach, along with the long-term investments we're making in our business and strategy, position us to deliver sustainable, profitable growth in the years ahead,\" Cornell added.\u003c/p\u003e\u003cp\u003eTarget shares were marked 11.8% higher in pre-market trading immediately following the earnings release to indicate an opening bell price of $139.76 each.\u003c/p\u003e\u003cul\u003e\u003cli\u003e\u003cstrong\u003e Action Alerts PLUS offers expert portfolio guidance to help you make informed investing decisions. \u003ca href=\"https://subscriptions.thestreet.com/action-alerts-plus?placement=editorialv2\"\u003eSign up now\u003c/a\u003e.\u003c/strong\u003e\u003c/li\u003e\u003c/ul\u003e\u003cp\u003e\u003ci\u003eThe Arena Media Brands, LLC THESTREET is a registered trademark of TheStreet, Inc.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278294053",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Martin Baccardax\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eTheStreet\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Target slashed its 2023 profit forecast, even after beating Street earnings estimates over the second quarter, suggesting consumers will face significant spending pressures over the back half of the year.",
+      "lead_media": {
+        "id": "270475867",
+        "url": "https://www.mcclatchy-wires.com/incoming/wf95br/picture270475867",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "746da4af-1fcc-4f1c-9c0d-77588b560863",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692183409,
+        "expires": 1693392214,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1672173214,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/wf95br/picture270475867/alternates/FREE_1140/746da4af-1fcc-4f1c-9c0d-77588b560863",
+        "href": "/web/v1/content/270475867",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "The Street",
+      "copyright": "The Street",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278293888",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278293888.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Stocks stall as markets eye Fed minutes amid August sell-off",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692182524,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.thestreet.com/investing/stocks/stocks-stall-as-markets-eye-fed-minutes-amid-august-sell-off",
+      "meta_description": "Stocks are struggling to find upside momentum in August, with rising Treasury bond yields and a sputtering China recovery holding back risk sentiment.",
+      "published_date": 1692181323,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/2st4q1/picture278293778/alternates/FREE_1140/959e4b97-5df4-4b4a-9527-c567522b4490",
+      "authors": [
+        {
+          "name": "Martin Baccardax",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87307"
+      ],
+      "credit": "TheStreet",
+      "dateline": "",
+      "summary": "Stocks are struggling to find upside momentum in August, with rising Treasury bond yields and a sputtering China recovery holding back risk sentiment.",
+      "content": "\u003cp\u003eU.S. equity futures were little-changed Wednesday, following from the lowest close on Wall Street in more than a month, as investors continue to gauge the impact of China's sputtering recovery on global growth while extending bets on a soft landing for the domestic economy.\u003c/p\u003e\u003cp\u003eSolid retail sales for the month of July, which showed the key control group reading -- which feeds into GDP calculations -- surging 1% from the prior month, have added to hopes that consumers are weathering the Federal Reserve's aggressive rate hikes while continuing to leverage the earnings power of an historically tight labor market. \u003c/p\u003e\u003cp\u003eThe spending rush, however, has revived concerns that the Fed may need to lift rates once more between now and the end of the year in order to keep inflation from ticking higher over the autumn months. \u003c/p\u003e\u003cp\u003eBenchmark 10-year Treasury bond yields were marked at around 4.188% in overnight trading, having touched a 2023 high of 4.274% during the Tuesday session, while 2-year notes were pegged at 4.908% ahead of minutes of the Fed's July policy meeting, which will be published at 2:00 pm Eastern time later today.\u003c/p\u003e\u003cp\u003eThe broader economy, meanwhile, is growing at a 5% clip, according to the Atlanta Fed's GDPNow forecasting tool, following on from its 2.4% advance over the three months ending in June.\u003c/p\u003e\u003cp\u003eRate traders see little chance of a follow-on rate hike from the Fed in September, with the CME Group's FedWatch tool indicating a 90.5% chance that rates will remain steady, with bets on a final 2023 increase pegged at 29.5% for November and 27.5% for December.\u003c/p\u003e\u003cp\u003eOn Wall Street, futures suggest a modest slip lower following yesterday's sell-off, which was lead by bank and energy stocks linked to a warning from Fitch Ratings on potential downgrades and concerns that China's weakening economy will lead to softer near-term crude oil demand.\u003c/p\u003e\u003cp\u003eFutures tied to the S\u0026P 500 are indicating a 1 point opening bell decline while those linked to the Dow Jones Industrial Average suggest a 2 point dip. Nasdaq futures were down 2 points.\u003c/p\u003e\u003cul\u003e\u003cli\u003e\u003cstrong\u003e Get investment guidance from trusted portfolio managers without the management fees. Sign up for \u003ca href=\"https://subscriptions.thestreet.com/action-alerts-plus?placement=editorialv1\"\u003eAction Alerts PLUS\u003c/a\u003e now.\u003c/strong\u003e\u003c/li\u003e\u003c/ul\u003e\u003cp\u003e\u003ci\u003eThe Arena Media Brands, LLC THESTREET is a registered trademark of TheStreet, Inc.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278293888",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Martin Baccardax\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eTheStreet\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Stocks are struggling to find upside momentum in August, with rising Treasury bond yields and a sputtering China recovery holding back risk sentiment. ",
+      "lead_media": {
+        "id": "278293778",
+        "url": "https://www.mcclatchy-wires.com/incoming/2st4q1/picture278293778",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "959e4b97-5df4-4b4a-9527-c567522b4490",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692182462,
+        "expires": 1693390923,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692181323,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/2st4q1/picture278293778/alternates/FREE_1140/959e4b97-5df4-4b4a-9527-c567522b4490",
+        "href": "/web/v1/content/278293778",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "The Street",
+      "copyright": "The Street",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278285863",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278285863.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Las Vegas Strip brings back classic superstar residency",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692140882,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.thestreet.com/travel/las-vegas-strip-brings-back-classic-superstar-residency",
+      "meta_description": "A superstar popular music and country star opens a new residency on the Strip in May 2024.",
+      "published_date": 1692140102,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/pc72t2/picture278285768/alternates/FREE_1140/6fec2ea1-bb04-45f0-a86b-00f5898e1bdd",
+      "authors": [
+        {
+          "name": "Kirk O’Neil",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87307"
+      ],
+      "credit": "TheStreet",
+      "dateline": "",
+      "summary": "A superstar popular music and country star opens a new residency on the Strip in May 2024.",
+      "content": "\u003cp\u003eFans of Las Vegas Strip star headliners are often disappointed when a residency ends, especially if they didn't get the opportunity to catch their favorite entertainer during a certain engagement. But then again, those same fans can be overwhelmed with joy when one of their favorite performers returns to the Strip for another residency.\u003c/p\u003e\u003cp\u003eLegendary Osmond Brothers singer Donny Osmond finished his North American Tour Aug. 13 and will resume his residency at Harrah's Las Vegas Showroom on Sept. 5 and ending Nov. 11, before embarking on a UK tour from Nov. 28 through Dec. 14. Osmond began his Harrah's residency in August 2021. Vegas can't get enough of Osmond as he \u003ca href=\"https://www.thestreet.com/travel/las-vegas-strip-welcomes-back-legendary-superstar-for-residency\"\u003esigned on for another 55 shows\u003c/a\u003e beginning Jan. 23, 2024.\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eDON'T MISS: \u003c/strong\u003e\u003ca href=\"https://www.thestreet.com/travel/las-vegas-strip-brings-back-a-huge-star-who-may-sell-out-fast\"\u003e\u003cstrong\u003eLas Vegas Strip brings back a huge star who may sell out fast\u003c/strong\u003e\u003c/a\u003e\u003c/p\u003e\u003ch2\u003eLady Gaga returns to the Strip\u003c/h2\u003e\u003cp\u003eLady Gaga performed her \u003ca href=\"https://www.thestreet.com/travel/las-vegas-strip-brings-back-huge-superstar-singer-for-residency\"\u003epopular Enigma + Jazz \u0026 Piano residency\u003c/a\u003e on the Strip as it ran Dec. 28, 2018, through May 1, 2022, at MGM Resorts International's \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/MGM\"\u003eMGM\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=MGM\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e Park Theater at the Park MGM. The \"Paparazzi\" singer will make her return to the Strip at Dolby Live at the Park MGM, for a 12-show Jazz + Piano residency. The engagement will run Aug. 31, Sept. 2, 3, 6, 7, 9, 10, 28, 30, Oct. 1, 4 and 5. \u003c/p\u003e\u003cp\u003eSuperstar popular music and country star Shania Twain has performed two long-running residencies on the Strip, her \"Still the One\" engagement at the Colosseum at Caesars Palace in 2012-14 and \"Let's Go\" at the Zappos Theater, before it was renamed Bakkt Theater, at Caesars Entertainment's \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/CZR\"\u003eCZR\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=CZR\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e Planet Hollywood Las Vegas in 2019-22.\u003c/p\u003e\u003cp\u003eFans of Twain had to wait awhile for her return to the Strip, but the \"From This Moment On\" singer on Aug. 15 released details of her new \"Come On Over\" Vegas residency, a 24-show run beginning May 10 and concluding Dec. 14.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278285763; alt=\"340f02b9-6d9c-45ff-aba0-c62d261b8456\"% --\u003e\u003c/p\u003e\u003ch2\u003eShania Twain has many special deals for fans\u003c/h2\u003e\u003cp\u003eTwain's marketing for her shows is considerably extensive. The residency offers Premium Group Table Packages for six with bottle of champagne, dedicated beverage service and access to a dedicated VIP entrance to skip the general public line. The shows also offer the Premium Loveseat Table Package for two with a glass of champagne for each person, dedicated beverage service and dedicated VIP entrance.\u003c/p\u003e\u003cp\u003eSeveral ticket add-ons that don't include a ticket to the show are available, including:\u003c/p\u003e\u003cul\u003e\u003cli\u003e\"Still The One\" On Stage Proposal Package that includes a preshow meet and greet and more.\u003c/li\u003e\u003cli\u003e\"From This Moment\" VIP Package that includes an on-stage serenade by Twain for two people and more.\u003c/li\u003e\u003cli\u003e\"Party  For Two\" that allows a certain group to introduce the song \"Party For Two\" with Twain and more.\u003c/li\u003e\u003cli\u003e\"Come On Over\" Package allows package holders an on-stage photo with Twain during the show and more.\u003c/li\u003e\u003cli\u003eShania Kids Can Backstage Meet \u0026 Greet to meet Twain backstage before the show and be photographed with the singer.\u003c/li\u003e\u003cli\u003ePre-Show Reception that includes VIP check-in and early entrance to the venue lobby and two complimentary drinks.\u003c/li\u003e\u003cli\u003ePremier Venue Access through the dedicated VIP Entrance to bypass the general public line.\u003c/li\u003e\u003c/ul\u003e\u003cp\u003eTickets go on sale to the general public at Ticketmaster.com Aug. 21 at 10 a.m. Pacific time, though three different pre-sales are on sale Aug. 16 at 10 a.m. and 2 p.m. Pacific time. Ticket packages and add-ons are available at Ticketmaster, as well.\u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Arena Media Brands, LLC THESTREET is a registered trademark of TheStreet, Inc.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278285863",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Kirk O’Neil\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eTheStreet\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "A superstar popular music and country star opens a new residency on the Strip in May 2024.",
+      "lead_media": {
+        "id": "278285768",
+        "url": "https://www.mcclatchy-wires.com/incoming/pc72t2/picture278285768",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "6fec2ea1-bb04-45f0-a86b-00f5898e1bdd",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692140811,
+        "expires": 1693349702,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692140102,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/pc72t2/picture278285768/alternates/FREE_1140/6fec2ea1-bb04-45f0-a86b-00f5898e1bdd",
+        "href": "/web/v1/content/278285768",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "The Street",
+      "copyright": "The Street",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        }
+      ]
+    },
+    {
+      "id": "278271813",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278271813.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "McDonald’s adding a new take on a beloved holiday tradition",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692154401,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.thestreet.com/restaurants/mcdonalds-adding-a-new-take-on-a-beloved-holiday-tradition",
+      "meta_description": "The fast-food chain is bringing back something its customers love in a whole new way.",
+      "published_date": 1692120477,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/5dz8ij/picture263713603/alternates/FREE_1140/mcdonalds.jpg",
+      "authors": [
+        {
+          "name": "Daniel Kline",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87307"
+      ],
+      "credit": "TheStreet",
+      "dateline": "",
+      "summary": "The fast-food chain is bringing back something its customers love in a whole new way.",
+      "content": "\u003cp\u003eMcDonald’s has, at least since the late 1970s, been about more than just the chain’s food. It pioneered the idea of using toys to excite kids about coming into its stores when it launched the Happy Meal in 1979.\u003c/p\u003e\u003cp\u003eThat famed kid’s meal included toys from popular brands as well as tie-ins with big movies. McDonald’s never limited itself to promotions aimed directly at kids. It also had giveaways featuring Coca-Cola glasses and Star Wars that had a lot of appeal for adults as well.\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eDON’T MISS: \u003ca href=\"https://www.thestreet.com/restaurants/mcdonalds-menu-adds-controversial-new-item\"\u003eMcDonald’s menu adds a potentially dangerous item\u003c/a\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003eIn recent years, it has actually become somewhat frowned upon to use toys to make unhealthy food more attractive to kids so the chain has mixed up its offerings. Some of McDonald’s promotions -- like its partnerships with Walt Disney and Pokemon -- have led to items that appeal to all ages.\u003c/p\u003e\u003cp\u003eEven something like the Pikachu Happy Meal boxes, a product ostensibly aimed at kids, also attract collectors and adults who either still love the character or view it nostalgically. And, of course, the chain also had its collaboration with Cactus Plant Flea Market for Happy Meal toys that caused the meals to be unofficially dubbed “Adult Happy Meals.”\u003c/p\u003e\u003cp\u003eNow, McDonald’s has partnered with another popular brand that appeals to adults to bring back a unique take on a Halloween favorite. \u003c/p\u003e\u003cp\u003e\u003c!-- %asset:278271758; alt=\"d9716ea5-afe7-431d-b53d-744462a983d2\"% --\u003e\u003c/p\u003e\u003ch2\u003eMcDonald’s has a new take on Halloween buckets \u003c/h2\u003e\u003cp\u003eIn past years, McDonald’s has offered Halloween Boo Buckets, plastic pails with food inside that could be reused for trick or treating. They first appeared in 1986 and have been brought back multiple times since then.\u003c/p\u003e\u003cp\u003eThey come in three versions: a white McBoo bucket, the orange McPunk’n, and a green witch-like McGoblin. McDonald’s has not shared whether it plans to bring the Boo Buckets back for this Halloween, but the chain has partnered with Loungefly, a kitschy bag company, for Boo Buckets crossbody bags. \u003c/p\u003e\u003cp\u003eLoungefly also makes a “McDonald’s Hamburglar Cosplay Mini Backpack” which can be found on its website for $63. The company, which targets all ages, also has deals with Walt Disney \u003cspan\u003e (\u003cstrong\u003e\u003ca href=\"https://www.thestreet.com/quote/DIS\"\u003eDIS\u003c/a\u003e\u003c/strong\u003e) - \u003ca href=\"https://secure2.thestreet.com/cap/prm.do?OID=033365\u0026ticker=DIS\"\u003eGet Free Report\u003c/a\u003e\u003c/span\u003e for a number of its most popular franchises.\u003c/p\u003e\u003cp\u003eThe Boo Buckets will come in two varieties, one for McPunk’n and the other for McGoblin. Loungefly described the McPunk’n bag as follows:\u003c/p\u003e\u003cp\u003e “Your bucket list just got more fashionable! Set out on fun-filled adventures with our Loungefly McDonald’s Halloween Happy Meal McPunk’n Crossbody Bag. This fully figural bag takes on the shape of a classic McDonald’s Happy Meal pumpkin treat bucket, complete with a wickedly charming jack-o’-lantern face. In the dark, this bag glows!” the company shared.\u003c/p\u003e\u003cp\u003eMcBoo does not appear to be included in the lineup. Each bag costs $70 and they are not for sale yet. The company does offer a “notify me” feature on its website for people looking to get one of the sure-to-sell-out bags.\u003c/p\u003e\u003cp\u003eLoungefly offers a full array of Halloween bags including ones themed to Chucky, Annabelle, and Michael Myers of “Halloween” movie fame. There are also multiple “Killer Clowns From Outer Space” products and, for people who want a more mild scare, items themed to the “Goosebumps” books. \u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Arena Media Brands, LLC THESTREET is a registered trademark of TheStreet, Inc.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278271813",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Daniel Kline\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eTheStreet\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "The fast-food chain is bringing back something its customers love in a whole new way.",
+      "lead_media": {
+        "id": "263713603",
+        "url": "https://www.mcclatchy-wires.com/incoming/5dz8ij/picture263713603",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "mcdonalds.jpg",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692121372,
+        "expires": 1693330077,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1658445949,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/5dz8ij/picture263713603/alternates/FREE_1140/mcdonalds.jpg",
+        "href": "/web/v1/content/263713603",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "The Street",
+      "copyright": "The Street",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        },
+        {
+          "name": "mcc-syndication-test"
+        }
+      ]
+    },
+    {
+      "id": "278276148",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278276148.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "Disney rival Universal plans big expansion before Epic Universe",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692153728,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.thestreet.com/travel/disney-rival-universal-plans-big-expansion-before-epic-universe",
+      "meta_description": "Even with a major theme park being built, Universal Studios Florida plans a major expansion to its original park Disney World may not be able to match.",
+      "published_date": 1692125771,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/d0zavq/picture258948428/alternates/FREE_1140/disney-world-universal-studios.jpg",
+      "authors": [
+        {
+          "name": "Daniel Kline",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87307"
+      ],
+      "credit": "TheStreet",
+      "dateline": "",
+      "summary": "Even with a major theme park being built, Universal Studios Florida plans a major expansion to its original park Disney World may not be able to match.",
+      "content": "\u003cp\u003eAside from completing renovations at Epcot, Disney World has no major attractions set to open. The company has said it plans to invest $17 billion in its Florida theme parks over the next 10 years, but it has not shared many details about where that money might get spent.\u003c/p\u003e\u003cp\u003eAside from Disney Parks Chairman Josh D’Amaro talking in very broad terms at the recent D23 Expo about adding new attractions to increase capacity at Disney World. In those remarks, he blue-skyed some ideas and hinted at major things to come, but in the months since, nothing has been announced and no new construction appears imminent.\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eDON’T MISS: \u003ca href=\"https://www.thestreet.com/travel/desantis-repeats-false-claim-in-call-for-disney-to-drop-lawsuit\"\u003eFlorida’s Ron DeSantis uses false claim to attack Disney World\u003c/a\u003e\u003c/strong\u003e\u003c/p\u003e\u003cp\u003eSome of that may be due to Walt Disney’s ongoing battles with Florida Gov. Ron DeSantis. That political war, which will take months to play out in court, has led to the company threatening to pull some of that investment.\u003c/p\u003e\u003cp\u003eDisney has added a number of major rides relatively recently, including “Tron Lightcycle/Run” at Magic Kingdom and “Guardians of the Galaxy: Cosmic Rewind” at Epcot, but it has nothing big on tap to counter the 2025 opening of Universal’s third Florida theme park, Epic Universe. \u003c/p\u003e\u003cp\u003eAnd, while Disney has mostly been quiet, Comcast’s Florida theme parks have continued steadily adding rides with “Villain-Con Minion Blast” opening in August. That, along with a new gift shop and restaurant, joins the existing “Despicable Me Minion Mayhem” ride to form a new land at Universal Studios Florida.\u003c/p\u003e\u003cp\u003eNow, even with Epic Universe on the way, it appears the company has not stopped adding new lands to its existing parks. The theme park giant has also shared -- albeit without a lot of details -- that it’s adding a land based on its DreamWorks animated properties in 2024.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:275733321; alt=\"847ac30f-3a52-427d-9b14-940fd521fe1b\"% --\u003e\u003c/p\u003e\u003ch2\u003eDreamWorks takes over Universal’s KidZone\u003c/h2\u003e\u003cp\u003eWhen Universal closed its KidZone land in January, construction walls went up immediately. It was clear the company was going to put something in the area, but it had not shared its plans. \u003c/p\u003e\u003cp\u003eNow, the theme park giant has shared that the space will be used for a reimagined series of rides based on popular DreamWorks Animation characters. \u003c/p\u003e\u003cp\u003e“As guests step into this new land, their imaginations will run wild as they take in the vibrant colors, sights and sounds that surround them. They will share special moments with their favorite characters like Gabby from Gabby’s Dollhouse and explore themed, interactive play spaces and attractions that bring popular franchises like Shrek, Trolls, and Kung Fu Panda to life in the most imaginatively fun ways,” the company shared.\u003c/p\u003e\u003cp\u003eThis marks a major return to Universal Studios Orlando for Shrek as the popular ogre’s “Shrek: 4-D” ride was closed to make way for the new Minion-based attractions. \u003c/p\u003e\u003cp\u003eThe press release did not share any details as to how each character will appear, but \u003ca href=\"https://www.themeparktourist.com/news/20230814/33613/universals-immersive-new-land-set-open-2024-roller-coaster-character\"\u003eTheme Park Tourist\u003c/a\u003e appears to have some it figured out. \u003c/p\u003e\u003cp\u003e“Rumors have hinted that the former Fivel’s Playland area is currently being transformed into Shrek’s Swamp,” the website shared. \u003c/p\u003e\u003cp\u003eIn addition, concept art for the new area does appear to show a Trolls-themed family roller coaster on the site of the former coast themed to Woody Woodpecker. \u003c/p\u003e\u003cp\u003e“In addition to the playground and roller coaster attractions, there will be a character meet and greet areas in this land where guests can meet a rotating cast of familiar faces from DreamWorks films as well as new characters from upcoming movies, similar to the former Dreamworks Destination attraction,” the website reported.\u003c/p\u003e\u003cp\u003eDreamWorks’s “How to Train Your Dragon” franchise is expected to be part of Epic Universe and was not named in this press release. \u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Arena Media Brands, LLC THESTREET is a registered trademark of TheStreet, Inc.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278276148",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Daniel Kline\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eTheStreet\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Even with a major theme park being built, Universal Studios Florida plans a major expansion to its original park Disney World may not be able to match.",
+      "lead_media": {
+        "id": "258948428",
+        "url": "https://www.mcclatchy-wires.com/incoming/d0zavq/picture258948428",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "disney-world-universal-studios.jpg",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692126861,
+        "expires": 1693335371,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1646184985,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/d0zavq/picture258948428/alternates/FREE_1140/disney-world-universal-studios.jpg",
+        "href": "/web/v1/content/258948428",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "The Street",
+      "copyright": "The Street",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        },
+        {
+          "name": "mcc-syndication-test"
+        }
+      ]
+    },
+    {
+      "id": "278277928",
+      "url": "https://www.mcclatchy-wires.com/incoming/article278277928.html",
+      "asset_type": "wirestory",
+      "state": "published",
+      "title": "The JetBlue alliance with American Airlines is cutting back on flights",
+      "publication": "mcclatchy-wires",
+      "layout_option": "",
+      "home": "/web/v1/sections/50877",
+      "home_section": {
+        "name": "New Articles",
+        "url": "https://www.mcclatchy-wires.com/incoming/"
+      },
+      "modified_date": 1692153619,
+      "allow_index": false,
+      "allow_follow": false,
+      "originating_url": "https://www.thestreet.com/travel/major-us-airline-makes-big-change-impact-passengers",
+      "meta_description": "Travelers deal with some adjustments.",
+      "published_date": 1692127328,
+      "thumbnail": "https://www.mcclatchy-wires.com/incoming/ijgjuj/picture278277723/alternates/FREE_1140/b1fc3ba9-815f-4b84-84f0-b2b50236ab3c",
+      "authors": [
+        {
+          "name": "Jeffrey Quiggle",
+          "email": ""
+        }
+      ],
+      "access_tags": [
+        "matopend"
+      ],
+      "additional_sections": [
+        "50877",
+        "87307"
+      ],
+      "credit": "TheStreet",
+      "dateline": "",
+      "summary": "Travelers deal with some adjustments.",
+      "content": "\u003cp\u003eThe Northeast Alliance (NEA) was a partnership between American Airlines and JetBlue that began in early 2021 and ended in July 2023.\u003c/p\u003e\u003cp\u003eThe NEA’s goal was to combine the two airlines’ operations in Boston and New York City. It hoped to give customers more flight choices and mutual frequent flyer benefits.\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eDON’T MISS: \u003ca href=\"https://www.thestreet.com/travel/major-us-airline-makes-strict-change-affecting-all-its-passengers\"\u003eMajor US Airline Makes Strict Change Affecting All Its Passengers\u003c/a\u003e\u003c/strong\u003e \u003c/p\u003e\u003cp\u003eBut the U.S. Department of Justice sued to block the alliance, saying it had the potential to reduce competition and harm consumers in the Northeast.\u003c/p\u003e\u003cp\u003eA U.S. District Court in Boston issued a ruling in May that favored the DOJ, which led to an ending of the partnership.\u003c/p\u003e\u003cp\u003eJetBlue said it would not appeal the decision.\u003c/p\u003e\u003cp\u003e“Despite our deep conviction in the procompetitive benefits of the NEA, after much consideration, JetBlue has made the difficult decision not to appeal the court’s determination ... and has instead initiated the termination of the NEA, beginning a wind down process that will take place over the coming months,” JetBlue said in a statement. “We will now turn even more focus to our proposed combination with Spirit.”\u003c/p\u003e\u003cp\u003eThe DOJ has also challenged JetBlue’s merger with Spirit Airlines.\u003c/p\u003e\u003cp\u003e\u003c!-- %asset:272607456; alt=\"b186748f-c5ba-4a27-b3c4-6dfe0c9ddbd4\"% --\u003e\u003c/p\u003e\u003ch2\u003eJetBlue is forced to change some routes\u003c/h2\u003e\u003cp\u003eWith this new reality, JetBlue has made some changes to its routes in the Northeast that will have an impact on passengers.\u003c/p\u003e\u003cp\u003e“The New York-based carrier filed plans over the weekend to end service between LaGuardia Airport (LGA) and Savannah/Hilton Head International Airport (SAV) in Georgia as of Oct. 28, Cirium schedules show,” \u003ca href=\"https://thepointsguy.com/news/jetblue-northeast-alliance-route-changes/\"\u003ewrote\u003c/a\u003e Zach Griff on The Points Guy website Aug. 15.\u003c/p\u003e\u003cp\u003e“Furthermore, JetBlue will slash a daily flight between LGA and both Charleston International Airport (CHS) in South Carolina and Nashville International Airport (BNA),” Griff continued. “Under the Northeast Alliance, the airline was planning to operate two daily flights in both markets, but without the tie-up with American Airlines, JetBlue can seemingly no longer make these routes work with increased frequencies.”\u003c/p\u003e\u003cp\u003eJetBlue will also reportedly slash up to four daily trips between New York and Boston starting in November.\u003c/p\u003e\u003cp\u003eAfter the DOJ’s successful antitrust lawsuit, American Airlines is making changes as well.\u003c/p\u003e\u003cp\u003e“American has already started rejiggering its network for a post-Northeast Alliance world,” Griff wrote. “This includes switching the New York-to-Doha flight to Philadelphia and restarting service between LaGuardia and Boston, a key domestic shuttle route that American handed over to JetBlue last year.”\u003c/p\u003e\u003cp\u003eIn May, the DOJ issued a statement on the U.S. District Court’s decision.\u003c/p\u003e\u003cp\u003e“Today’s decision is a win for Americans who rely on competition between airlines to travel affordably,” \u003ca href=\"https://www.justice.gov/opa/pr/justice-department-statements-district-court-ruling-enjoining-american-airlines-and-jetblue-s\"\u003esaid\u003c/a\u003e Attorney General Merrick B. Garland. “The Justice Department will continue to protect competition and enforce our antitrust laws in the heavily consolidated airline industry and across every industry.”\u003c/p\u003e\u003cp\u003e“We are pleased with the court’s decision. The outcome of this litigation recognizes the value of competition in the airline industry,” said Assistant Attorney General Jonathan Kanter of the Justice Department’s Antitrust Division. “We are grateful to our state law enforcement partners and the dedicated and talented Antitrust Division staff that investigated and tried this important case.”\u003c/p\u003e\u003cp\u003e\u003cstrong\u003eGet exclusive access to portfolio managers and their proven investing strategies with Real Money Pro. \u003ca href=\"https://subscriptions.thestreet.com/real-money-pro?placement=editorialv1\"\u003eGet started now\u003c/a\u003e. \u003c/strong\u003e\u003c/p\u003e\u003cp\u003e\u003ci\u003eThe Arena Media Brands, LLC THESTREET is a registered trademark of TheStreet, Inc.\u003c/i\u003e\u003c/p\u003e",
+      "kicker": "",
+      "text_alignment": "Left",
+      "href": "/web/v1/content/278277928",
+      "allow_ads": true,
+      "allow_stn_player": true,
+      "byline": "\u003cp\u003e\u003cspan class=\"ng_byline_name\"\u003eBy Jeffrey Quiggle\u003c/span\u003e\u003c/p\u003e\n\u003cp\u003e\u003cspan class=\"ng_byline_credit\"\u003eTheStreet\u003c/span\u003e\u003c/p\u003e",
+      "template_type": "",
+      "story_teaser": "Travelers deal with some adjustments.",
+      "lead_media": {
+        "id": "278277723",
+        "url": "https://www.mcclatchy-wires.com/incoming/ijgjuj/picture278277723",
+        "asset_type": "picture",
+        "state": "published",
+        "title": "b1fc3ba9-815f-4b84-84f0-b2b50236ab3c",
+        "publication": "mcclatchy-wires",
+        "layout_option": "",
+        "home": "/web/v1/sections/50877",
+        "modified_date": 1692128673,
+        "expires": 1693336928,
+        "allow_comments": false,
+        "allow_index": false,
+        "allow_follow": false,
+        "published_date": 1692127328,
+        "thumbnail": "https://www.mcclatchy-wires.com/incoming/ijgjuj/picture278277723/alternates/FREE_1140/b1fc3ba9-815f-4b84-84f0-b2b50236ab3c",
+        "href": "/web/v1/content/278277723",
+        "additional_sections": [
+          "50877"
+        ],
+        "credit": "",
+        "dateline": "",
+        "is_mugshot": false,
+        "text_alignment": "Default",
+        "summary": "",
+        "byline": "",
+        "kicker": ""
+      },
+      "owner": "The Street",
+      "copyright": "The Street",
+      "allow_comments": true,
+      "disable_amp": true,
+      "topic_tags": [
+        {
+          "name": "mcc-syndication"
+        },
+        {
+          "name": "mcc-syndication-test"
+        }
+      ]
+    }
+  ]
+}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -65,6 +65,9 @@
     <!-- fake ads -->
     <script defer src="/js/fake-ad.js"></script>
 
+    <!-- layout options -->
+    <script defer src="/js/layout-options.js"></script>
+
     {{ block "head" . }}{{ end }}
   </head>
 

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -22,12 +22,12 @@
 
   <div id="zone-el-1" class="zone-el hidden"></div>
   <div id="zone-el-2" class="zone-el zone" data-type="ad">
-    <fake-ad size="[[970,250],[728,90],[320,50]]"></fake-ad>
+    <fake-ad size="[[970,250],[300,250]]"></fake-ad>
   </div>
 
-  {{ partial "masthead" . }}
+  {{- partial "masthead" . }}
 
-  {{ .Content }}
+  {{- .Content }}
 
-  {{ partial "footer" . }}
+  {{- partial "footer" . }}
 {{ end }}

--- a/layouts/_default/story.html
+++ b/layouts/_default/story.html
@@ -12,61 +12,6 @@
   <!-- the wrapper was added by the front-end team -->
   <div class="server-rendered">
     <article class="story-body paper">{{ .Content }}</article>
-
-    <section class="grid">
-      <div class="card read-next col-span-2">
-        <div class="label sticky"><span class="h5">READ NEXT</span></div>
-        <figure>
-          <img src="https://www.kansascity.com/living/food-drink/come-into-my-kitchen/tl1ycf/picture205504244/ALTERNATES/LANDSCAPE_1140/0321%20cimk%20kuwata%2003022018%20s%20%284%29" alt="Lorem ipsum dolor sit amet" width="1140" height="161" loading="lazy">
-        </figure>
-        <div class="package">
-          <header class="header">
-            <a class="kicker h6" href="#">SECTION</a>
-            <h1><a href="#">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus lorem a</a></h1>
-            <div class="bio">
-              <div>
-                <p class="byline">By <a href="#">John Doe</a> <span class="credit">SAMPLE NEWSPAPER</span></p>
-                <div>
-                  <time>AUG 13, 2018, UPDATED 4 MONTHS AGO</time>
-                </div>
-              </div>
-              <div class="social-media">
-                <a href="#">
-                  <svg data-name="twitter" viewBox="0 0 512 512"><title>Share this story on Twitter</title><path d="M459.37 151.716c.325 4.548.325 9.097.325 13.645 0 138.72-105.583 298.558-298.558 298.558-59.452 0-114.68-17.219-161.137-47.106 8.447.974 16.568 1.299 25.34 1.299 49.055 0 94.213-16.568 130.274-44.832-46.132-.975-84.792-31.188-98.112-72.772 6.498.974 12.995 1.624 19.818 1.624 9.421 0 18.843-1.3 27.614-3.573-48.081-9.747-84.143-51.98-84.143-102.985v-1.299c13.969 7.797 30.214 12.67 47.431 13.319-28.264-18.843-46.781-51.005-46.781-87.391 0-19.492 5.197-37.36 14.294-52.954 51.655 63.675 129.3 105.258 216.365 109.807-1.624-7.797-2.599-15.918-2.599-24.04 0-57.828 46.782-104.934 104.934-104.934 30.213 0 57.502 12.67 76.67 33.137 23.715-4.548 46.456-13.32 66.599-25.34-7.798 24.366-24.366 44.833-46.132 57.827 21.117-2.273 41.584-8.122 60.426-16.243-14.292 20.791-32.161 39.308-52.628 54.253z"></path></svg>
-                </a>
-                <a href="#">
-                  <svg data-name="facebook" viewBox="0 0 264 512"><title>Share this story on Facebook</title><path d="M76.7 512V283H0v-91h76.7v-71.7C76.7 42.4 124.3 0 193.8 0c33.3 0 61.9 2.5 70.2 3.6V85h-48.2c-37.8 0-45.1 18-45.1 44.3V192H256l-11.7 91h-73.6v229"></path></svg>
-                </a>
-                <a href="#">
-                  <svg data-name="envelope" viewBox="0 0 512 512"><title>Email this story</title><path d="M502.3 190.8c3.9-3.1 9.7-.2 9.7 4.7V400c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V195.6c0-5 5.7-7.8 9.7-4.7 22.4 17.4 52.1 39.5 154.1 113.6 21.1 15.4 56.7 47.8 92.2 47.6 35.7.3 72-32.8 92.3-47.6 102-74.1 131.6-96.3 154-113.7zM256 320c23.2.4 56.6-29.2 73.4-41.4 132.7-96.3 142.8-104.7 173.4-128.7 5.8-4.5 9.2-11.5 9.2-18.9v-19c0-26.5-21.5-48-48-48H48C21.5 64 0 85.5 0 112v19c0 7.4 3.4 14.3 9.2 18.9 30.6 23.9 40.7 32.4 173.4 128.7 16.8 12.2 50.2 41.8 73.4 41.4z"></path></svg>
-                </a>
-              </div>
-            </div>
-          </header>
-          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vulputate enim dolor, sit amet lacinia ex lacinia ac. Sed facilisis nulla felis, eget ultricies dolor cursus nec. Cras sodales ligula elementum ipsum elementum gravida.</p>
-          <a href="#" class="more-link">KEEP READING</a>
-        </div>
-      </div>
-
-      {{ template "shortcodes/digest.html" }}
-
-      {{- range seq 5 }}
-        {{ template "shortcodes/card.html" }}
-      {{- end }}
-
-      <article class="card">
-        <figure>
-          <a href="#">
-            <img src="/img/lanterns.jpg" width="1140" height="641" alt="Lanterns floating in a body of water" loading="lazy">
-          </a>
-        </figure>
-        <div class="package">
-          <a class="kicker h6 impact" href="#">SPONSORED CONTENT</a>
-          <h3><a href="#">Lorem ipsum dolor sit amet.</a></h3>
-          <time>BY FIRST LAST AS SEEN ON SITE</time>
-        </div>
-      </article>
-    </section>
   </div>
 
   {{ partial "footer" . }}

--- a/layouts/shortcodes/card.html
+++ b/layouts/shortcodes/card.html
@@ -1,52 +1,33 @@
 {{- $class := .Get "class" -}}
 {{- $headlineSize := default "h3" (.Get "headline-size") -}}
-{{- $img := default "/img/kitten.jpg" (.Get "img" ) -}}
-{{- $headline := default "Kitten clings for life as man awaits rescue from Florence." (.Get "headline") -}}
+{{- $taboola := .Get "taboola" }}
 
-{{- if .Get "taboola" }}
-<article class="card {{ .Get "class" }}" data-tb-region-item>
+{{- .Page.Scratch.Add "cardIndex" 1 }}
+{{- $current := int (.Page.Scratch.Get "cardIndex") }}
+{{- $story := index .Site.Data.news.items (sub $current 1) }}
+
+{{- with $story }}
+<article class="card {{ $class }}" {{- if $taboola }} data-tb-region-item {{- end }}>
+  {{- $img := default "/img/kitten.jpg" (replace .lead_media.thumbnail "FREE" "LANDSCAPE") }}
   <figure>
-
-    {{- if in $class "horizontal" }}
-    <div class="label sticky"><h5 class="impact">READ NEXT</h5></div>
-    {{ end -}}
-
-    <a href="#" data-tb-link>
-      <img src="{{ $img }}" alt="alt text" width="1140" height="641" loading="lazy">
+    <a href="#" {{- if $taboola }} data-tb-link {{- end }}>
+      <img src="{{ $img }}" alt="{{ .lead_media.caption }}" width="1140" height="641" loading="lazy">
     </a>
   </figure>
   <div class="package">
-    <a class="kicker h6" href="#" data-tb-category>FOOD</a>
-    <h2 class="{{ $headlineSize }}"><a href="#" data-tb-link data-tb-title>{{ $headline }}</a></h2>
-
-    {{- if or (in $class "lead-item") (in $class "in-depth") }}
-    <p class="summary" data-tb-description>As far as we can estimate, a baboon is a vaulting blow. An effuse feet's objective comes with it the thought that the quaggy discussion is a rub. The amount is a growth. The literature would have us believe that a dreggy hate is not but a nephew.</p>
+    <h2 class="caps h6">
+      <a class="kicker" href="#" {{- if $taboola }} data-tb-category {{- end }}>{{ .home_section.name }}</a>
+    </h2>
+    <h3 class="{{ $headlineSize }}">
+      <a href="#" {{- if $taboola }} data-tb-link data-tb-title {{- end }}>{{ .title }}</a>
+    </h3>
+    
+    {{- if in $class "lead-item" }}
+    <p class="summary" {{- if $taboola }} data-tb-description {{- end }}>{{ .summary }}</p>
     {{ end -}}
 
-    <div class="time" data-tb-date>{{ if in $class "sponsored" -}} sponsored content {{- else -}} March 16, 2018 11:33 am {{- end }}</div>
+    {{- $pubdate := (time (int .modified_date)).Format "Jan 2, 2006 3:04 PM" }}
+    <div class="time" {{- if $taboola }} data-tb-date {{- end }}>{{ if in $class "sponsored" -}} sponsored content {{- else -}} {{ $pubdate }} {{- end }}</div>
   </div>
 </article>
-{{- else }}
-<article class="card {{ .Get "class" }}">
-  <figure>
-
-    {{- if in $class "horizontal" }}
-    <div class="label sticky"><h5 class="impact">READ NEXT</h5></div>
-    {{ end -}}
-
-    <a href="#">
-      <img src="{{ $img }}" alt="alt text" width="1140" height="641" loading="lazy">
-    </a>
-  </figure>
-  <div class="package">
-    <a class="kicker h6" href="#">FOOD</a>
-    <h2 class="{{ $headlineSize }}"><a href="#">{{ $headline }}</a></h2>
-
-    {{- if or (in $class "lead-item") (in $class "in-depth") }}
-    <p class="summary">As far as we can estimate, a baboon is a vaulting blow. An effuse feet's objective comes with it the thought that the quaggy discussion is a rub. The amount is a growth. The literature would have us believe that a dreggy hate is not but a nephew.</p>
-    {{ end -}}
-
-    <div class="time">{{ if in $class "sponsored" -}} sponsored content {{- else -}} March 16, 2018 11:33 am {{- end }}</div>
-  </div>
-</article>
-{{ end -}}
+{{- end }}

--- a/layouts/shortcodes/digest.html
+++ b/layouts/shortcodes/digest.html
@@ -1,91 +1,29 @@
-{{- $label := .Get "label" -}}
-{{- $kicker := default "OPINION" (.Get "kicker") -}}
+{{- $label := .Get "label" }}
+{{- $kicker := default "NEWS" (.Get "kicker") }}
+{{- $feed := default "news" (.Get "feed") }}
 {{- $region := default false (.Get "region") -}}
 
-{{ with $region }}
 <div class="digest">
-  <div class="paper" data-tb-region="{{ $region }}">
-    <a href="#" class="label">
+  <div class="paper" {{- with $region }} data-tb-region="{{ $region }}" {{- end }}>
+    <a href="#" class="label {{ $label }}">
       <span class="h5">{{ $kicker }}</span>
     </a>
-    {{- if eq $label "sticky" }}
-    <article class="card" data-tb-region-item>
+    {{- with (index .Site.Data $feed).items }}
+    {{- range $index, $story := first 5 . }}
+    <article class="card" {{- with $region }} data-tb-region-item {{- end }}>
+      {{- if and (eq $label "sticky") (eq $index 0) }}
+      {{- $img := default "/img/kitten.jpg" (replace .lead_media.thumbnail "FREE" "LANDSCAPE") }}
       <figure>
-        <a href="#" data-tb-link>
-          <img src="https://pics.mcclatchyinteractive.com/opinion/gi1163/picture205928719/ALTERNATES/LANDSCAPE_640/AP_18073734498485" srcset="https://pics.mcclatchyinteractive.com/opinion/gi1163/picture205928719/ALTERNATES/LANDSCAPE_1140/AP_18073734498485 1140w"> 
+        <a href="#" {{- with $region }} data-tb-link {{- end }}>
+          <img src="{{ $img }}" alt="{{ .lead_media.caption }}" width="1140" height="641" loading="lazy">
         </a>
       </figure>
+      {{- end }}
       <div class="package">
-        <h2 class="h3"><a href="#" data-tb-title data-tb-link>Kudlow joins White House that sorely needs cooler heads to prevail</a></h2>
-        <time>March 19, 2018 5:34 pm</time>
+        <h2 class="h3"><a href="#" {{- with $region }} data-tb-title data-tb-link {{- end }}>{{ $story.title }}</a></h2>
+        <div class="time">{{ (time (int $story.modified_date)).Format "Jan 2, 2006 3:04 PM" }}</div>
       </div>
     </article>
-    {{- else }}
-    <article class="package" data-tb-region-item>
-      <h2 class="h3"><a href="#" data-tb-title data-tb-link>Kudlow joins White House that sorely needs cooler heads to prevail</a></h2>
-      <time>March 19, 2018 5:34 pm</time>
-    </article>
-    {{- end }}
-    <article class="package" data-tb-region-item>
-      <h2 class="h3"><a href="#" data-tb-title data-tb-link>The Episcopal Church changed course for our LGBT members</a></h2>
-      <time>March 16, 2018 3:42 pm</time>
-    </article>
-    <article class="package" data-tb-region-item>
-      <h2 class="h3"><a href="#" data-tb-title data-tb-link>The Kansas Republican Party is taking a stance on transgender identity</a></h2>
-      <time>March 16, 2018 3:58 pm</time>
-    </article>
-    <article class="package" data-tb-region-item>
-      <h2 class="h3"><a href="#" data-tb-title data-tb-link>Letters: Readers discuss teen drinking, tax-cut benefits in Missouri and student protests</a></h2>
-      <time>March 16, 2018 4:08 pm</time>
-    </article>
-    <article class="package" data-tb-region-item>
-      <h2 class="h3"><a href="#" data-tb-title data-tb-link>Administration unveils steps to boost racial equity in govt</a></h2>
-      <time>March 16, 2018 4:08 pm</time>
-    </article>
+    {{- end }}{{ end }}
   </div>
-  <a href="#" class="more-link">MORE IN {{ $kicker }}</a>
 </div>
-{{- else }}
-<div class="digest">
-  <div class="paper">
-    <a href="#" class="label">
-      <span class="h5">{{ $kicker }}</span>
-    </a>
-    {{- if eq $label "sticky" }}
-    <article class="card">
-      <figure>
-        <a href="#">
-          <img src="https://pics.mcclatchyinteractive.com/opinion/gi1163/picture205928719/ALTERNATES/LANDSCAPE_640/AP_18073734498485" srcset="https://pics.mcclatchyinteractive.com/opinion/gi1163/picture205928719/ALTERNATES/LANDSCAPE_1140/AP_18073734498485 1140w"> 
-        </a>
-      </figure>
-      <div class="package">
-        <h2 class="h3"><a href="#">Kudlow joins White House that sorely needs cooler heads to prevail</a></h2>
-        <time>March 19, 2018 5:34 pm</time>
-      </div>
-    </article>
-    {{- else }}
-    <article class="package">
-      <h2 class="h3"><a href="#">Kudlow joins White House that sorely needs cooler heads to prevail</a></h2>
-      <time>March 19, 2018 5:34 pm</time>
-    </article>
-    {{- end }}
-    <article class="package">
-      <h2 class="h3"><a href="#">The Episcopal Church changed course for our LGBT members</a></h2>
-      <time>March 16, 2018 3:42 pm</time>
-    </article>
-    <article class="package">
-      <h2 class="h3"><a href="#">The Kansas Republican Party is taking a stance on transgender identity</a></h2>
-      <time>March 16, 2018 3:58 pm</time>
-    </article>
-    <article class="package">
-      <h2 class="h3"><a href="#">Letters: Readers discuss teen drinking, tax-cut benefits in Missouri and student protests</a></h2>
-      <time>March 16, 2018 4:08 pm</time>
-    </article>
-    <article class="package">
-      <h2 class="h3"><a href="#">Administration unveils steps to boost racial equity in govt</a></h2>
-      <time>March 16, 2018 4:08 pm</time>
-    </article>
-  </div>
-  <a href="#" class="more-link">MORE IN {{ $kicker }}</a>
-</div>
-{{- end }}

--- a/static/css/cards/grid.css
+++ b/static/css/cards/grid.css
@@ -78,7 +78,11 @@
  */
 
 .grid [class*=digest-group] {
-  display: contents;
+  /* display: contents; */
+  display: grid;
+  grid-template-columns: var(--columns);
+  grid-column: 1/-1;
+  gap: var(--gap);
 }
 
 [class*=digest-group] .digest {

--- a/static/css/website/site.css
+++ b/static/css/website/site.css
@@ -138,45 +138,8 @@ td:first-child {
 }
 
 /*
- * Region showcase
- */
-
-[data-tb-region-item] {
-  position: relative;
-}
-
-[data-tb-region-item]:after {
-  content: "";
-  display: block;
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  padding: 15px;
-  box-sizing: border-box;
-  background-color: rgba(0, 0, 255, 0.6);
-  font: 1.2em var(--sans);
-  color: white;
-}
-
-/*
  * Zones
  */
-
-.zone::before {
-  content: attr(id);
-  display: block;
-  position: absolute;
-  left: 5px;
-  top: 5px;
-  font: 14px/1em var(--sans);
-  color: #777;
-}
-
-.zone[data-type=editorial] {
-  --color: cornflowerblue;
-}
 
 #zone-el-2 {
   height: 250px;
@@ -193,4 +156,23 @@ td:first-child {
   content: url("../../img/taboola.svg");
   display: block;
   width: 250px;
+}
+
+/*
+ * Taboola region overlays
+ */
+
+[data-layout=taboola] [data-tb-region-item]:after {
+  content: attr(data-region);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: grid;
+  place-items: center;
+  font: bold 18px var(--sans);
+  background-color: rgba(5,65,100,0.9);
+  color: white;
+  border: 1px solid white;
 }

--- a/static/js/layout-options.js
+++ b/static/js/layout-options.js
@@ -1,0 +1,21 @@
+/*
+ * Allows for setting themes
+ */
+
+function setLayout() {
+  const value = window.location.hash.substring(1);
+  document.documentElement.dataset.layout = value;
+
+  switch(value) {
+    case "taboola":
+      const regions = document.querySelectorAll("[data-tb-region]");
+
+      regions.forEach(region => {
+        const items = region.querySelectorAll("[data-tb-region-item]");
+        items.forEach(item => item.dataset.region = region.dataset.tbRegion);
+      });
+  }
+}
+
+window.addEventListener("hashchange", setLayout);
+setLayout()


### PR DESCRIPTION
### What does this PR do?

It makes the shortcodes more dynamic and incorporates static versions of some public section feeds as data sources for templates.

1. Digests have a new feed property to pick the feed of choice (default "news")
2. Cards auto-increment themselves as they are added to decks (max 20 for now)

In addition to this cleanup, this also adds some JS functionality to append the `data-layout` attribute to the `<html>` tag on hashchange. It also adds some CSS to show Taboola regions so we can talk those through with stakeholders.

### Steps to test

Please take a look at the source code as well and hit me with any questions or concerns over the approach.

1. Check out the new branch and fire up the Hugo server.
2. Take a look at all decks, but specifically the homepage and section versions. 
3. On the hompage deck, add `#taboola` to the url to see the overlay.

### Here's what the overlay should look like.
![Screenshot 2023-08-16 5 14 07 PM](https://github.com/mcclatchy/design/assets/198070/d0be839e-23a2-4c19-a630-33836617d4b3)
