### PR TITLE
2.8.2

### DIFF
--- a/static/css/cards/breaking-news-banner.css
+++ b/static/css/cards/breaking-news-banner.css
@@ -8,18 +8,18 @@
   background-color: var(--red);
   color: var(--white);
   max-width: 100%;
+  height: 41px;
 }
 
 .breaking-news-macro {
   display: flex;
-  justify-content: space-between;
   flex-direction: row;
-  font-family: var(--sans);
-  font-size: 20px;
-  line-height: 1;
+  justify-content: space-between;
   max-width: var(--section-width);
-  padding: 15px;
-  margin:0 auto;
+  margin: 0 auto;
+  padding: 10px;
+  font-family: var(--sans);
+  line-height: 1;
 }
 
 .breaking-news-macro h3 {
@@ -34,6 +34,7 @@
   padding-left: 20px;
   opacity: 1;
   transition: all .6s ease;
+  min-width: 10px;
 }
 
 .breaking-news-macro .icon-wrap {
@@ -42,4 +43,22 @@
 
 .breaking-news-macro .icon-wrap .close-breaking-news::before {
   content: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="8" height="9" viewBox="0 0 8 9" fill="none"%3E%3Cpath d="M7.59049 1.05497C7.81823 0.781777 7.78195 0.376006 7.50786 0.149016C7.23376 -0.0779743 6.82664 -0.0418166 6.5989 0.231375L3.87 3.49562L1.1411 0.231375C0.91336 -0.0418166 0.506242 -0.0779743 0.232143 0.149016C-0.0419554 0.376006 -0.0782332 0.781777 0.149511 1.05497L3.02956 4.5L0.149511 7.94503C-0.0782332 8.21822 -0.0419554 8.62399 0.232143 8.85098C0.506242 9.07797 0.91336 9.04182 1.1411 8.76862L3.87 5.50438L6.5989 8.76862C6.82664 9.04182 7.23376 9.07797 7.50786 8.85098C7.78195 8.62399 7.81823 8.21822 7.59049 7.94503L4.71044 4.5L7.59049 1.05497Z" fill="white"/%3E%3C/svg%3E');
+}
+
+/*
+ * Mobile CLS fix
+ */
+@media (max-width: 767px) {
+  .breaking-news-organism {
+    height: 62px;
+    overflow: hidden;
+  }
+
+  .breaking-news-macro > div {
+    overflow: hidden;
+   display: -webkit-box;
+   -webkit-line-clamp: 2;
+           line-clamp: 2; 
+   -webkit-box-orient: vertical;
+  }
 }

--- a/static/css/cards/zones.css
+++ b/static/css/cards/zones.css
@@ -99,7 +99,6 @@
 
 #zone-el-2.sticky-leaderboard {
   position: fixed;
-  top: 90px;
   z-index: 98;
   width: 100vw;
   height: 106px;
@@ -114,9 +113,5 @@
   #zoneContainer:has(.sticky-leaderboard),
   #zone-el-2.sticky-leaderboard {
     height: 66px;
-  }
-
-  #zone-el-2.sticky-leaderboard {
-    top: 45px;
   }
 }

--- a/static/css/decks/fixes.css
+++ b/static/css/decks/fixes.css
@@ -129,7 +129,7 @@ custom-digest {
 }
 
 /*
- * Viafoura
+ * Viafoura - comments vendor
  */
 
 .viafoura {
@@ -161,6 +161,14 @@ custom-digest {
 
 .viafoura button.vf-follow-button.vf-button[data-v-632eed25] {
   padding: 5px 10px;
+}
+
+.viafoura span.vf-follow-button__visible-text[data-v-25cf7183] {
+  position: relative;
+}
+
+.viafoura .vf-follow-button__hidden-text[data-v-25cf7183] {
+  display: none;
 }
 
 .viafoura #commentingIntro,


### PR DESCRIPTION
### SDS 2.8.2

This PR is the precursor to the 2.8.2 release. It includes 3 updates, including the following:

1. **Breaking News Banner** - updated styles implemented as the long term solution to existing modifications in WPS, which includes media query for the banner to be a single line tall on desktop and two lines with an ellipsis on mobile. This design solution helps mediate CLS issues. 
Related Jira ticket: [FE-862](https://mcclatchy.atlassian.net/browse/FE-862)

2. **Viafoura** "following" and "unfollow" button position fix - styles included in `fixes.css` to overwrite the vendor code that absolutely positioned the text element with a class addition. 
Related Jira ticket: [PE-542](https://mcclatchy.atlassian.net/browse/PE-542)

3. **Sticky Leaderboard Ad** for PM - the `top` value has been removed from positioning so that it appears relative to other elements. Testing with the promo banner demonstrated that the top value was obsolete. 
Related Jira ticket: [FE-876](https://mcclatchy.atlassian.net/browse/FE-876)