### PR TITLE
add key takeaway styles to amp pages

### DIFF
--- a/dist/amp.css
+++ b/dist/amp.css
@@ -1730,6 +1730,73 @@ footer {
 }
 
 /**
+ * AI Summary/Key Takeaways
+ */
+ .ai-summary-wrapper { 
+  padding: 2px;
+  position: relative;
+  border-radius: 3px;
+  background: linear-gradient(0deg, #BD56FF, #0FB7FF);
+}
+
+@media (max-width: 800px) {
+  .story-body .ai-summary-wrapper {
+    margin: var(--space);
+  }
+}
+
+.ai-summary {
+  font-family: var(--sans);
+  background-color: var(--paper-color);
+  padding: var(--space);
+  --grid-row-gap: 5px;
+  --columns: auto;
+  --header-transform: none;
+  --secondary-text-color: var(--lightgray);
+}
+
+@media (min-width: 797px) {
+  .ai-summary .grid {
+    grid-auto-flow: column;
+    align-items: baseline;
+  }
+}
+
+.ai-summary .expander {
+  justify-content: space-between;
+  align-items: baseline;
+  --link-color: var(--text-color);
+}
+
+.ai-summary-header {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+}
+
+.ai-summary p {
+  font-size: 0.67em;
+  color: var(--darkgray);
+  margin: 0;
+}
+
+.ai-summary p a {
+  display: inline-block;
+}
+
+.ai-summary ul {
+  list-style-type: square;
+  font-size: 0.78em;
+  line-height: 1.5em;
+  margin-bottom: 0;
+}
+
+.ai-summary hr {
+  align-self: stretch;
+  border: .5px solid #afb9ca;
+}
+
+/**
  * SWG Promo card
  */
 .card.swg-promo .package {


### PR DESCRIPTION
Front End increased the scope of the Key Takeaways (formerly AI Summaries) feature to be available on AMP pages. Therefore, the amp.css file has been updated to include the styling from the regular Saratoga build. More information available in this Jira ticket: https://mcclatchy.atlassian.net/browse/PTECH-2848

There were a couple additional modifications to account for atoms level styles that have not been updated in amp but have in sds, namely the `header-transform` and `hr` element.

This is to be published as a patch release.