### PR TITLE
2.8.24

### DIFF
--- a/dist/amp.css
+++ b/dist/amp.css
@@ -1393,6 +1393,7 @@ footer {
 .quote {
   font-family: var(--sans);
   max-width: 600px;
+  margin: 0 auto;
   padding: 20px 0;
 }
 

--- a/dist/amp.css
+++ b/dist/amp.css
@@ -1397,9 +1397,16 @@ footer {
   padding: 20px 0;
 }
 
+@media (max-width: 720px) {
+  .quote {
+    padding: 20px 40px;
+  }
+}
+
 .quote blockquote {
   margin: 0;
   font: bold var(--block-quote-font-size, 24px) / 1.33em var(--sans);
+  overflow-wrap: break-word;
 }
 
 .quote blockquote:before {

--- a/static/css/cards/flag.css
+++ b/static/css/cards/flag.css
@@ -217,7 +217,7 @@ html.msb .masthead {
     padding: 0 var(--space-sm);
   }
   
-  .flag .msb-hide a:last-of-type {
+  .flag .flag-account a:last-of-type {
     padding-right: var(--space-sm);
   }
 

--- a/static/css/cards/menu.css
+++ b/static/css/cards/menu.css
@@ -1,21 +1,23 @@
 /* Menu */
 .main-nav {
-  position: fixed;
-  top: var(--flag-height);
-  left: 0;
-  bottom: 0;
-  width: var(--menu-width);
-  height: calc(100vh - var(--flag-height));
-  color: var(--black);
   --text-color: var(--black);
   --link-color: var(--black);
   --fill-color: var(--black);
+  position: fixed;
+  z-index: 99;
+  top: var(--flag-height);
+  bottom: 0;
+  left: 0;
+  box-sizing: border-box;
+  width: var(--menu-width);
+  height: calc(100dvh - var(--flag-height));
+  padding-bottom: var(--space);
   background-color: var(--nav-color, var(--white));
+  color: var(--black);
   overflow: scroll;
   -webkit-overflow-scrolling: touch;
   transform: translateX(-150%);
   transition: transform 0.4s ease;
-  z-index: 99;
 }
 
 .main-nav:hover :focus {

--- a/static/css/cards/related-stories.css
+++ b/static/css/cards/related-stories.css
@@ -3,7 +3,7 @@
  */
 
 .related-stories > *:last-child {
-  border-bottom: 0.5px solid var(--secondary-text-color);
+  border-bottom: 1px solid #D0DAE7;
   padding-bottom: var(--space);
 }
 
@@ -20,7 +20,7 @@
 @media(max-width: 674px) {
   .related-stories .package::after {
     content: '';
-    border-bottom: 1px solid #d9d9d9;
+    border-bottom: 1px solid #D0DAE7;
     width: 40px;
     display: block;
     margin-bottom: var(--space-sm);

--- a/static/css/cards/story.css
+++ b/static/css/cards/story.css
@@ -162,9 +162,16 @@
   padding: 20px 0;
 }
 
+@media (max-width: 720px) {
+  .quote {
+    padding: 20px 40px;
+  }
+}
+
 .quote blockquote {
   margin: 0;
   font: bold var(--block-quote-font-size, 24px) / 1.33em var(--sans);
+  overflow-wrap: break-word;
 }
 
 .quote blockquote:before {


### PR DESCRIPTION
### Bug Fixes & UI/UX Improvements                                                                                                                                       
                                                                                                                                                
**AMP quote alignment**
Centers `.quote` with `margin: 0 auto` and adds mobile `padding (20px 40px)` at ≤ `720px`; also adds `overflow-wrap: break-word` to blockquote to prevent text overflow
Related Jira ticket: [PTECH-6245](https://mcclatchy.atlassian.net/browse/PTECH-6245)          
                                                                               
**Story quote**
Same mobile padding and overflow-wrap fixes applied to the non-AMP story styles
Related Jira ticket: [PTECH-6245](https://mcclatchy.atlassian.net/browse/PTECH-6245)       
                                     
**Flag account padding**
Fixes selector from `.msb-hide a:last-of-type` to `.flag-account a:last-of-type` for correct padding-right targeting 
Related Jira ticket: [PTECH-7062](https://mcclatchy.atlassian.net/browse/PTECH-7062)
                                                                                                                      
**Menu**
Updates height to `100dvh`, adds `padding-bottom`, reorders declarations (custom properties → position → box model → visual → transform/transition)
Related Jira ticket: [PTECH-7136](https://mcclatchy.atlassian.net/browse/PTECH-7136) 

**Related stories border**
Standardizes border color to `#D0DAE7` (replacing `var(--secondary-text-color)` and #`d9d9d9`) and updates bottom border width to `1px`
Related [Figma file](figma.com/design/Pf8RbdPXgcnETbPrzZ9kdJ/Audience-%7C-API-Promotions-202603?node-id=34-52&t=eyeJDuVgllLfw2Lj-0#1694036658)