### PR TITLE
update grid rules for digest group and fix mobile spacing for partner…

### DIFF
--- a/static/css/cards/grid.css
+++ b/static/css/cards/grid.css
@@ -77,12 +77,15 @@
  * Custom grid arrangements
  */
 
-.grid [class*=digest-group] {
-  /* display: contents; */
+.grid [class*=digest-group],
+[class*=digest-group] {
   display: grid;
-  grid-template-columns: var(--columns);
   grid-column: 1/-1;
-  gap: var(--gap);
+  grid-template-columns: var(--columns);
+  padding: 0;
+  grid-gap: var(--gap);
+  width: min(var(--section-width), 100%);
+  margin: 0;
 }
 
 [class*=digest-group] .digest {

--- a/static/css/cards/grid.css
+++ b/static/css/cards/grid.css
@@ -77,15 +77,13 @@
  * Custom grid arrangements
  */
 
-.grid [class*=digest-group],
 [class*=digest-group] {
   display: grid;
   grid-column: 1/-1;
   grid-template-columns: var(--columns);
-  padding: 0;
   grid-gap: var(--gap);
-  width: min(var(--section-width), 100%);
   margin: 0;
+  padding: 0;
 }
 
 [class*=digest-group] .digest {

--- a/static/css/cards/utilities.css
+++ b/static/css/cards/utilities.css
@@ -176,6 +176,12 @@ form[id^=bx-form] {
   font: 700 1.8rem var(--serif);
 }
 
+@media(max-width: 600px) {
+  .partner-label {
+    margin: 0 var(--page-padding);
+  }
+}
+
 .partner-label::before {
   content: "";
   position: absolute;


### PR DESCRIPTION
### What does this PR do?

This PR adjusts for a better user interface. It does the following:

1. Adds more rules to the `digest-group` class to ensure visually grouped spacing, creating a break in the grid when a new group follows below (this may appear as a "hole" on two column layouts, as depicted)
2. Fixes the Partner label to have horizontal padding on mobile screen widths

### Steps to test

Please take a look at the source code as well and hit me with any questions or concerns over the approach.

1. Check out the new branch (`digest-group`) and fire up the Hugo server.
2. Take a look the homepage deck. 
3. Verify that when you adjust your browser width to two columns, the partner digest group stays contained and the content below doesn't get pushed up to fill in the second column.
4. Verify that the "From our partners" label on mobile/one column width has horizontal padding so that the text doesn't crash into the edge of the page.

### Here's what the page should look like at the described widths.
<img width="944" alt="Screenshot 2023-08-17 at 4 01 28 PM" src="https://github.com/mcclatchy/design/assets/16546254/c885f1a4-d304-44cd-8a4e-18f9351a9cc4">
</br>
<img width="416" alt="Screenshot 2023-08-17 at 4 01 48 PM" src="https://github.com/mcclatchy/design/assets/16546254/0a3b46d3-dd99-4ea8-8cfe-6120410ee964">