### PR TITLE
CLS improvement - upper nav

### DIFF
--- a/content/saratoga/upper-nav.md
+++ b/content/saratoga/upper-nav.md
@@ -8,4 +8,4 @@ The upper-nav element links verticals and nichce products to the parent publicat
 
 #### EXAMPLE
 
-*The upper-nav is included in our [story deck](../decks/story) and is better represented there.*
+*The upper-nav is included in our [section deck](../decks/section) and is better represented there.*

--- a/static/css/cards/upper-nav.css
+++ b/static/css/cards/upper-nav.css
@@ -3,6 +3,7 @@
   z-index: 11;
   display: flex;
   background-color: var(--body-background);
+  height: 44px;
 }
 
 .upper-nav .tab {
@@ -42,6 +43,10 @@
 }
 
 @media (min-width: 768px) {
+  .upper-nav {
+    height: 35px;
+  }
+
   .upper-nav .tab .favicon {
     display: none;
   }


### PR DESCRIPTION
### What does this PR do?

In the interest of working toward a better CLS score on our sites, this PR sets a `height` property on the `.upper-nav` class so that the element does not change height when the user loads a page.

### Steps to test

Please take a look at the source code as well and hit me with any questions or concerns over the approach.

1. Check out the new branch (`cls-upper-nav`) and fire up the Hugo server.
2. Take a look the section deck. 
3. Verify that when you adjust your browser the upper nav element height adjusts properly from desktop to mobile and back and nothing is visually off. 

Note: On mobile the background color of the ad background bleeds into the inactive logos side of the upper nav, which is already occurring on our live sites. Perhaps something to revisit and update UI-wise!