### PR TITLE
PE-304 related stories border styling

### DIFF
--- a/layouts/shortcodes/related-stories.html
+++ b/layouts/shortcodes/related-stories.html
@@ -12,5 +12,4 @@
       <time>Aug 13, 2018</time>
     </article>
   </div>
-  <hr>
 </div>

--- a/static/css/cards/related-stories.css
+++ b/static/css/cards/related-stories.css
@@ -2,7 +2,12 @@
  * Related stories
  */
 
-.related-stories h3 {
+.related-stories > *:last-child {
+  border-bottom: 0.5px solid var(--secondary-text-color);
+  padding-bottom: var(--space);
+}
+
+ .related-stories h3 {
   font-size: 0.89rem;
 }
 
@@ -11,10 +16,6 @@
   text-transform: uppercase;
   margin-top: 0;
   margin-bottom: var(--space);
-}
-
-.related-stories hr {
-  margin-top: 15px;
 }
 
 @media(max-width: 674px) {


### PR DESCRIPTION
The `hr` element is being swapped for `border-bottom` styling on related stories in order to more efficiently maintain the styling system.

[Jira ticket](https://mcclatchy.atlassian.net/browse/PE-304)

