### PR TITLE
Pe 398 2.5 automation

### DIFF
--- a/.github/workflows/deploy-to-gcs.yml
+++ b/.github/workflows/deploy-to-gcs.yml
@@ -31,4 +31,5 @@ jobs:
 
       - name: Sync files to Google Cloud Storage
         run: |
-          gcloud storage rsync --recursive dist gs://mc-high-impact/sds/$version
+          gcloud storage rsync --recursive --dry-run dist gs://mc-high-impact/sds/$version/dist
+          gcloud storage rsync --recursive --dry-run static/css gs://mc-high-impact/sds/$version/css

--- a/.github/workflows/deploy-to-gcs.yml
+++ b/.github/workflows/deploy-to-gcs.yml
@@ -31,5 +31,5 @@ jobs:
 
       - name: Sync files to Google Cloud Storage
         run: |
-          gcloud storage rsync --recursive --dry-run dist gs://mc-high-impact/sds/$version/dist
-          gcloud storage rsync --recursive --dry-run static/css gs://mc-high-impact/sds/$version/css
+          gcloud storage rsync --recursive dist gs://mc-high-impact/sds/$version/dist
+          gcloud storage rsync --recursive static/css gs://mc-high-impact/sds/$version/css

--- a/.github/workflows/deploy-to-gcs.yml
+++ b/.github/workflows/deploy-to-gcs.yml
@@ -31,8 +31,4 @@ jobs:
 
       - name: Sync files to Google Cloud Storage
         run: |
-          gcloud storage rsync --dry-run --recursive dist gs://mc-high-impact/sds/$version
-
-      # - name: List files in bucket (Optional - for verification)
-      #   run: |
-      #     gsutil ls gs://${{ secrets.GCP_BUCKET_NAME }}/my_files
+          gcloud storage rsync --recursive dist gs://mc-high-impact/sds/$version

--- a/dist/saratoga.css
+++ b/dist/saratoga.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * Default parameters
  */
@@ -118,9 +119,11 @@ h6, .h6 {
   h1, .h1 {
     font-size: var(--h2);
   }
+
   h2, .h2 {
     font-size: 1.22rem;
   }
+
   h3, .h3 {
     font-size: var(--font-base);
   }
@@ -414,13 +417,13 @@ input:focus, select:focus, .focus {
 }
 
 .password-label:after {
-  content: "\f070";
+  content: "";
   font: 400 14px Font Awesome\ 5 Free;
   cursor: pointer;
 }
 
 .password-label.active:after {
-  content: "\f06e";
+  content: "";
 }
 
 /**
@@ -641,7 +644,7 @@ figcaption .byline {
 }
 
 .slider::-webkit-scrollbar-thumb {
-  background: var(--scrollbar-foreground, rgba(0, 0, 0, 0.4666666667));
+  background: var(--scrollbar-foreground, #0007);
 }
 
 .slider::--webkit-scrollbar-track {
@@ -680,6 +683,7 @@ section, .section {
   section, .section {
     padding: 0 var(--page-padding);
   }
+
   .section-label {
     padding: 0;
   }
@@ -962,27 +966,33 @@ html.msb .masthead {
     --flag-height: 44px;
     --menu-width: 100vw;
   }
+
   .flag {
     padding: 0;
     column-gap: 0;
     grid-template-columns: auto 1fr;
     grid-template-areas: "bottom top";
   }
+
   .flag .button {
     padding: 0 var(--space-sm);
   }
+
   .flag .msb-hide a:last-of-type {
     padding-right: var(--space-sm);
   }
+
   .flag-top {
     grid-template-columns: 200px 1fr;
     grid-template-areas: "middle right";
     gap: var(--space-sm);
   }
+
   .flag-bottom {
     grid-template-columns: 1fr;
     grid-template-areas: "left";
   }
+
   .flag-line {
     display: none;
   }
@@ -1092,6 +1102,7 @@ html.msb .masthead {
     grid-template-columns: 1fr 1fr;
     grid-template-areas: "menu account" "left right" "logo logo" "nav nav";
   }
+
   .msb .sds-flag {
     grid-template-areas: "menu account" "left right" "edition edition" "logo logo" "nav nav";
   }
@@ -1101,6 +1112,7 @@ html.msb .masthead {
     grid-template-columns: 1fr 2fr 1fr;
     grid-template-areas: "menu . account" "left logo right" "nav nav nav";
   }
+
   .msb .sds-flag {
     grid-template-areas: "menu edition account" "left logo right" "nav nav nav";
   }
@@ -1504,6 +1516,7 @@ footer {
     flex-direction: row;
     justify-content: space-around;
   }
+
   .bottom-nav {
     display: flex;
     justify-content: center;
@@ -1514,6 +1527,7 @@ footer {
   .footer {
     grid-template-columns: 340px 1fr;
   }
+
   .footer-links {
     justify-content: end;
   }
@@ -1558,8 +1572,9 @@ footer {
   .grid .two-columns {
     grid-column: span 2;
   }
+
   .grid .three-columns,
-  .grid .full-width {
+.grid .full-width {
     grid-column: 1/-1;
   }
 }
@@ -1571,14 +1586,17 @@ footer {
     grid-column-end: span 2;
     grid-row: span 2;
   }
+
   .grid .digest {
     align-self: stretch;
     grid-column: 1;
     grid-row-end: span 2;
   }
+
   .grid .in-depth {
     grid-column: 1/-1;
   }
+
   .grid .optional-digest {
     grid-row-start: 8;
   }
@@ -1716,7 +1734,7 @@ footer {
  */
 .story-body > .inline-video {
   box-sizing: border-box;
-  max-width: calc(var(--story-media-width) + var(--page-padding) * 2);
+  max-width: calc(var(--story-media-width) + (var(--page-padding) * 2));
 }
 
 /**
@@ -1934,32 +1952,40 @@ footer {
     flex-wrap: wrap;
     margin: -15px;
   }
+
   .flex-columns.reverse {
     flex-direction: row-reverse;
   }
+
   .flex-columns > * {
     flex: 1 1 300px;
     margin: 15px;
   }
+
   .flex-columns > zeus-ad {
     flex: none;
     padding: 15px;
   }
+
   .flex-columns > .flex-columns {
     margin: 0;
   }
+
   .flex-columns .main-stage {
     flex: 2 1 660px;
     align-self: flex-start;
   }
+
   .flex-columns .rail {
     flex-basis: 330px;
     align-self: flex-start;
   }
+
   /** Special cases **/
   .lead-section .main-stage > :first-child {
     flex-basis: 100%;
   }
+
   .main-stage > .flex-columns + .flex-columns {
     padding-top: 15px;
   }
@@ -2045,7 +2071,8 @@ footer {
 
 .scrollow > * {
   position: sticky;
-  top: 70px; /* flag height - padding */
+  top: 70px;
+  /* flag height - padding */
 }
 
 /**
@@ -2193,6 +2220,7 @@ footer {
   .search-form {
     grid-template-columns: 1fr 140px 200px;
   }
+
   .search-form .select {
     grid-column: auto;
   }
@@ -2279,6 +2307,7 @@ footer {
     grid-template-columns: 35px 1fr;
     align-items: start;
   }
+
   .opinion-banner svg {
     grid-row: span 2;
   }
@@ -2337,6 +2366,11 @@ footer {
 /**
  * Related stories
  */
+.related-stories > *:last-child {
+  border-bottom: 0.5px solid var(--secondary-text-color);
+  padding-bottom: var(--space);
+}
+
 .related-stories h3 {
   font-size: 0.89rem;
 }
@@ -2348,10 +2382,6 @@ footer {
   margin-bottom: var(--space);
 }
 
-.related-stories hr {
-  margin-top: 15px;
-}
-
 @media (max-width: 674px) {
   .related-stories .package::after {
     content: "";
@@ -2361,6 +2391,7 @@ footer {
     margin-bottom: var(--space-sm);
     padding-top: 5px;
   }
+
   .related-stories .package:last-child::after {
     display: none;
   }
@@ -2464,13 +2495,16 @@ footer {
     grid-template-columns: auto 3fr 2fr;
     grid-template-areas: "thumb info contact" "thumb bio contact";
   }
+
   .author-bio .a-details {
     align-self: end;
   }
+
   .author-bio .thumb {
     width: 160px;
     height: 160px;
   }
+
   .author-bio .a-social {
     justify-self: end;
   }
@@ -2485,7 +2519,7 @@ footer {
   --header-family: var(--sans);
   --header-weight: 600;
   --header-transform: uppercase;
-  padding: var(--timeline-padding, calc(var(--space) * 2 / 3) var(--space));
+  padding: var(--timeline-padding, calc(var(--space)*2/3) var(--space));
 }
 
 .timeline-event:before {
@@ -2600,10 +2634,12 @@ section.big-news {
   .big-news .h1 {
     font-size: 2.67rem;
   }
+
   .big-news .label .h5 {
     font-size: 1.33rem;
     margin: 0;
   }
+
   .big-news figcaption {
     font: 0.78rem var(--sans);
   }
@@ -2823,9 +2859,11 @@ section.big-news {
   .upper-nav {
     height: 35px;
   }
+
   .upper-nav .tab .favicon {
     display: none;
   }
+
   .upper-nav .tab .logo {
     display: block;
   }
@@ -3028,8 +3066,9 @@ section.big-news {
   .h-tablet {
     display: none;
   }
+
   .h-phone,
-  .d-tablet {
+.d-tablet {
     display: var(--display, block);
   }
 }
@@ -3037,6 +3076,7 @@ section.big-news {
   .h-desktop {
     display: none;
   }
+
   .d-desktop {
     display: var(--display, block);
   }
@@ -3126,6 +3166,7 @@ section.big-news {
   #promo-banner h3 {
     font-size: 16px;
   }
+
   #promo-banner .button {
     display: none;
   }
@@ -3437,6 +3478,7 @@ custom-digest {
     align-items: flex-start;
     flex-direction: column;
   }
+
   .viafoura .vf-comment-header .vf-comment-header__actions {
     align-items: start;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saratoga-design-system",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "scripts": {
     "build": "sass --style expanded --no-source-map builds:dist",
     "version": "npm run build && git add -A dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saratoga-design-system",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "scripts": {
     "build": "sass --style expanded --no-source-map builds:dist",
     "version": "npm run build && git add -A dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saratoga-design-system",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "scripts": {
     "version": "sass --style expanded --no-source-map builds:dist"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "sass --style expanded --no-source-map builds:dist",
     "version": "npm run build && git add -A dist",
-    "postversion": "git push && git push --tags"
+    "postversion": "git push"
   },
   "files": [
     "dist/saratoga.css",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "saratoga-design-system",
   "version": "2.5.6",
   "scripts": {
-    "version": "sass --style expanded --no-source-map builds:dist"
+    "build": "sass --style expanded --no-source-map builds:dist",
+    "version": "npm run build && git add -A dist",
+    "postversion": "git push %% git push --tags"
   },
   "files": [
     "dist/saratoga.css",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "saratoga-design-system",
   "version": "2.5.5",
+  "scripts": {
+    "version": "sass --style expanded --no-source-map builds:dist"
+  },
   "files": [
     "dist/saratoga.css",
     "dist/dsp.css",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "saratoga-design-system",
-  "version": "2.5.7",
+  "version": "2.5.5",
   "scripts": {
     "build": "sass --style expanded --no-source-map builds:dist",
     "version": "npm run build && git add -A dist",
-    "postversion": "git push %% git push --tags"
+    "postversion": "git push && git push --tags"
   },
   "files": [
     "dist/saratoga.css",


### PR DESCRIPTION
### Local scripts

I've added the automation based on `npm version patch` that will do the following:

1. Bump the version patch number
2. Run Sass builds
3. Commits the `package.json` and `dist` folders to the branch
4. Creates a local tag matching the version (but does not autoamtically push that tag)

On #4 .. I think this is a decent way to play in the middle to see how far we want to go. You can always delete tags and recreate them locally prior to pushing to the repo. Once there, it's slightly harder to take them out. Once you have everything set up the way you like it, just run `git push --tags` to move whatever you have up. We can turn off that automated tag creation with an optional flag if you'd like.

### Github Actions

It's currently setup to run manually, but the file performs the following steps:

1. Authenticates with GCP
2. Figures out the minor version using `jq`
3. Syncs the `dist` folder to our standard bucket at the path `mc-high-impact/sds/$version`

Thoughts. For 2.5 we only use the pre-built versions, so I am putting those directly into that folder in the bucket. If we wanted to also move up all the CSS files, that's very easy to do and I would recommend adding a layer like so:

`mc-high-impact/sds/$version/dist/*.css`
`mc-high-impact/sds/$version/css/atoms.css` (and all the others)

This would be very easy to do, so if you like that idea put in a change request and I'll do it before we merge. I do think 3.0 should house both like this if you're on the fence and that pushes you one way or the other.