### PR TITLE
initial clean up to remove purple tuesdays from fixes file

### DIFF
--- a/static/css/decks/fixes.css
+++ b/static/css/decks/fixes.css
@@ -45,17 +45,6 @@ figure .img-container figcaption,
   padding-top: 10px;
 }
 
-/* class needs removed in WPS */
-.load-more .impact {
-  color: var(--text-color);
-  background-color: var(--paper-color);
-}
-
-/* class needs removed in WPS */
-.digest .label .impact {
-  --impact-text-color: var(--darkgray);
-}
-
 /*
  * Fixes related to custom cards
  */
@@ -98,17 +87,6 @@ custom-digest {
 .button.big.impact.hcentered {
   background-color: var(--impact-color, var(--black));
   color: var(--impact-text-color, var(--white));
-}
-
-/*
- * Search and Promo buttons
- * impact class needs removed in WPS 
- */
-
-.search-form button,
-.swg-promo .button.impact {
-  --paper-color: var(--white);
-  --text-color: var(--black);
 }
 
 /*


### PR DESCRIPTION
Some clean up in the `fixes.css` file related to impact class. The following changes are to be made in WPS so that these lines can be removed:

1. Remove .impact class on `.load-more `buttons. Seen in `SeachContainerComponent.vue`
2. Remove .impact class on `.seach-form` element. See in the same component above
3. Remove .impact class from `.swg-promo` button in `subscriptionCtaMacro.nunjucks`
4. Remove `.impact` class from `footer` container in `footer.nunjucks`

[Jira ticket](https://mcclatchy.atlassian.net/browse/PE-397)