### PR TITLE
PE-423 header dom update

### DIFF
--- a/builds/saratoga.scss
+++ b/builds/saratoga.scss
@@ -22,6 +22,7 @@
 @use '../static/css/cards/correction';
 @use '../static/css/cards/related-stories';
 @use '../static/css/cards/author-card';
+@use '../static/css/cards/author-byline';
 @use '../static/css/cards/timeline';
 @use '../static/css/cards/transparency';
 @use '../static/css/cards/big-news';

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -46,6 +46,7 @@
     <link rel="stylesheet" href="/css/cards/correction.css">
     <link rel="stylesheet" href="/css/cards/related-stories.css">
     <link rel="stylesheet" href="/css/cards/author-card.css">
+    <link rel="stylesheet" href="/css/cards/author-byline.css">
     <link rel="stylesheet" href="/css/cards/timeline.css">
     <link rel="stylesheet" href="/css/cards/transparency.css">
     <link rel="stylesheet" href="/css/cards/big-news.css">

--- a/layouts/shortcodes/header.html
+++ b/layouts/shortcodes/header.html
@@ -8,9 +8,9 @@
       <span class="credit">Sample Newspaper</span>
     </div>
     <div class="article-details">
-      <time datetime="">Updated August 13, 2018 3:19 PM</time>
+      <time datetime="">Updated August 13, 2018 3:19 PM</time>      <!--comments DOM added for demo purposes only -->
       <span class="comments">
-        <svg viewBox="0 0 512 512" style="display: inline-block; height: 1em; --fill-color: gray; vertical-align: middle;" aria-hidden="true"><path d="M160 368c26.5 0 48 21.5 48 48l0 16 72.5-54.4c8.3-6.2 18.4-9.6 28.8-9.6L448 368c8.8 0 16-7.2 16-16l0-288c0-8.8-7.2-16-16-16L64 48c-8.8 0-16 7.2-16 16l0 288c0 8.8 7.2 16 16 16l96 0zm48 124l-.2 .2-5.1 3.8-17.1 12.8c-4.8 3.6-11.3 4.2-16.8 1.5s-8.8-8.2-8.8-14.3l0-21.3 0-6.4 0-.3 0-4 0-48-48 0-48 0c-35.3 0-64-28.7-64-64L0 64C0 28.7 28.7 0 64 0L448 0c35.3 0 64 28.7 64 64l0 288c0 35.3-28.7 64-64 64l-138.7 0L208 492z"></path></svg>
+        <svg viewBox="0 0 512 512" aria-hidden="true"><path d="M160 368c26.5 0 48 21.5 48 48l0 16 72.5-54.4c8.3-6.2 18.4-9.6 28.8-9.6L448 368c8.8 0 16-7.2 16-16l0-288c0-8.8-7.2-16-16-16L64 48c-8.8 0-16 7.2-16 16l0 288c0 8.8 7.2 16 16 16l96 0zm48 124l-.2 .2-5.1 3.8-17.1 12.8c-4.8 3.6-11.3 4.2-16.8 1.5s-8.8-8.2-8.8-14.3l0-21.3 0-6.4 0-.3 0-4 0-48-48 0-48 0c-35.3 0-64-28.7-64-64L0 64C0 28.7 28.7 0 64 0L448 0c35.3 0 64 28.7 64 64l0 288c0 35.3-28.7 64-64 64l-138.7 0L208 492z"></path></svg>
         <span class="vf-comments-count vf-body-text--deprecated viafoura vf-is-logged-in" style="min-height: 0px;">35</span>
       </span>
     </div>

--- a/layouts/shortcodes/header.html
+++ b/layouts/shortcodes/header.html
@@ -10,7 +10,7 @@
     <div class="article-details">
       <time datetime="">Updated August 13, 2018 3:19 PM</time>
       <span class="comments">
-        <svg viewBox="0 0 512 512" style="height: 1em; --fill-color: gray;" aria-hidden="true"><path d="M160 368c26.5 0 48 21.5 48 48l0 16 72.5-54.4c8.3-6.2 18.4-9.6 28.8-9.6L448 368c8.8 0 16-7.2 16-16l0-288c0-8.8-7.2-16-16-16L64 48c-8.8 0-16 7.2-16 16l0 288c0 8.8 7.2 16 16 16l96 0zm48 124l-.2 .2-5.1 3.8-17.1 12.8c-4.8 3.6-11.3 4.2-16.8 1.5s-8.8-8.2-8.8-14.3l0-21.3 0-6.4 0-.3 0-4 0-48-48 0-48 0c-35.3 0-64-28.7-64-64L0 64C0 28.7 28.7 0 64 0L448 0c35.3 0 64 28.7 64 64l0 288c0 35.3-28.7 64-64 64l-138.7 0L208 492z"></path></svg>
+        <svg viewBox="0 0 512 512" style="display: inline-block; height: 1em; --fill-color: gray; vertical-align: middle;" aria-hidden="true"><path d="M160 368c26.5 0 48 21.5 48 48l0 16 72.5-54.4c8.3-6.2 18.4-9.6 28.8-9.6L448 368c8.8 0 16-7.2 16-16l0-288c0-8.8-7.2-16-16-16L64 48c-8.8 0-16 7.2-16 16l0 288c0 8.8 7.2 16 16 16l96 0zm48 124l-.2 .2-5.1 3.8-17.1 12.8c-4.8 3.6-11.3 4.2-16.8 1.5s-8.8-8.2-8.8-14.3l0-21.3 0-6.4 0-.3 0-4 0-48-48 0-48 0c-35.3 0-64-28.7-64-64L0 64C0 28.7 28.7 0 64 0L448 0c35.3 0 64 28.7 64 64l0 288c0 35.3-28.7 64-64 64l-138.7 0L208 492z"></path></svg>
         <span class="vf-comments-count vf-body-text--deprecated viafoura vf-is-logged-in" style="min-height: 0px;">35</span>
       </span>
     </div>

--- a/layouts/shortcodes/header.html
+++ b/layouts/shortcodes/header.html
@@ -3,13 +3,16 @@
   <a class="kicker" href="#">Section</a>
   <h1 class="h1">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus lorem amet.</h1>
   <div class="author-byline">
-    {{- if eq $class "opinion" }}
-    <div class="thumb">
-      <img src="/img/aaron_moody.jpg" alt="John Doe">
+    <div>
+      By <span class="author-name">John Doe</span> and <span class="author-name">Jane Doe</span>
+      <span class="credit">Sample Newspaper</span>
     </div>
-    {{- end }}
-    <span class="author-name">John Doe</span>
-    <span class="credit">Sample Newspaper</span>
-    <time>Updated August 13, 2018 3:19 PM</time>
+    <div class="article-details">
+      <time datetime="">Updated August 13, 2018 3:19 PM</time>
+      <span class="comments">
+        <svg viewBox="0 0 512 512" style="height: 1em; --fill-color: gray;" aria-hidden="true"><path d="M160 368c26.5 0 48 21.5 48 48l0 16 72.5-54.4c8.3-6.2 18.4-9.6 28.8-9.6L448 368c8.8 0 16-7.2 16-16l0-288c0-8.8-7.2-16-16-16L64 48c-8.8 0-16 7.2-16 16l0 288c0 8.8 7.2 16 16 16l96 0zm48 124l-.2 .2-5.1 3.8-17.1 12.8c-4.8 3.6-11.3 4.2-16.8 1.5s-8.8-8.2-8.8-14.3l0-21.3 0-6.4 0-.3 0-4 0-48-48 0-48 0c-35.3 0-64-28.7-64-64L0 64C0 28.7 28.7 0 64 0L448 0c35.3 0 64 28.7 64 64l0 288c0 35.3-28.7 64-64 64l-138.7 0L208 492z"></path></svg>
+        <span class="vf-comments-count vf-body-text--deprecated viafoura vf-is-logged-in" style="min-height: 0px;">35</span>
+      </span>
+    </div>
   </div>
 </header>

--- a/layouts/shortcodes/header.html
+++ b/layouts/shortcodes/header.html
@@ -1,19 +1,15 @@
 {{- $class := .Get "class" }}
-
 <header class="header {{$class}}">
-  <a class="kicker h6" href="#">Section</a>
+  <a class="kicker" href="#">Section</a>
   <h1 class="h1">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus lorem amet.</h1>
-  <div class="bio">
+  <div class="author-byline">
     {{- if eq $class "opinion" }}
     <div class="thumb">
       <img src="/img/aaron_moody.jpg" alt="John Doe">
     </div>
     {{- end }}
-    <div>
-      <div class="byline">By <a href="#">John Doe</a> <span class="credit">Sample Newspaper</span></div>
-      <div>
-        <time>Updated August 13, 2018 3:19 PM</time>
-      </div>
-    </div>
+    <span class="author-name">John Doe</span>
+    <span class="credit">Sample Newspaper</span>
+    <time>Updated August 13, 2018 3:19 PM</time>
   </div>
 </header>

--- a/static/css/atoms.css
+++ b/static/css/atoms.css
@@ -158,15 +158,16 @@ li {
 
 .kicker {
   color: var(--secondary-text-color);
-  font-size: 0.667rem;
+  font: 0.667rem/1em var(--sans);
   font-weight: bold;
   text-transform: uppercase;
+  line-height: 1em;
 }
 
 time, .time, .byline {
   display: inline-block;
   color: var(--secondary-text-color);
-  font: 0.778rem/1.1em var(--sans);
+  font: 0.778rem/1em var(--sans);
 }
 
 .byline a {

--- a/static/css/cards/author-byline.css
+++ b/static/css/cards/author-byline.css
@@ -4,48 +4,56 @@
 
  .author-byline {
   display: grid;
-  grid-auto-flow: column;
-  justify-content: start;
-  overflow: hidden;
-  gap: var(--space);
+  gap: var(--byline-gap, 5px);
   font-size: var(--byline-font-size, 14px);
   font-family: var(--header-family);
-  font-weight: var(--header-weight);
-  text-transform: uppercase;
   color: var(--byline-color, var(--darkgray));
+ }
+
+ .author-name,
+ .article-details .viafoura {
+  font-weight: bold;
+ }
+
+ .article-details {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  overflow: hidden;
+  gap: 5px var(--space);
   --link-color: var(--darkgray);
   --line-offset: calc(var(--gap) / 2);
   --line-thickness: 1px;
   --line-color: #d9d9d9;
 }
 
-.author-byline > * {
+.article-details > * {
   position: relative;
   line-height: normal;
 }
 
-.author-byline > *::before {
+.article-details > *::before {
   content: '';
   position: absolute;
   background-color: var(--line-color);
-  z-index: 1;
-}
-
-.author-byline > *::before {
   inline-size: var(--line-thickness);
   block-size: 100vh;
   inset-block-start: 0;
   inset-inline-start: calc(var(--line-offset) * -1);
+  z-index: 1;
 }
 
-.author-byline .date,
-.author-byline .time,
-.author-byline time {
-  font-size: 12px;
-  font-weight: normal;
+.article details .article-credit,
+.article-details .viafoura {
+  font-size: 14px;
 }
 
-.author-byline .comments {
+.article-details .comments {
   display: inline-flex;
-  gap: var(--space);
+  gap: 5px;
+}
+
+.article-details .comments svg {
+  align-self: center;
+  padding-top: 2px;
 }

--- a/static/css/cards/author-byline.css
+++ b/static/css/cards/author-byline.css
@@ -43,11 +43,6 @@
   z-index: 1;
 }
 
-.article details .article-credit,
-.article-details .viafoura {
-  font-size: 14px;
-}
-
 .article-details .comments {
   display: inline-flex;
   gap: 5px;

--- a/static/css/cards/author-byline.css
+++ b/static/css/cards/author-byline.css
@@ -1,0 +1,51 @@
+/**
+ * Author byline
+ */
+
+ .author-byline {
+  display: grid;
+  grid-auto-flow: column;
+  justify-content: start;
+  overflow: hidden;
+  gap: var(--space);
+  font-size: var(--byline-font-size, 14px);
+  font-family: var(--header-family);
+  font-weight: var(--header-weight);
+  text-transform: uppercase;
+  color: var(--byline-color, var(--darkgray));
+  --link-color: var(--darkgray);
+  --line-offset: calc(var(--gap) / 2);
+  --line-thickness: 1px;
+  --line-color: #d9d9d9;
+}
+
+.author-byline > * {
+  position: relative;
+  line-height: normal;
+}
+
+.author-byline > *::before {
+  content: '';
+  position: absolute;
+  background-color: var(--line-color);
+  z-index: 1;
+}
+
+.author-byline > *::before {
+  inline-size: var(--line-thickness);
+  block-size: 100vh;
+  inset-block-start: 0;
+  inset-inline-start: calc(var(--line-offset) * -1);
+}
+
+.author-byline .date,
+.author-byline .time,
+.author-byline time {
+  font-size: 12px;
+  font-weight: normal;
+}
+
+.author-byline .comments {
+  display: inline-flex;
+  gap: var(--space);
+}

--- a/static/css/cards/author-byline.css
+++ b/static/css/cards/author-byline.css
@@ -48,7 +48,10 @@
   gap: 5px;
 }
 
-.article-details .comments svg {
+.article-details .comments > svg {
+  display: inline-block;
   align-self: center;
+  height: 1em;
   padding-top: 2px;
+  --fill-color: var(--byline-color);
 }

--- a/static/css/cards/story.css
+++ b/static/css/cards/story.css
@@ -4,7 +4,7 @@
 
 .story-body {
   display: flow-root;
-  font: var(--story-font, 18px/2em var(--serif));
+  font-family: var(--story-font, var(--serif));
   color: var(--story-text-color, var(--text-color));
   background-color: var(--story-background-color, var(--paper-color));
   --header-family: var(--story-subhead-family, var(--sans));

--- a/static/css/decks/fixes.css
+++ b/static/css/decks/fixes.css
@@ -159,7 +159,6 @@ custom-digest {
   font-family: 'Noto Sans', sans-serif;
   font-size: 20px;
   font-weight: 700;
-  text-transform: uppercase;
 }
 
 .viafoura button.vf-follow-button.vf-button[data-v-632eed25] {

--- a/static/css/decks/fixes.css
+++ b/static/css/decks/fixes.css
@@ -134,9 +134,7 @@ custom-digest {
 
 .viafoura {
   --dark-text-on-default-color: #0F1521;
-  color: #0F1521;
   font-family: 'Noto Sans', sans-serif;
-  font-size: 16px;
 }
 
 .viafoura p,


### PR DESCRIPTION
### SDS v2.6.0
Story Page Header DOM Update
The structure of the header has been updated to a clean, efficient version of the new 3.0 design.
- An `author-byline.css` file has been introduced as a home base, making it easier to find within the codebase.
- The `.article-details` div is set up to include divider lines as pseudo elements that will automatically populate in the correct place when the amount of details scales up.
- The Saratoga site now depicts the comments SVG and count number.

More information in the related Jira ticket - [PE-423](https://mcclatchy.atlassian.net/browse/PE-423)

Figma design screenshot below:
![story-header-mobile](https://github.com/user-attachments/assets/c461784d-6d4f-44f6-b6ce-8a09fbfd9f95)
