### PR TITLE
Viafoura

### DIFF
--- a/static/css/decks/fixes.css
+++ b/static/css/decks/fixes.css
@@ -151,3 +151,83 @@ custom-digest {
 .video-detail + .package {
   padding-top: var(--space);
 }
+
+
+/*
+ * Viafoura
+ */
+
+ .viafoura {
+  --dark-text-on-default-color: #0F1521;
+  color: #0F1521;
+  font-size: 16px;
+ }
+
+ .viafoura p, .zone-el .viafoura span.vf-dropdown-button__text, .zone-el .viafoura em.vf-post-name-button__username {
+  font-size: 16px;
+ }
+
+ .viafoura .all-comments p, .viafoura .vf-post-name-button__username {
+  font-size: 14px;
+ }
+
+ .viafoura nav.vf-tabbed-nav .vf-label-text, .vf-follow-button__text {
+  font-size: 12px;
+ }
+
+ .zone-el .viafoura .vf-label,
+ .viafoura time,
+ .viafoura .vf-comment-actions {
+  font-size: 10px;
+ }
+
+ .viafoura h2.vf-heading-text {
+  font-family: "Noto Sans";
+  font-size: 20px;
+  font-weight: 700;
+  text-transform: uppercase;
+ }
+
+ #commentingIntro, .v3-comments__post-form {
+  border-top: 1px solid #ECEEF2;
+  margin: 20px 0;
+  padding-top: 20px;
+ }
+
+ .viafoura nav.vf-tabbed-nav .vf-label-text, .zone-el .viafoura span.vf-dropdown-button__text, .zone-el .viafoura em.vf-post-name-button__username {
+  font-weight: 700;
+ }
+
+ .viafoura .vf3-comments__bottom-action .vf-load-more.vf-label-text button.vf-button.vf-load-more__button.vf-loader-button, .zone-el .viafoura button.big.button {
+  background-color: #4D5970;
+  color: white;
+  font: 700 16px/24px 'Noto Sans', sans-serif;
+  text-transform: uppercase;
+  padding: 10px 20px;
+ }
+
+ .viafoura .vf3-comments__bottom-action .vf-load-more.vf-label-text button.vf-button.vf-load-more__button.vf-loader-button:hover, .zone-el .viafoura button.big.button:hover {
+  color: #B0CBFF;
+ }
+
+ .viafoura p.vf-secondary-text, .zone-el .viafoura .vf-comments-trending-articles[data-v-1e6aff7f] .vf-trending-articles__header {
+  font-size: 14px;
+  font-weight: 400;
+ }
+
+ .viafoura .vf-button.is-size-tiny[data-v-7870d8ba] {
+  padding: 5px 10px;
+ }
+
+ .viafoura .vf-post-form__new-content[data-v-45fba7ae] {
+  margin-bottom: 20px;
+  padding: 0;
+ }
+
+ .viafoura .vf-content-focus-container--default[data-v-2917e5f4] {
+  padding: 5px 0;
+ }
+
+ .vf-actions-authentication, .viafoura .vf-post-form__new-content[data-v-45fba7ae] .vf-content-layout__right::before, .viafoura .vf-post-form__new-content[data-v-45fba7ae] .vf-content-layout__right::after {
+  display: none;
+ }

--- a/static/css/decks/fixes.css
+++ b/static/css/decks/fixes.css
@@ -232,8 +232,8 @@ custom-digest {
  }
 
  @media(max-width: 480px) {
-  .viafoura .vf-comment-header, .viafoura .vf-comment-header__actions {
-    display: block;
+  .viafoura .vf-comment-header {
+    flex-direction: column;
   }
   .viafoura .vf-follow-button {
     margin: 10px 0;

--- a/static/css/decks/fixes.css
+++ b/static/css/decks/fixes.css
@@ -160,10 +160,11 @@ custom-digest {
  .viafoura {
   --dark-text-on-default-color: #0F1521;
   color: #0F1521;
+  font-family: 'Noto Sans' sans-serif;
   font-size: 16px;
  }
 
- .viafoura p, .zone-el .viafoura span.vf-dropdown-button__text, .zone-el .viafoura em.vf-post-name-button__username {
+ .viafoura p, .viafoura .vf-post-name-button__username {
   font-size: 16px;
  }
 
@@ -171,34 +172,32 @@ custom-digest {
   font-size: 14px;
  }
 
- .viafoura nav.vf-tabbed-nav .vf-label-text, .vf-follow-button__text {
+ .viafoura nav.vf-tabbed-nav .vf-label-text, .viafoura .vf-follow-button__text, .viafoura .vf-dropdown-button__text {
   font-size: 12px;
  }
 
- .zone-el .viafoura .vf-label,
- .viafoura time,
- .viafoura .vf-comment-actions {
+ .viafoura .vf-label, .viafoura time, .viafoura .vf-comment-actions {
   font-size: 10px;
  }
 
  .viafoura h2.vf-heading-text {
-  font-family: "Noto Sans";
+  font-family: 'Noto Sans', sans-serif;
   font-size: 20px;
   font-weight: 700;
   text-transform: uppercase;
  }
 
- #commentingIntro, .v3-comments__post-form {
+ .viafoura #commentingIntro, .viafoura .v3-comments__post-form {
   border-top: 1px solid #ECEEF2;
   margin: 20px 0;
   padding-top: 20px;
  }
 
- .viafoura nav.vf-tabbed-nav .vf-label-text, .zone-el .viafoura span.vf-dropdown-button__text, .zone-el .viafoura em.vf-post-name-button__username {
+ .viafoura .vf-tabbed-nav .vf-label-text, .viafoura .vf-dropdown-button__text, .viafoura .vf-post-name-button__username {
   font-weight: 700;
  }
 
- .viafoura .vf3-comments__bottom-action .vf-load-more.vf-label-text button.vf-button.vf-load-more__button.vf-loader-button, .zone-el .viafoura button.big.button {
+ .viafoura .vf3-comments__bottom-action .vf-load-more.vf-label-text button.vf-button.vf-load-more__button.vf-loader-button, .viafoura button.big.button {
   background-color: #4D5970;
   color: white;
   font: 700 16px/24px 'Noto Sans', sans-serif;
@@ -206,28 +205,37 @@ custom-digest {
   padding: 10px 20px;
  }
 
- .viafoura .vf3-comments__bottom-action .vf-load-more.vf-label-text button.vf-button.vf-load-more__button.vf-loader-button:hover, .zone-el .viafoura button.big.button:hover {
+ .viafoura .vf3-comments__bottom-action .vf-load-more.vf-label-text button.vf-button.vf-load-more__button.vf-loader-button:hover, .viafoura button.big.button:hover {
   color: #B0CBFF;
  }
 
- .viafoura p.vf-secondary-text, .zone-el .viafoura .vf-comments-trending-articles[data-v-1e6aff7f] .vf-trending-articles__header {
+ .viafoura .vf-secondary-text, .viafoura .vf-comments-trending-articles .vf-trending-articles__header {
   font-size: 14px;
   font-weight: 400;
  }
 
- .viafoura .vf-button.is-size-tiny[data-v-7870d8ba] {
+ .viafoura .vf-button.is-size-tiny {
   padding: 5px 10px;
  }
 
- .viafoura .vf-post-form__new-content[data-v-45fba7ae] {
+ .viafoura .vf-post-form__new-content {
   margin-bottom: 20px;
   padding: 0;
  }
 
- .viafoura .vf-content-focus-container--default[data-v-2917e5f4] {
+ .viafoura .vf-content-focus-container--default {
   padding: 5px 0;
  }
 
- .vf-actions-authentication, .viafoura .vf-post-form__new-content[data-v-45fba7ae] .vf-content-layout__right::before, .viafoura .vf-post-form__new-content[data-v-45fba7ae] .vf-content-layout__right::after {
+ .viafoura .vf-actions-authentication, .viafoura .vf-post-form__new-content .vf-content-layout__right::before, .viafoura .vf-post-form__new-content .vf-content-layout__right::after {
   display: none;
+ }
+
+ @media(max-width: 480px) {
+  .viafoura .vf-comment-header, .viafoura .vf-comment-header__actions {
+    display: block;
+  }
+  .viafoura .vf-follow-button {
+    margin: 10px 0;
+  }
  }

--- a/static/css/decks/fixes.css
+++ b/static/css/decks/fixes.css
@@ -214,13 +214,13 @@ custom-digest {
   font-weight: 400;
  }
 
- .viafoura .vf-button.is-size-tiny {
-  padding: 5px 10px;
- }
-
  .viafoura .vf-post-form__new-content {
   margin-bottom: 20px;
   padding: 0;
+ }
+
+ .viafoura .vf-button.is-size-tiny {
+  padding: 5px 10px;
  }
 
  .viafoura .vf-content-focus-container--default {


### PR DESCRIPTION
New styling preceded with a `.viafoura` class has been added to modify the commenting native styles to better match our brand and the new design. The concern began with the current spacing, alignment, and font sizes that do not accurately reflect the design mock.

For testing, I've been using an overrides file and commenting our Performance's code. We'll also need to make sure that SDS styles are loaded after Viafoura's code, for as of now that's not the case on production.

Related Jira ticket from Performance with comments where Joe W described the current inline styling modifications:
https://mcclatchy.atlassian.net/browse/PERF-854

Figma mock:
https://www.figma.com/design/EETJOb1k7q4rD31kkpWwxz/Viafoura?node-id=157-3378&m=dev