### PR TITLE
Author initials

### DIFF
--- a/layouts/shortcodes/author-card.html
+++ b/layouts/shortcodes/author-card.html
@@ -2,7 +2,7 @@
 
 <div class="author-card author-bio package">
   <div class="thumb">
-    <div class="intials">AM</div>
+    <div class="initials">AM</div>
     <!-- <img src="/img/aaron_moody.jpg" width="400" height="400" alt="Aaron Moody"> -->
   </div>
   <div class="a-details package">
@@ -23,7 +23,7 @@
 <div class="story-module">
   <div class="author-card package">
     <div class="thumb">
-      <div class="intials">AM</div>
+      <div class="initials">AM</div>
       <!-- <img src="/img/aaron_moody.jpg" width="400" height="400" alt="Aaron Moody"> -->
     </div>
     <div class="flex">

--- a/layouts/shortcodes/author-card.html
+++ b/layouts/shortcodes/author-card.html
@@ -2,7 +2,8 @@
 
 <div class="author-card author-bio package">
   <div class="thumb">
-    <img src="/img/aaron_moody.jpg" width="400" height="400" alt="Aaron Moody">
+    <div class="intials">AM</div>
+    <!-- <img src="/img/aaron_moody.jpg" width="400" height="400" alt="Aaron Moody"> -->
   </div>
   <div class="a-details package">
     <!-- <span class="h6 gray">SPORTS REPORTER</span> -->
@@ -22,7 +23,8 @@
 <div class="story-module">
   <div class="author-card package">
     <div class="thumb">
-      <img src="/img/aaron_moody.jpg" width="400" height="400" alt="Aaron Moody">
+      <div class="intials">AM</div>
+      <!-- <img src="/img/aaron_moody.jpg" width="400" height="400" alt="Aaron Moody"> -->
     </div>
     <div class="flex">
       <span class="h6 byline">

--- a/static/css/cards/author-card.css
+++ b/static/css/cards/author-card.css
@@ -22,10 +22,20 @@
 
 .author-card .thumb {
   position: relative;
+  background-color: #ECEEF2;
   width: 80px;
   height: 80px;
   box-sizing: border-box;
   grid-area: thumb;
+  border-radius: 50%;
+}
+
+.author-card .thumb .intials {
+  align-content: center;
+  height: 100%;
+  font-size: 36px;
+  font-weight: 700;
+  text-align: center;
 }
 
 .author-card .thumb img {

--- a/static/css/cards/author-card.css
+++ b/static/css/cards/author-card.css
@@ -30,7 +30,7 @@
   border-radius: 50%;
 }
 
-.author-card .thumb .intials {
+.author-card .thumb .initials {
   align-content: center;
   height: 100%;
   font-size: 36px;

--- a/static/css/cards/author-card.css
+++ b/static/css/cards/author-card.css
@@ -23,8 +23,8 @@
 .author-card .thumb {
   position: relative;
   background-color: var(--media-background-color);
-  width: 80px;
-  height: 80px;
+  width: 70px;
+  height: 70px;
   box-sizing: border-box;
   grid-area: thumb;
   border-radius: 50%;
@@ -33,7 +33,7 @@
 .author-card .thumb .initials {
   align-content: center;
   height: 100%;
-  font-size: 36px;
+  font-size: 24px;
   font-weight: 700;
   text-align: center;
 }

--- a/static/css/cards/author-card.css
+++ b/static/css/cards/author-card.css
@@ -22,7 +22,7 @@
 
 .author-card .thumb {
   position: relative;
-  background-color: #ECEEF2;
+  background-color: var(--media-background-color);
   width: 80px;
   height: 80px;
   box-sizing: border-box;


### PR DESCRIPTION
When an author does not have a thumbnail image, their initials will appear instead in a `div` with the class `.initials`. 

- Styling has been added to provide a light grey background color and center the initials within the circular area
- The dimensions have also been updated at design's request to be reduced from 80x80px to 70x70px