### PR TITLE
Blog branding fix

### DIFF
--- a/static/css/cards/header.css
+++ b/static/css/cards/header.css
@@ -24,6 +24,13 @@
   margin: 0;
 }
 
+.blog-branding .teaser {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
 /**
  * Opinion changes
  */

--- a/static/css/cards/header.css
+++ b/static/css/cards/header.css
@@ -27,8 +27,19 @@
 .blog-branding .teaser {
   display: flex;
   align-items: center;
-  justify-content: center;
   flex-wrap: wrap;
+  gap: 10px;
+}
+
+.blog-branding .blog-brand-img {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+}
+
+.blog-branding .teaser .title {
+  font-size: 18px;
+  font-family: var(--serif);
 }
 
 /**


### PR DESCRIPTION
**Background**
The header on story pages sometimes includes a branded blog component, like "_For Pete's Sake_". Until recent efforts, the styling has been housed in WPS itself. In order to consolidate design and clean up the templates, we have moved the necessary styles to the `design` repo. 

Along with this SDS update, we'll need to remove all blog branding styles from WPS before it's released to production from Front End. I did notice several associated utility classes related to screen size, but we'll dig in more with QA.

Example article: https://www.kansascity.com/sports/spt-columns-blogs/for-petes-sake/article299790484.html

<img width="849" height="352" alt="Screenshot 2025-08-13 at 3 10 45 PM" src="https://github.com/user-attachments/assets/6c04d849-e51e-4d81-bb4b-a085c6dd5c6e" />
