### PR TITLE
add editors note shortcode and class for styling code maintenance

### DIFF
--- a/builds/saratoga.scss
+++ b/builds/saratoga.scss
@@ -27,6 +27,7 @@
 @use '../static/css/cards/header';
 @use '../static/css/cards/series-nav';
 @use '../static/css/cards/correction';
+@use '../static/css/cards/editors-note';
 @use '../static/css/cards/related-stories';
 @use '../static/css/cards/author-card';
 @use '../static/css/cards/author-byline';

--- a/content/decks/story.md
+++ b/content/decks/story.md
@@ -14,6 +14,7 @@ aliases:
 {{< series-nav >}}
 
 {{< correction >}}
+{{< editors-note >}}
 
 If this was somewhat unclear, an offence is a seeing breath. Preschool tails show us how taxicabs can be gasolines. The trapezoids could be said to resemble reddish yogurts. Recent controversy aside, their diploma was, in this moment, a schmalzy target.
 

--- a/dist/amp.css
+++ b/dist/amp.css
@@ -1654,6 +1654,10 @@ footer {
   font-style: italic;
 }
 
+.editors-note {
+  font-style: italic;
+}
+
 /**
  * Related stories
  */

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -49,6 +49,7 @@
     <link rel="stylesheet" href="/css/cards/header.css">
     <link rel="stylesheet" href="/css/cards/series-nav.css">
     <link rel="stylesheet" href="/css/cards/correction.css">
+    <link rel="stylesheet" href="/css/cards/editors-note.css">
     <link rel="stylesheet" href="/css/cards/related-stories.css">
     <link rel="stylesheet" href="/css/cards/author-card.css">
     <link rel="stylesheet" href="/css/cards/author-byline.css">

--- a/layouts/shortcodes/editors-note.html
+++ b/layouts/shortcodes/editors-note.html
@@ -1,0 +1,1 @@
+<div class="editors-note">Editor's Note: The editor's note is updated in CUE in its own field. The associated class helps with code maintenance.</div>

--- a/static/css/cards/editors-note.css
+++ b/static/css/cards/editors-note.css
@@ -1,0 +1,3 @@
+.editors-note {
+  font-style: italic;
+}


### PR DESCRIPTION
**Background**
The Editor's Note has been historically added into articles pages in a variety of methods. The Backend team has updated our CMS,  CUE, to include a designated field for reporters to enter that data/information. The current implementation include an `<i>` tag to style the element. For long-term design maintenance, it's better practice to include a class that we can target and manage the styles within this `design` repository.
Jira ticket for reference: [PTECH-6950](https://mcclatchy.atlassian.net/browse/PTECH-6950)

**Changes**

New files:                                                                                                                                  
- `editors-note.html` — new Hugo shortcode with a placeholder that renders a `div.editors-note`
- `editors-note.css` — new card CSS defining `.editors-note { font-style: italic; } `                                            

Modified files:                                                                                                                               
- `builds/saratoga.scss` — added `@use '../static/css/cards/editors-note'` (between correction and related-stories)                             
- `layouts/_default/baseof.html` — added `<link rel="stylesheet" href="/css/cards/editors-note.css"> `(same position in load order)               
- `dist/amp.css` — includes compiled `.editors-note` styles for AMP                                                                             
- `content/decks/story.md` — added `{{< editors-note >}}` to the story demo deck for reference 