### PR TITLE
ad unit zone specific updates

### DIFF
--- a/static/css/cards/zones.css
+++ b/static/css/cards/zones.css
@@ -9,8 +9,6 @@
 }
 
 [data-type=ad] > * {
-  position: sticky;
-  top: 0;
   padding: var(--space) 0;
 }
 
@@ -80,4 +78,13 @@
   max-width: var(--story-width);
   margin: 40px auto;
   padding: 0;
+}
+
+.htlad-web-native {
+  padding: 0;
+}
+
+.scrollow > * {
+  position: sticky;
+  top: 70px; /* flag height - padding */
 }


### PR DESCRIPTION
We needed to fix a couple ad-related zone issues:

1. The initially implemented "scrollow" functionality was being applied to all `[data-type=ad]` elements, but that included Taboola, which should not have that functionality, nor should every single ad. After troubleshooting with the ad team, we decided to coordinate an update with the Performance Team that includes a `.scrollow` class. This class is now the target for the specific scrollow functionality, making it predictable and easy to manage.
2. The native ad unit in GAM that resembles a content card had gray bars appearing from the vertical padding, so now those specific zones have the padding systematically removed. Another note here - any "sponsored by" ad units that are programmed inline within a digest are not currently supported but will be as soon as that targeting method is determined.

Related Jira ticket: [FE-563](https://mcclatchy.atlassian.net/browse/FE-563)