### PR TITLE
PE-298 viafoura updates

### DIFF
--- a/static/css/decks/fixes.css
+++ b/static/css/decks/fixes.css
@@ -4,7 +4,7 @@
  * Note: these things are very old and may be dead
  */
 
-form[id^=bx-form] {
+ form[id^=bx-form] {
   display: block;
 }
 
@@ -116,33 +116,31 @@ custom-digest {
  * impact class needs removed in WPS 
  */
 
- .impact form input {
-    background-color: white;
- }
+.impact form input {
+  background-color: white;
+}
 
- .impact form .button {
-    color: white;
- }
+.impact form .button {
+  color: white;
+}
 
 /*
  * Breaking news banner text
  * impact class needs removed in WPS 
  */
 
- .breaking-news-organism.impact a {
+.breaking-news-organism.impact a {
   color: inherit;
 }
-
 
 /*
  * Braze notification modal
  * to be integrated into the system
  */
 
- #brzpushpermission {
+#brzpushpermission {
   --link-color: none;
 }
-
 
 /*
  * Video detail page oddness
@@ -152,91 +150,108 @@ custom-digest {
   padding-top: var(--space);
 }
 
-
 /*
  * Viafoura
  */
 
- .viafoura {
+.viafoura {
   --dark-text-on-default-color: #0F1521;
   color: #0F1521;
-  font-family: 'Noto Sans' sans-serif;
+  font-family: 'Noto Sans', sans-serif;
   font-size: 16px;
- }
+}
 
- .viafoura p, .viafoura .vf-post-name-button__username {
+.viafoura p,
+.viafoura .all-comments p,
+.viafoura p.vf-primary-text,
+.viafoura .vf-post-name-button__username,
+.viafoura nav.vf-tabbed-nav .vf-nav-label .vf-label-text,
+.viafoura .vf-dropdown-button__text {
   font-size: 16px;
- }
+}
 
- .viafoura .all-comments p, .viafoura .vf-post-name-button__username {
+.viafoura .vf-follow-button__text,
+.viafoura .vf-post-name-button__username,
+.viafoura h2.vf-subheading-text {
   font-size: 14px;
- }
+}
 
- .viafoura nav.vf-tabbed-nav .vf-nav-label .vf-label-text, .viafoura .vf-follow-button__text, .viafoura .vf-dropdown-button__text {
-  font-size: 12px;
- }
-
- .viafoura .vf-label, .viafoura time, .viafoura .vf-comment-actions {
-  font-size: 10px;
- }
-
- .viafoura h2.vf-heading-text {
+.viafoura h2.vf-heading-text {
   font-family: 'Noto Sans', sans-serif;
   font-size: 20px;
   font-weight: 700;
   text-transform: uppercase;
- }
+}
 
- .viafoura #commentingIntro, .viafoura .v3-comments__post-form {
+.viafoura button.vf-follow-button.vf-button[data-v-632eed25] {
+  padding: 5px 10px;
+}
+
+.viafoura #commentingIntro,
+.viafoura .v3-comments__post-form {
   border-top: 1px solid #ECEEF2;
   margin: 20px 0;
   padding-top: 20px;
- }
+}
 
- .viafoura .vf-tabbed-nav .vf-label-text, .viafoura .vf-dropdown-button__text, .viafoura .vf-post-name-button__username {
+.viafoura #commentingIntro {
+  line-height: 26px;
+}
+
+.viafoura .vf-tabbed-nav .vf-label-text,
+.viafoura .vf-tabbed-nav .vf-nav-tab-button__text[data-v-5517aee9],
+.viafoura .vf-dropdown-button__text,
+.viafoura .vf-post-name-button__username {
   font-weight: 700;
- }
+  text-transform: uppercase;
+}
 
- .viafoura .vf3-comments__bottom-action .vf-load-more.vf-label-text button.vf-button.vf-load-more__button.vf-loader-button, .viafoura button.big.button {
-  background-color: #4D5970;
+.viafoura .vf3-comments__bottom-action .vf-load-more.vf-label-text button.vf-button.vf-load-more__button.vf-loader-button,
+.viafoura button.big.button {
+  background-color: var(--black);
   color: white;
   font: 700 16px/24px 'Noto Sans', sans-serif;
   text-transform: uppercase;
-  padding: 10px 20px;
- }
+  padding: .4em 1em;
+}
 
- .viafoura .vf3-comments__bottom-action .vf-load-more.vf-label-text button.vf-button.vf-load-more__button.vf-loader-button:hover, .viafoura button.big.button:hover {
+.viafoura .vf3-comments__bottom-action .vf-load-more.vf-label-text button.vf-button.vf-load-more__button.vf-loader-button:hover,
+.viafoura button.big.button:hover {
   color: #B0CBFF;
- }
+}
 
- .viafoura .vf-secondary-text, .viafoura .vf-comments-trending-articles .vf-trending-articles__header {
+.viafoura .vf-secondary-text,
+.viafoura .vf-comments-trending-articles[data-v-1e6aff7f] h2.vf-trending-articles__header {
   font-size: 14px;
   font-weight: 400;
- }
+}
 
- .viafoura div.vf-post-form__new-content[data-v-45fba7ae] {
+.viafoura div.vf-post-form__new-content[data-v-45fba7ae] {
   margin-bottom: 20px;
   padding: 0;
- }
+}
 
- .viafoura .vf-button.is-size-tiny {
+.viafoura .vf-button.is-size-tiny {
   padding: 5px 10px;
- }
+}
 
- .viafoura .vf-content-focus-container--default {
+.viafoura .vf-content-focus-container--default {
   padding: 5px 0;
- }
+}
 
- .viafoura .vf-actions-authentication, .viafoura .vf-post-form__new-content .vf-content-layout__right::before, .viafoura .vf-post-form__new-content .vf-content-layout__right::after {
+.viafoura .vf-actions-authentication,
+.viafoura .vf-post-form__new-content .vf-content-layout__right::before,
+.viafoura .vf-post-form__new-content .vf-content-layout__right::after,
+.viafoura .vf-client-settings-button-logout {
   display: none;
- }
+}
 
- @media(max-width: 480px) {
+@media (max-width: 480px) {
   .viafoura header.vf-comment-header[data-v-ddad5b80] {
     align-items: flex-start;
     flex-direction: column;
   }
-  
+
   .viafoura .vf-comment-header .vf-comment-header__actions {
     align-items: start;
   }

--- a/static/css/decks/fixes.css
+++ b/static/css/decks/fixes.css
@@ -195,10 +195,6 @@ custom-digest {
   padding-top: 20px;
 }
 
-.viafoura #commentingIntro {
-  line-height: 26px;
-}
-
 .viafoura .vf-tabbed-nav .vf-label-text,
 .viafoura .vf-tabbed-nav .vf-nav-tab-button__text[data-v-5517aee9],
 .viafoura .vf-dropdown-button__text,
@@ -209,6 +205,12 @@ custom-digest {
 
 .viafoura .vf-nav-tab-button--inside-dropdown[data-v-5517aee9] {
   align-items: center;
+}
+
+.viafoura div.vf3-comments__tabbed-nav__right[data-v-66fa0041] {
+  justify-content: space-between;
+  width: 100%;
+  margin-left: 0;
 }
 
 .viafoura .vf3-comments__bottom-action .vf-load-more.vf-label-text button.vf-button.vf-load-more__button.vf-loader-button,
@@ -236,6 +238,10 @@ custom-digest {
   padding: 0;
 }
 
+.viafoura div.vf-content-layout[data-v-2396f95c] {
+  padding: 20px 0;
+}
+
 .viafoura .vf-button.is-size-tiny {
   padding: 5px 10px;
 }
@@ -244,9 +250,14 @@ custom-digest {
   padding: 5px 0;
 }
 
+.viafoura .vf3-conversations-list--comments[data-v-5ce821cf] .vf3-conversations-list--comments--list {
+  margin: 0;
+}
+
 .viafoura .vf-actions-authentication,
 .viafoura .vf-post-form__new-content .vf-content-layout__right::before,
 .viafoura .vf-post-form__new-content .vf-content-layout__right::after,
+.viafoura div.vf-top-comments-info-trigger__container[data-v-e15d4864],
 .viafoura .vf-client-settings-button-logout {
   display: none;
 }

--- a/static/css/decks/fixes.css
+++ b/static/css/decks/fixes.css
@@ -172,7 +172,8 @@ custom-digest {
 
 .viafoura .vf-follow-button__text,
 .viafoura .vf-post-name-button__username,
-.viafoura h2.vf-subheading-text {
+.viafoura h2.vf-subheading-text,
+.viafoura time.vf-label {
   font-size: 14px;
 }
 
@@ -204,6 +205,10 @@ custom-digest {
 .viafoura .vf-post-name-button__username {
   font-weight: 700;
   text-transform: uppercase;
+}
+
+.viafoura .vf-nav-tab-button--inside-dropdown[data-v-5517aee9] {
+  align-items: center;
 }
 
 .viafoura .vf3-comments__bottom-action .vf-load-more.vf-label-text button.vf-button.vf-load-more__button.vf-loader-button,


### PR DESCRIPTION
Additional styling updates to Viafoura request by design. [This](https://www.figma.com/design/EETJOb1k7q4rD31kkpWwxz/Viafoura?node-id=558-3811&t=wiMPdAIDxlHLYvGr-0) is the original Figma file, but there was a meeting to discuss more particular updates. Changes listed below:

1. Upsized text for legibility
2. Spacing refinement
3. Black button color
4. Remove padding around user comments so they appear flush to the side
5. Left align tabs, leaving notification bell icon aligned right