### PR TITLE
update transparency DOM and styling with read more expander redesign

### DIFF
--- a/layouts/shortcodes/transparency.html
+++ b/layouts/shortcodes/transparency.html
@@ -1,15 +1,9 @@
 <div class="transparency">
-  <h3 class="expander" onclick="this.classList.toggle('open');">Behind the Story</h3>
-  <div class="question" style="display: block;">
-    <h3>Why did we report this story?</h3>
-    <p class="summary">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut pretium pretium tempor. Ut eget imperdiet neque. In volutpat ante semper diam molestie, et aliquam erat laoreet. Sed sit amet arcu aliquet, molestie justo at, auctor nunc. Phasellus ligula ipsum, volutpat eget semper id, viverra eget nibh. Suspendisse luctus mattis cursus. Nam consectetur ante at nisl hendrerit gravida. Donec vehicula rhoncus mattis. Mauris dignissim semper mattis. Fusce porttitor a mi at suscipit.</p>
-  </div>
+  <h3>Behind the story</h3>
+  <p class="summary">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut pretium pretium tempor. Ut eget imperdiet neque. In volutpat ante semper diam molestie, et aliquam erat laoreet. Sed sit amet arcu aliquet, molestie justo at, auctor nunc. Phasellus ligula ipsum, volutpat eget semper id, viverra eget nibh. Suspendisse luctus mattis cursus. Nam consectetur ante at nisl hendrerit gravida. Donec vehicula rhoncus mattis. Mauris dignissim semper mattis. Fusce porttitor a mi at suscipit.</p>
+  <a class="more-link expander" onclick="this.classList.toggle('open');">Read More</a>
   <div class="question">
-    <h3>Where did this idea come from?</h3>
-    <p class="summary">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut pretium pretium tempor. Ut eget imperdiet neque. In volutpat ante semper diam molestie, et aliquam erat laoreet. Sed sit amet arcu aliquet, molestie justo at, auctor nunc. Phasellus ligula ipsum, volutpat eget semper id, viverra eget nibh. Suspendisse luctus mattis cursus. Nam consectetur ante at nisl hendrerit gravida. Donec vehicula rhoncus mattis. Mauris dignissim semper mattis. Fusce porttitor a mi at suscipit.</p>
-  </div>
-  <div class="question">
-    <h3>Who did we talk to?</h3>
+    <h3>What's next?</h3>
     <p class="summary">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut pretium pretium tempor. Ut eget imperdiet neque. In volutpat ante semper diam molestie, et aliquam erat laoreet. Sed sit amet arcu aliquet, molestie justo at, auctor nunc. Phasellus ligula ipsum, volutpat eget semper id, viverra eget nibh. Suspendisse luctus mattis cursus. Nam consectetur ante at nisl hendrerit gravida. Donec vehicula rhoncus mattis. Mauris dignissim semper mattis. Fusce porttitor a mi at suscipit.</p>
   </div>
   <div class="question">

--- a/static/css/cards/transparency.css
+++ b/static/css/cards/transparency.css
@@ -13,16 +13,15 @@
 	font-size: 1.11rem;
 	font-weight: bold;
 	text-transform: uppercase;
-}
-
-.transparency .expander {
-	justify-content: space-between;
+	padding-bottom: var(--space-sm);
 }
 
 .transparency .summary {
 	font-size: var(--font-base);
 	font-family: var(--serif);
 	line-height: 30px;
+	margin: 0;
+	padding: 0 var(--space);
 }
 
 .question {
@@ -34,4 +33,8 @@
 .question h3 {
 	text-transform: none;
 	margin: 0;
+}
+
+.question .summary {
+	padding: 0;
 }


### PR DESCRIPTION
The story page transparency box is getting a UI update to improve user experience. Most notably, the expander says "read more" and is intended to say "close" while in the expanded state. This SDS change requires a WPS DOM update too.

[Jira ticket](https://mcclatchy.atlassian.net/browse/PE-309)
[Figma file](https://www.figma.com/design/IGF5QSErRX4oLU7TuLJPeK/New-Design-System?node-id=3240-1473&t=BPjdgAV39oFfQJjW-0)