### PR TITLE
V2.5.7

### DIFF
--- a/static/css/cards/related-stories.css
+++ b/static/css/cards/related-stories.css
@@ -13,7 +13,6 @@
 
 .related-stories h5 {
   font-size: var(--h3);
-  text-transform: uppercase;
   margin-top: 0;
   margin-bottom: var(--space);
 }

--- a/static/css/decks/fixes.css
+++ b/static/css/decks/fixes.css
@@ -159,7 +159,6 @@ custom-digest {
   font-family: 'Noto Sans', sans-serif;
   font-size: 20px;
   font-weight: 700;
-  text-transform: uppercase;
 }
 
 .viafoura button.vf-follow-button.vf-button[data-v-632eed25] {


### PR DESCRIPTION
Removing text-transform properties on a couple elements that will now render in title case:
- Viafoura "Join the Conversation" title
- "Related Stories from ..."

More information in the related [Jira ticket](https://mcclatchy.atlassian.net/browse/PE-420), which has details on updates made in other repos.