### PR TITLE
fix gap/spacing on breaking news banner

### DIFF
--- a/static/css/cards/breaking-news-banner.css
+++ b/static/css/cards/breaking-news-banner.css
@@ -15,6 +15,7 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  gap: var(--space-sm);
   max-width: var(--section-width);
   margin: 0 auto;
   padding: 10px;
@@ -31,7 +32,6 @@
 }
 
 .breaking-news-macro div.close-breaking-news {
-  padding-left: 20px;
   opacity: 1;
   transition: all .6s ease;
   min-width: 10px;


### PR DESCRIPTION
Removed `20px` left padding on close button and introduced `gap` property to maintain space between the text and the button while ensuring the button does not get displaced on smaller width screens.

Related Jira ticket: [FE-862](https://mcclatchy.atlassian.net/browse/FE-862)