### PR TITLE
Sticky leaderboard ad close button - updated styles

### DIFF
--- a/static/css/cards/zones.css
+++ b/static/css/cards/zones.css
@@ -94,6 +94,7 @@
 }
 
 #zoneContainer:has(.sticky-leaderboard) {
+  position: relative;
   height: 106px;
 }
 
@@ -117,9 +118,12 @@
 }
 
 #sticky_ad_close {
-  position: absolute;
-  top: 0;
-  right: 25px;
+  position: fixed;
+  right: 0;
+  z-index: 99;
+  width: 20px;
+  padding-left: 10px;
+  background-color: var(--media-background-color);
   cursor: pointer;
   --fill-color: var(--black);
 }


### PR DESCRIPTION
While testing in QA, the team observed that the close button element was getting removed from the `#zone-el-2` div after initial load. We decided to relocate the button element in the DOM so that it is now placed outside of the div as a sibling to the zone. 

Consequently, the styles needed to change in order to position the button correctly. We also added a background color to keep the button legible if it ever overlaps the ad unit.

Testing was done by overriding the styles via the source tab in devtools on the [QA1 site for Kansas City](https://qa1.kansascity.com/?vsim=kjnasdc). I double checked behavior on scroll and at multiple screen widths including mobile.

Related Jira ticket: https://mcclatchy.atlassian.net/browse/PTECH-3238