### PR TITLE
modify styling for existing h3 elements as to not be affected by new CUE…

### DIFF
--- a/layouts/shortcodes/header.html
+++ b/layouts/shortcodes/header.html
@@ -8,7 +8,8 @@
       <span class="credit">Sample Newspaper</span>
     </div>
     <div class="article-details">
-      <time datetime="">Updated August 13, 2018 3:19 PM</time>      <!--comments DOM added for demo purposes only -->
+      <time datetime="">Updated August 13, 2018 3:19 PM</time>      
+      <!--comments DOM added for demo purposes only -->
       <span class="comments">
         <svg viewBox="0 0 512 512" aria-hidden="true"><path d="M160 368c26.5 0 48 21.5 48 48l0 16 72.5-54.4c8.3-6.2 18.4-9.6 28.8-9.6L448 368c8.8 0 16-7.2 16-16l0-288c0-8.8-7.2-16-16-16L64 48c-8.8 0-16 7.2-16 16l0 288c0 8.8 7.2 16 16 16l96 0zm48 124l-.2 .2-5.1 3.8-17.1 12.8c-4.8 3.6-11.3 4.2-16.8 1.5s-8.8-8.2-8.8-14.3l0-21.3 0-6.4 0-.3 0-4 0-48-48 0-48 0c-35.3 0-64-28.7-64-64L0 64C0 28.7 28.7 0 64 0L448 0c35.3 0 64 28.7 64 64l0 288c0 35.3-28.7 64-64 64l-138.7 0L208 492z"></path></svg>
         <span class="vf-comments-count vf-body-text--deprecated viafoura vf-is-logged-in" style="min-height: 0px;">35</span>

--- a/static/css/cards/story.css
+++ b/static/css/cards/story.css
@@ -27,7 +27,7 @@
   }
 }
 
-.story-body h3 {
+.story-body h3:not(.h3) {
   font-size: var(--h2);
 }
 

--- a/static/css/cards/story.css
+++ b/static/css/cards/story.css
@@ -27,7 +27,7 @@
   }
 }
 
-.story-body h3:not(.h3) {
+.story-body > h3:not(.h3) {
   font-size: var(--h2);
 }
 


### PR DESCRIPTION
Story page `<h3>` rule is rewritten to no longer include those containing `.h3,` as the new CUE `<h3> `elements will include that class (`<h3 class=h3>Example Header</h3>`). This will help ensure that the new CUE headers have different sizes while retaining the live site modifications to `<h3>` elements with a desired `.h2` size.

Related Jira ticket: [PE-471](https://mcclatchy.atlassian.net/jira/software/c/projects/PE/boards/24?selectedIssue=PE-471)